### PR TITLE
Fix: update project info for NuGet pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Stryker.NET offers you mutation testing for your .NET Core projects. It allows y
 
 ``` XML
 <ItemGroup>
-    <DotNetCliToolReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
-    <PackageReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
+    <DotNetCliToolReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
+    <PackageReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
 </ItemGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/853yby19lvrrd435/branch/master?svg=true)](https://ci.appveyor.com/project/stryker-mutator/stryker-net/branch/master)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/stryker-mutator/stryker-net.svg?columns=all)](https://waffle.io/stryker-mutator/stryker-net)
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/stryker-mutator/stryker-net.svg?columns=To%20Do,In%20Progress,Needs%20Review)](https://waffle.io/stryker-mutator/stryker-net)
 
 # Stryker.NET
 *Professor X: For someone who hates mutants... you certainly keep some strange company.*  
@@ -7,13 +7,22 @@
 
 ## Introduction
 
-For an introduction to mutation testing and Stryker's features, see [stryker-mutator.io](https://stryker-mutator.io/).
+For an introduction to mutation testing and Stryker's features, see [stryker-mutator.io](https://stryker-mutator.io/). Looking for [mutation testing in JavaScript](https://stryker-mutator.github.io)?
 
 ## Getting started
-Stryker.NET offers you mutation testing for your .NET Core projects. It allows you to test your tests by temporarily inserting bugs.
+Stryker.NET offers you mutation testing for your .NET Core projects. It allows you to test your tests by temporarily inserting bugs. Stryker.NET is installed using [NuGet](https://www.nuget.org/packages/Stryker.Runner.DotNetCore.CLI/).
 
-#### Note
-This project is still in its early days and is not yet available on NuGet. In the meantime, start by [mutation testing your JavaScript](https://stryker-mutator.github.io).
+#### Install
+ To install Stryker.NET on your *test project* add the following lines to the root of your `.csproj` file. on your *test* project. 
+
+``` XML
+<ItemGroup>
+    <DotNetCliToolReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
+    <PackageReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
+</ItemGroup>
+```
+
+After adding the references, install the packages by executing `dotnet restore` inside the project folder.
 
 #### Usage
 Stryker.NET can be used by executing the `dotnet stryker` command inside your test project folder, using the Stryker.CLI package.
@@ -22,9 +31,6 @@ For the full documentation on how to use Stryker.NET, see the [Stryker.CLI readm
 
 #### Compatibility
 Only compatible with .NET Core version 1.1+
-
-## Usage
-For the full documentation about the `dotnet stryker` command, see the [Stryker.CLI readme](/src/Stryker.CLI/README.md).
 
 ## Supported Mutators
 Right now, Stryker.NET supports the following mutators:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,14 +6,6 @@ image:
 - Visual Studio 2017
 init:
 - ps: git config --global core.autocrlf false
-dotnet_csproj:
-  patch: false
-  file: '**\*.csproj'
-  version: '{version}'
-  package_version: '{version}'
-  assembly_version: '{version}'
-  file_version: '{version}'
-  informational_version: '{version}'
 before_build:
 - ps: dotnet restore src/Stryker.CLI/Stryker.CLI.sln
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ image:
 init:
 - ps: git config --global core.autocrlf false
 dotnet_csproj:
-  patch: true
+  patch: false
   file: '**\*.csproj'
   version: '{version}'
   package_version: '{version}'

--- a/appveyor_nugetpack.yml
+++ b/appveyor_nugetpack.yml
@@ -1,0 +1,30 @@
+version: 0.0.{build}
+branches:
+  only:
+  - master
+image: Visual Studio 2017
+init:
+- ps: git config --global core.autocrlf false
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
+before_build:
+- ps: dotnet restore src/Stryker.CLI/Stryker.CLI.sln
+build:
+  project: src/Stryker.CLI/Stryker.CLI.sln
+  publish_nuget: true
+  include_nuget_references: true
+  verbosity: minimal
+artifacts:
+- path: '**\*.nupkg'
+deploy:
+- provider: NuGet
+  server: https://ci.appveyor.com/nuget/stryker-mutator-2f6sybqrq13d
+  api_key:
+    secure: luYiGBpmMqhFR/FRXEXxa9bAOsZvmCzrj0QYsAACEQk=
+  skip_symbols: true

--- a/src/Stryker.CLI/README.md
+++ b/src/Stryker.CLI/README.md
@@ -6,8 +6,8 @@ To install Stryker.NET on your *test project* add the following lines to the roo
 
 ``` XML
 <ItemGroup>
-    <DotNetCliToolReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
-    <PackageReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
+    <DotNetCliToolReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
+    <PackageReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
 </ItemGroup>
 ```
 

--- a/src/Stryker.CLI/README.md
+++ b/src/Stryker.CLI/README.md
@@ -6,8 +6,8 @@ To install Stryker.NET on your *test project* add the following lines to the roo
 
 ``` XML
 <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-stryker" Version="0.1.*" />
-    <PackageReference Include="dotnet-stryker" Version="0.1.*" />
+    <DotNetCliToolReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
+    <PackageReference Include="Stryker.Runner.DotNetCore.CLI" Version="*" />
 </ItemGroup>
 ```
 

--- a/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
+++ b/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>Stryker.CLI</RootNamespace>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Version>0.0.1</Version>
-    <PackageId>Stryker.Runner.DotNetCore.CLI</PackageId>
+    <PackageId>StrykerMutator.DotNetCoreCli</PackageId>
     <PackageVersion>0.0.1</PackageVersion>
     <AssemblyVersion>0.0.1</AssemblyVersion>
     <FileVersion>0.0.1</FileVersion>

--- a/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
+++ b/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
@@ -4,12 +4,22 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageId>dotnet-stryker</PackageId>
-    <Authors>Richard</Authors>
-    <Company>InfoSupport</Company>
+    <Authors>Richard Werkman</Authors>
     <Product>Mutation Testing</Product>
     <AssemblyName>dotnet-stryker</AssemblyName>
     <RootNamespace>Stryker.CLI</RootNamespace>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Version>0.0.1</Version>
+    <PackageId>Stryker.Runner.DotNetCore.CLI</PackageId>
+    <PackageVersion>0.0.1</PackageVersion>
+    <AssemblyVersion>0.0.1</AssemblyVersion>
+    <FileVersion>0.0.1</FileVersion>
+    <InformationalVersion>0.0.1</InformationalVersion>
+    <Description>The Stryker.NET Command Line Interface Runner for .NET Core. Adds the dotnet stryker command to your test project.</Description>
+    <PackageProjectUrl>https://github.com/stryker-mutator/stryker-net</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/stryker-mutator/stryker-net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/stryker-mutator/stryker/master/stryker-80x80.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/stryker-mutator/stryker-net</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -2,19 +2,26 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Authors>Richard</Authors>
-    <Company>InfoSupport</Company>
+    <DebugType>Full</DebugType>
+    <Authors>Richard Werkman</Authors>
     <Product>Mutation Testing</Product>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
-    <StartupObject />
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The main package for stryker.net</Description>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <PackageId>Stryker.Core</PackageId>
-    <DebugType>Full</DebugType>
     <AssemblyName>Stryker.Core</AssemblyName>
     <RootNamespace>Stryker.Core</RootNamespace>
+    <StartupObject />
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Version>0.0.1</Version>
+    <PackageId>Stryker.Core</PackageId>
+    <PackageVersion>0.0.1</PackageVersion>
+    <AssemblyVersion>0.0.1</AssemblyVersion>
+    <FileVersion>0.0.1</FileVersion>
+    <InformationalVersion>0.0.1</InformationalVersion>
+    <Description>The core package for Stryker.NET. Used by other Stryker packages to run. Please install a Stryker.Runner.* package to use this package.</Description>
+    <PackageProjectUrl>https://github.com/stryker-mutator/stryker-net</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/stryker-mutator/stryker-net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/stryker-mutator/stryker/master/stryker-80x80.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/stryker-mutator/stryker-net</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -12,7 +12,7 @@
     <StartupObject />
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Version>0.0.1</Version>
-    <PackageId>Stryker.Core</PackageId>
+    <PackageId>StrykerMutator.Core</PackageId>
     <PackageVersion>0.0.1</PackageVersion>
     <AssemblyVersion>0.0.1</AssemblyVersion>
     <FileVersion>0.0.1</FileVersion>


### PR DESCRIPTION
To prepare the codebase for automatic releases trough appveyor. The nuget pack and nuget push command will use the info from the .csproj files.