### PR TITLE
Check if there is a config file, else use default

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
@@ -1,0 +1,67 @@
+﻿using Moq;
+using Serilog.Events;
+using Stryker.Core;
+using Stryker.Core.Options;
+using System.IO;
+using Xunit;
+
+namespace Stryker.CLI.UnitTest
+{
+    [CollectionDefinition("Non-Parallel Collection", DisableParallelization = true)]
+    public class ConfigFileTests
+    {
+        [Fact]
+        public void StrykerCLI_WithNoArgumentsAndEmptyConfig_ShouldStartStrykerWithDefaultOptions()
+        {
+            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 2000 &&
+                                                                        c.LogOptions.LogLevel == LogEventLevel.Information &&
+                                                                        c.LogOptions.LogToFile == false &&
+                                                                        c.ProjectUnderTestNameFilter == null &&
+                                                                        c.Reporter == "Console"))).Verifiable();
+
+            var target = new StrykerCLI(mock.Object);
+
+            target.Run(new string[] { });
+
+            mock.VerifyAll();
+        }
+
+        [Fact]
+        public void StrykerCLI_WithNoArgumentsAndNoConfigFile_ShouldStartStrykerWithConfigOptions()
+        {
+            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 2000 &&
+                                                                        c.LogOptions.LogLevel == LogEventLevel.Information &&
+                                                                        c.LogOptions.LogToFile == false &&
+                                                                        c.ProjectUnderTestNameFilter == null &&
+                                                                        c.Reporter == "Console"))).Verifiable();
+            File.Move("stryker-config.json", "temp.json");
+            var target = new StrykerCLI(mock.Object);
+
+            target.Run(new string[] { });
+
+            mock.VerifyAll();
+            File.Move("temp.json", "stryker-config.json");
+        }
+
+        [Theory]
+        [InlineData("--configFilePath")]
+        [InlineData("-cp")]
+        public void StrykerCLI_WithConfigFile_ShouldStartStrykerWithConfigFileOptions(string argName)
+        {
+            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 9999 &&
+                                                                        c.LogOptions.LogLevel == LogEventLevel.Verbose &&
+                                                                        c.LogOptions.LogToFile == true &&
+                                                                        c.ProjectUnderTestNameFilter == "ExampleProject.csproj" &&
+                                                                        c.Reporter == "RapportOnly"))).Verifiable();
+
+            var target = new StrykerCLI(mock.Object);
+
+            target.Run(new string[] { argName, "filled-stryker-config.json" });
+
+            mock.VerifyAll();
+        }
+    }
+}

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="stryker-config.json" CopyToOutputDirectory="Always" />
-    <None Include="filled-stryker-config.json" CopyToOutputDirectory="Always" />
+    <None Update="filled-stryker-config.json" CopyToOutputDirectory="Always" />
+    <None Update="stryker-config.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <Target Name="PrintReferences" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences">

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="filled-stryker-config.json" CopyToOutputDirectory="Always" />
-    <None Update="stryker-config.json" CopyToOutputDirectory="Always" />
+    <None Include="filled-stryker-config.json" CopyToOutputDirectory="Always" />
+    <None Include="stryker-config.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <Target Name="PrintReferences" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences">

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -3,6 +3,7 @@ using Serilog.Events;
 using Stryker.Core;
 using Stryker.Core.Options;
 using System;
+using System.IO;
 using Xunit;
 
 namespace Stryker.CLI.UnitTest
@@ -24,61 +25,6 @@ namespace Stryker.CLI.UnitTest
         }
 
         [Fact]
-        public void StrykerCLI_WithNoArguments_ShouldStartStrykerWithDefaultOptions()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 2000 &&
-                                                                        c.LogOptions.LogLevel ==LogEventLevel.Information &&
-                                                                        c.LogOptions.LogToFile == false &&
-                                                                        c.ProjectUnderTestNameFilter == null &&
-                                                                        c.Reporter == "Console"))).Verifiable();
-
-            var target = new StrykerCLI(mock.Object);
-
-            target.Run(new string[] { });
-
-            mock.VerifyAll();
-        }
-
-        [Theory]
-        [InlineData("--configFilePath")]
-        [InlineData("-cp")]
-        public void StrykerCLI_WithConfigFile_ShouldStartStrykerWithConfigFileOptions(string argName)
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 9999 &&
-                                                                        c.LogOptions.LogLevel == LogEventLevel.Verbose &&
-                                                                        c.LogOptions.LogToFile == true &&
-                                                                        c.ProjectUnderTestNameFilter == "ExampleProject.csproj" &&
-                                                                        c.Reporter == "RapportOnly"))).Verifiable();
-
-            var target = new StrykerCLI(mock.Object);
-
-            target.Run(new string[] { argName, "filled-stryker-config.json" });
-
-            mock.VerifyAll();
-        }
-
-        [Theory]
-        [InlineData("--configFile")]
-        [InlineData("-c")]
-        public void StrykerCLI_WithConfigFileIsFalse_ShouldStartStrykerWithDefaultOptions(string argName)
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            mock.Setup(x => x.RunMutationTest(It.Is<StrykerOptions>(c => c.AdditionalTimeoutMS == 2000 &&
-                                                                        c.LogOptions.LogLevel == LogEventLevel.Information &&
-                                                                        c.LogOptions.LogToFile == false &&
-                                                                        c.ProjectUnderTestNameFilter == null &&
-                                                                        c.Reporter == "Console"))).Verifiable();
-
-            var target = new StrykerCLI(mock.Object);
-
-            target.Run(new string[] { argName, "false" , "-cp", "filled-stryker-config.json"});
-
-            mock.VerifyAll();
-        }
-
-        [Fact]
         public void StrykerCLI_OnException_ShouldExit()
         {
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
@@ -86,7 +32,7 @@ namespace Stryker.CLI.UnitTest
             
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { "-c", "false" });
+            target.Run(new string[] { });
 
             mock.VerifyAll();
         }
@@ -101,7 +47,7 @@ namespace Stryker.CLI.UnitTest
 
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { argName, "Console", "-c", "false" });
+            target.Run(new string[] { argName, "Console" });
 
             mock.Verify(x => x.RunMutationTest(It.Is<StrykerOptions>(o => o.Reporter == "Console")));
         }
@@ -116,7 +62,7 @@ namespace Stryker.CLI.UnitTest
 
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { argName, "SomeProjectName.csproj", "-c", "false" });
+            target.Run(new string[] { argName, "SomeProjectName.csproj" });
 
             mock.Verify(x => x.RunMutationTest(It.Is<StrykerOptions>(o => o.ProjectUnderTestNameFilter == "SomeProjectName.csproj")));
         }
@@ -131,7 +77,7 @@ namespace Stryker.CLI.UnitTest
 
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { argName, "debug", "-c", "false" });
+            target.Run(new string[] { argName, "debug" });
 
             mock.Verify(x => x.RunMutationTest(It.Is<StrykerOptions>(o => 
                 o.LogOptions.LogLevel == LogEventLevel.Debug && 
@@ -147,7 +93,7 @@ namespace Stryker.CLI.UnitTest
 
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { argName, "true", "-c", "false" });
+            target.Run(new string[] { argName, "true" });
 
             mock.Verify(x => x.RunMutationTest(It.Is<StrykerOptions>(o => o.LogOptions.LogToFile == true)));
         }
@@ -162,7 +108,7 @@ namespace Stryker.CLI.UnitTest
 
             var target = new StrykerCLI(mock.Object);
 
-            target.Run(new string[] { argName, "1000", "-c", "false" });
+            target.Run(new string[] { argName, "1000" });
 
             mock.Verify(x => x.RunMutationTest(It.Is<StrykerOptions>(o =>
                 o.AdditionalTimeoutMS == 1000)));

--- a/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
@@ -2,13 +2,6 @@
 {
     public static class CLIOptions
     {
-        public static readonly CLIOption<bool> UseConfigFile = new CLIOption<bool> {
-            ArgumentName = "--configFile",
-            ArgumentShortName = "-c <useConfigFile>",
-            ArgumentDescription = "Use configFile. When not defined you must have a config file and configFilePath must be set | Options [true (default), false]",
-            DefaultValue = true
-        };
-
         public static readonly CLIOption<string> ConfigFilePath = new CLIOption<string>
         {
             ArgumentName = "--configFilePath",

--- a/src/Stryker.CLI/Stryker.CLI/OptionsBuilder.cs
+++ b/src/Stryker.CLI/Stryker.CLI/OptionsBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.Extensions.CommandLineUtils;
 using Stryker.Core.Options;
+using System.IO;
 
 namespace Stryker.CLI
 {
@@ -16,10 +17,10 @@ namespace Stryker.CLI
             CommandOption additionalTimeoutMS,
             CommandOption logLevel,
             CommandOption logToFile,
-            CommandOption configFilePath,
-            CommandOption useConfigFile)
+            CommandOption configFilePath)
         {
-            if (GetOption(useConfigFile, CLIOptions.UseConfigFile))
+            var fileLocation = Path.Combine(basePath, GetOption(configFilePath, CLIOptions.ConfigFilePath));
+            if (File.Exists(fileLocation))
             {
                 config = new ConfigurationBuilder()
                         .SetBasePath(basePath)

--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -28,10 +28,6 @@ namespace Stryker.CLI
                 ExtendedHelpText = "Welcome to StrykerNet for .Net Core. Run dotnet stryker to kick off a mutation test run"
             };
 
-            var useConfigFileParam = app.Option($"{CLIOptions.UseConfigFile.ArgumentName} | {CLIOptions.UseConfigFile.ArgumentShortName}",
-                CLIOptions.UseConfigFile.ArgumentDescription,
-                CommandOptionType.SingleValue);
-
             var configFilePathParam = app.Option($"{CLIOptions.ConfigFilePath.ArgumentName} | {CLIOptions.ConfigFilePath.ArgumentShortName}",
                 CLIOptions.ConfigFilePath.ArgumentDescription,
                 CommandOptionType.SingleValue);
@@ -67,8 +63,7 @@ namespace Stryker.CLI
                     timeoutParam,
                     logConsoleParam,
                     fileLogParam,
-                    configFilePathParam,
-                    useConfigFileParam);
+                    configFilePathParam);
 
                 return RunStryker(options);
             });


### PR DESCRIPTION
Check if there is a config file called stryker-config.json or with the given name. else it should use the default 

Fixes #101