### PR TITLE
feat(build): Add multiple framework support

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
@@ -250,14 +250,11 @@ namespace Stryker.Core.UnitTest.Initialisation
         [InlineData("netcoreapp2.1")]
         public void ProjectFileReader_ShouldParseWhenMultipleFrameworks(string target)
         {
-            var xDocument = new XDocument();
-
-            if (target.Contains(";"))
-            {
-                xDocument = XDocument.Parse($@"
+            var xDocument = XDocument.Parse($@"
 <Project Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
-        <TargetFrameworks>{target}</TargetFrameworks>
+    <PropertyGroup>{(
+        target.Contains(";") ? $"<TargetFrameworks>{target}</TargetFrameworks>" : $"<TargetFramework>{target}</TargetFramework>"
+    )}        
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -273,29 +270,6 @@ namespace Stryker.Core.UnitTest.Initialisation
     </ItemGroup>
                 
 </Project>");
-            }
-            else
-            {
-                xDocument = XDocument.Parse($@"
-<Project Sdk=""Microsoft.NET.Sdk"">
-    <PropertyGroup>
-        <TargetFramework>{target}</TargetFramework>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
-        <PackageReference Include=""xunit"" Version=""2.3.1"" />
-        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
-        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
-    </ItemGroup>
-               
-    <ItemGroup>
-        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
-    </ItemGroup>
-                
-</Project>");
-            }
             
             var result = new ProjectFileReader().ReadProjectFile(xDocument, null);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
@@ -243,5 +243,63 @@ namespace Stryker.Core.UnitTest.Initialisation
             var result = new ProjectFileReader().ReadProjectFile(xDocument, "");
             result.AssemblyName.ShouldBeNull();
         }
+
+        [Theory]
+        [InlineData("netcoreapp2.0;net461;netstandard2.0")]
+        [InlineData("netcoreapp1.1;net45")]
+        [InlineData("netcoreapp2.1")]
+        public void ProjectFileReader_ShouldParseWhenMultipleFrameworks(string target)
+        {
+            var xDocument = new XDocument();
+
+            if (target.Contains(";"))
+            {
+                xDocument = XDocument.Parse($@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFrameworks>{target}</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
+        <PackageReference Include=""xunit"" Version=""2.3.1"" />
+        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
+        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
+    </ItemGroup>
+               
+    <ItemGroup>
+        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
+    </ItemGroup>
+                
+</Project>");
+            }
+            else
+            {
+                xDocument = XDocument.Parse($@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFramework>{target}</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
+        <PackageReference Include=""xunit"" Version=""2.3.1"" />
+        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
+        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
+    </ItemGroup>
+               
+    <ItemGroup>
+        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
+    </ItemGroup>
+                
+</Project>");
+            }
+            
+            var result = new ProjectFileReader().ReadProjectFile(xDocument, null);
+
+            result.TargetFramework.ShouldBe(target.Split(';')[0]);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Stryker.Core.Logging;
 using System;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -12,59 +13,72 @@ namespace Stryker.Core.Initialisation
 
         public ProjectFileReader()
         {
-            _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader> ();
+            _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader>();
         }
 
         public ProjectFile ReadProjectFile(XDocument projectFileContents, string projectUnderTestNameFilter)
         {
-            _logger.LogDebug ("Reading the project file {0}", projectFileContents.ToString ());
+            _logger.LogDebug("Reading the project file {0}", projectFileContents.ToString());
 
-            var rererence = FindProjectReference (projectFileContents, projectUnderTestNameFilter);
-            var targetFramework = FindTargetFrameworkReference (projectFileContents);
-            var assemblyName = FindAssemblyName (projectFileContents);
+            var reference = FindProjectReference(projectFileContents, projectUnderTestNameFilter);
+            var targetFramework = FindTargetFrameworkReference(projectFileContents);
+            var assemblyName = FindAssemblyName(projectFileContents);
 
-            return new ProjectFile ()
+            return new ProjectFile()
             {
-                ProjectReference = rererence,
+                ProjectReference = reference,
                 TargetFramework = targetFramework
             };
         }
 
         private string FindProjectReference(XDocument document, string projectUnderTestNameFilter)
         {
-            _logger.LogDebug ("Determining project under test with name filter {0}", projectUnderTestNameFilter);
+            _logger.LogDebug("Determining project under test with name filter {0}", projectUnderTestNameFilter);
 
-            var projectReferenceElements = document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase));
+            var projectReferenceElements = document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase));
             // get all the values from the projectReferenceElements
-            var projectReferences = projectReferenceElements.SelectMany (x => x.Attributes ()).Where (x => string.Equals (x.Name.LocalName, "Include", StringComparison.OrdinalIgnoreCase)).Select (x => x?.Value).ToList ();
+            var projectReferences = projectReferenceElements.SelectMany(x => x.Attributes()).Where(x => string.Equals(x.Name.LocalName, "Include", StringComparison.OrdinalIgnoreCase)).Select(x => x?.Value).ToList();
 
-            if (projectReferences.Count () > 1) {
+            if (projectReferences.Count() > 1)
+            {
                 // put the references together in one string seperated by ", "
-                string referencesString = string.Join (", ", projectReferences);
-                if (string.IsNullOrEmpty (projectUnderTestNameFilter))
+                string referencesString = string.Join(", ", projectReferences);
+                if (string.IsNullOrEmpty(projectUnderTestNameFilter))
                 {
-                    throw new NotSupportedException ("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException : new Exception ($"Found the following references: {referencesString}"));
+                    throw new NotSupportedException("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException: new Exception($"Found the following references: {referencesString}"));
                 }
                 else
                 {
-                    var searchResult = projectReferences.Where (x => x.ToLower ().Contains (projectUnderTestNameFilter.ToLower ())).ToList ();
-                    if (!searchResult.Any ())
+                    var searchResult = projectReferences.Where(x => x.ToLower().Contains(projectUnderTestNameFilter.ToLower())).ToList();
+                    if (!searchResult.Any())
                     {
-                        throw new ArgumentException ($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException : new Exception ($"Found the following references: {referencesString}"));
+                        throw new ArgumentException($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException: new Exception($"Found the following references: {referencesString}"));
                     }
-                    else if (searchResult.Count () > 1)
+                    else if (searchResult.Count() > 1)
                     {
-                        throw new ArgumentException ($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException : new Exception ($"Found the following references: {referencesString}"));
+                        throw new ArgumentException($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException: new Exception($"Found the following references: {referencesString}"));
                     }
-                    return searchResult.Single ();
+                    return ConvertPathSeparators(searchResult.Single());
                 }
             }
-            else if (!projectReferences.Any ())
+            else if (!projectReferences.Any())
             {
-                throw new NotSupportedException ("No project references found in test project file, unable to find project to mutate.");
+                throw new NotSupportedException("No project references found in test project file, unable to find project to mutate.");
             }
-            return projectReferences.Single ();
+            return ConvertPathSeparators(projectReferences.Single());
+        }
 
+        private static string ConvertPathSeparators(string filePath)
+        {
+            const char windowsDirectorySeparator = '\\';
+            if (Path.DirectorySeparatorChar == windowsDirectorySeparator)
+            {
+                return filePath;
+            }
+            else
+            {
+                return filePath.Replace(windowsDirectorySeparator, Path.DirectorySeparatorChar);
+            }
         }
 
         private string FindTargetFrameworkReference(XDocument document)
@@ -81,7 +95,7 @@ namespace Stryker.Core.Initialisation
 
         public string FindAssemblyName(XDocument document)
         {
-            return document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault ()?.Value;
+            return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault()?.Value;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -1,80 +1,71 @@
-﻿using Microsoft.Extensions.Logging;
-using Stryker.Core.Logging;
-using System;
+﻿using System;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Stryker.Core.Logging;
 
-namespace Stryker.Core.Initialisation
-{
-    public class ProjectFileReader
-    {
+namespace Stryker.Core.Initialisation {
+    public class ProjectFileReader {
         private ILogger _logger { get; set; }
 
-        public ProjectFileReader()
-        {
-            _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader>();
+        public ProjectFileReader () {
+            _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader> ();
         }
 
-        public ProjectFile ReadProjectFile(XDocument projectFileContents, string projectUnderTestNameFilter)
-        {
-            _logger.LogDebug("Reading the project file {0}", projectFileContents.ToString());
+        public ProjectFile ReadProjectFile (XDocument projectFileContents, string projectUnderTestNameFilter) {
+            _logger.LogDebug ("Reading the project file {0}", projectFileContents.ToString ());
 
-            var rererence = FindProjectReference(projectFileContents, projectUnderTestNameFilter);
-            var targetFramework = FindTargetFrameworkReference(projectFileContents);
-            var assemblyName = FindAssemblyName(projectFileContents);
+            var rererence = FindProjectReference (projectFileContents, projectUnderTestNameFilter);
+            var targetFramework = FindTargetFrameworkReference (projectFileContents);
+            var assemblyName = FindAssemblyName (projectFileContents);
 
-            return new ProjectFile()
-            {
+            return new ProjectFile () {
                 ProjectReference = rererence,
-                TargetFramework = targetFramework
+                    TargetFramework = targetFramework
             };
         }
 
-        private string FindProjectReference(XDocument document, string projectUnderTestNameFilter)
-        {
-            _logger.LogDebug("Determining project under test with name filter {0}", projectUnderTestNameFilter);
+        private string FindProjectReference (XDocument document, string projectUnderTestNameFilter) {
+            _logger.LogDebug ("Determining project under test with name filter {0}", projectUnderTestNameFilter);
 
-            var projectReferenceElements = document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase));
+            var projectReferenceElements = document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase));
             // get all the values from the projectReferenceElements
-            var projectReferences = projectReferenceElements.SelectMany(x => x.Attributes()).Where(x => string.Equals(x.Name.LocalName, "Include", StringComparison.OrdinalIgnoreCase)).Select(x => x?.Value).ToList();
+            var projectReferences = projectReferenceElements.SelectMany (x => x.Attributes ()).Where (x => string.Equals (x.Name.LocalName, "Include", StringComparison.OrdinalIgnoreCase)).Select (x => x?.Value).ToList ();
 
-            if (projectReferences.Count() > 1)
-            {
+            if (projectReferences.Count () > 1) {
                 // put the references together in one string seperated by ", "
-                string referencesString = string.Join(", ", projectReferences);
-                if (string.IsNullOrEmpty(projectUnderTestNameFilter))
-                {
-                    throw new NotSupportedException("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException: new Exception($"Found the following references: {referencesString}"));
-                }
-                else
-                {
-                    var searchResult = projectReferences.Where(x => x.ToLower().Contains(projectUnderTestNameFilter.ToLower())).ToList();
-                    if(!searchResult.Any())
-                    {
-                        throw new ArgumentException($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException: new Exception($"Found the following references: {referencesString}"));
-                    } else if (searchResult.Count() > 1)
-                    {
-                        throw new ArgumentException($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException: new Exception($"Found the following references: {referencesString}"));
+                string referencesString = string.Join (", ", projectReferences);
+                if (string.IsNullOrEmpty (projectUnderTestNameFilter)) {
+                    throw new NotSupportedException ("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException : new Exception ($"Found the following references: {referencesString}"));
+                } else {
+                    var searchResult = projectReferences.Where (x => x.ToLower ().Contains (projectUnderTestNameFilter.ToLower ())).ToList ();
+                    if (!searchResult.Any ()) {
+                        throw new ArgumentException ($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException : new Exception ($"Found the following references: {referencesString}"));
+                    } else if (searchResult.Count () > 1) {
+                        throw new ArgumentException ($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException : new Exception ($"Found the following references: {referencesString}"));
                     }
-                    return searchResult.Single();
+                    return searchResult.Single ();
                 }
+            } else if (!projectReferences.Any ()) {
+                throw new NotSupportedException ("No project references found in test project file, unable to find project to mutate.");
             }
-            else if (!projectReferences.Any())
+            return projectReferences.Single ();
+
+        }
+
+        private string FindTargetFrameworkReference (XDocument document) {
+            if (document.Elements().Descendants("TargetFrameworks").Any())
             {
-                throw new NotSupportedException("No project references found in test project file, unable to find project to mutate.");
+                return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "TargetFrameworks", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value.Split(';')[0];
             }
-            return projectReferences.Single();
-
+            else
+            {
+                return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "TargetFramework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value;
+            }
         }
 
-        private string FindTargetFrameworkReference(XDocument document)
-        {
-            return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "TargetFramework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value;
-        }
-
-        public string FindAssemblyName(XDocument document)
-        {
-            return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault()?.Value;
+        public string FindAssemblyName (XDocument document) {
+            return document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault ()?.Value;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -10,12 +10,12 @@ namespace Stryker.Core.Initialisation
     {
         private ILogger _logger { get; set; }
 
-        public ProjectFileReader ()
+        public ProjectFileReader()
         {
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader> ();
         }
 
-        public ProjectFile ReadProjectFile (XDocument projectFileContents, string projectUnderTestNameFilter)
+        public ProjectFile ReadProjectFile(XDocument projectFileContents, string projectUnderTestNameFilter)
         {
             _logger.LogDebug ("Reading the project file {0}", projectFileContents.ToString ());
 
@@ -26,11 +26,11 @@ namespace Stryker.Core.Initialisation
             return new ProjectFile ()
             {
                 ProjectReference = rererence,
-                    TargetFramework = targetFramework
+                TargetFramework = targetFramework
             };
         }
 
-        private string FindProjectReference (XDocument document, string projectUnderTestNameFilter)
+        private string FindProjectReference(XDocument document, string projectUnderTestNameFilter)
         {
             _logger.LogDebug ("Determining project under test with name filter {0}", projectUnderTestNameFilter);
 
@@ -44,19 +44,22 @@ namespace Stryker.Core.Initialisation
                 if (string.IsNullOrEmpty (projectUnderTestNameFilter))
                 {
                     throw new NotSupportedException ("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException : new Exception ($"Found the following references: {referencesString}"));
-                } else
+                }
+                else
                 {
                     var searchResult = projectReferences.Where (x => x.ToLower ().Contains (projectUnderTestNameFilter.ToLower ())).ToList ();
                     if (!searchResult.Any ())
                     {
                         throw new ArgumentException ($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException : new Exception ($"Found the following references: {referencesString}"));
-                    } else if (searchResult.Count () > 1)
+                    }
+                    else if (searchResult.Count () > 1)
                     {
                         throw new ArgumentException ($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException : new Exception ($"Found the following references: {referencesString}"));
                     }
                     return searchResult.Single ();
                 }
-            } else if (!projectReferences.Any ())
+            }
+            else if (!projectReferences.Any ())
             {
                 throw new NotSupportedException ("No project references found in test project file, unable to find project to mutate.");
             }
@@ -64,7 +67,7 @@ namespace Stryker.Core.Initialisation
 
         }
 
-        private string FindTargetFrameworkReference (XDocument document)
+        private string FindTargetFrameworkReference(XDocument document)
         {
             if (document.Elements().Descendants("TargetFrameworks").Any())
             {
@@ -76,7 +79,7 @@ namespace Stryker.Core.Initialisation
             }
         }
 
-        public string FindAssemblyName (XDocument document)
+        public string FindAssemblyName(XDocument document)
         {
             return document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault ()?.Value;
         }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using Stryker.Core.Logging;
+using System;
 using System.Linq;
 using System.Xml.Linq;
-using Microsoft.Extensions.Logging;
-using Stryker.Core.Logging;
 
-namespace Stryker.Core.Initialisation {
+namespace Stryker.Core.Initialisation
+{
     public class ProjectFileReader {
         private ILogger _logger { get; set; }
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -6,27 +6,32 @@ using System.Xml.Linq;
 
 namespace Stryker.Core.Initialisation
 {
-    public class ProjectFileReader {
+    public class ProjectFileReader
+    {
         private ILogger _logger { get; set; }
 
-        public ProjectFileReader () {
+        public ProjectFileReader ()
+        {
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<ProjectFileReader> ();
         }
 
-        public ProjectFile ReadProjectFile (XDocument projectFileContents, string projectUnderTestNameFilter) {
+        public ProjectFile ReadProjectFile (XDocument projectFileContents, string projectUnderTestNameFilter)
+        {
             _logger.LogDebug ("Reading the project file {0}", projectFileContents.ToString ());
 
             var rererence = FindProjectReference (projectFileContents, projectUnderTestNameFilter);
             var targetFramework = FindTargetFrameworkReference (projectFileContents);
             var assemblyName = FindAssemblyName (projectFileContents);
 
-            return new ProjectFile () {
+            return new ProjectFile ()
+            {
                 ProjectReference = rererence,
                     TargetFramework = targetFramework
             };
         }
 
-        private string FindProjectReference (XDocument document, string projectUnderTestNameFilter) {
+        private string FindProjectReference (XDocument document, string projectUnderTestNameFilter)
+        {
             _logger.LogDebug ("Determining project under test with name filter {0}", projectUnderTestNameFilter);
 
             var projectReferenceElements = document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "ProjectReference", StringComparison.OrdinalIgnoreCase));
@@ -36,25 +41,31 @@ namespace Stryker.Core.Initialisation
             if (projectReferences.Count () > 1) {
                 // put the references together in one string seperated by ", "
                 string referencesString = string.Join (", ", projectReferences);
-                if (string.IsNullOrEmpty (projectUnderTestNameFilter)) {
+                if (string.IsNullOrEmpty (projectUnderTestNameFilter))
+                {
                     throw new NotSupportedException ("Only one referenced project is supported, please add the --project-file=[projectname] argument to specify the project to mutate", innerException : new Exception ($"Found the following references: {referencesString}"));
-                } else {
+                } else
+                {
                     var searchResult = projectReferences.Where (x => x.ToLower ().Contains (projectUnderTestNameFilter.ToLower ())).ToList ();
-                    if (!searchResult.Any ()) {
+                    if (!searchResult.Any ())
+                    {
                         throw new ArgumentException ($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException : new Exception ($"Found the following references: {referencesString}"));
-                    } else if (searchResult.Count () > 1) {
+                    } else if (searchResult.Count () > 1)
+                    {
                         throw new ArgumentException ($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException : new Exception ($"Found the following references: {referencesString}"));
                     }
                     return searchResult.Single ();
                 }
-            } else if (!projectReferences.Any ()) {
+            } else if (!projectReferences.Any ())
+            {
                 throw new NotSupportedException ("No project references found in test project file, unable to find project to mutate.");
             }
             return projectReferences.Single ();
 
         }
 
-        private string FindTargetFrameworkReference (XDocument document) {
+        private string FindTargetFrameworkReference (XDocument document)
+        {
             if (document.Elements().Descendants("TargetFrameworks").Any())
             {
                 return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "TargetFrameworks", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value.Split(';')[0];
@@ -65,7 +76,8 @@ namespace Stryker.Core.Initialisation
             }
         }
 
-        public string FindAssemblyName (XDocument document) {
+        public string FindAssemblyName (XDocument document)
+        {
             return document.Elements ().Descendants ().Where (x => string.Equals (x.Name.LocalName, "AssemblyName", StringComparison.OrdinalIgnoreCase)).FirstOrDefault ()?.Value;
         }
     }


### PR DESCRIPTION
-Add multiple framework support to ProjectFileReader.

-Add tests to ensure expected functionality and to ensure no regressions

Fixes #130, if a .csproj contains multiple framework support, currently Stryker breaks with a NullReference Exception.  This change inserts a stop-gap that instructs Stryker to use the first found framework.