### PR TITLE
fix(mutating): Make sure a broken mutation does not exist twice, so that we can roll back the mutation (#145)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -248,7 +248,7 @@ namespace ExampleProject
         }
 
         [Fact]
-        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhen()
+        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhenUriIsEmpty()
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(@"
 using System;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -246,5 +246,61 @@ namespace ExampleProject
                 fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
             }
         }
+
+        [Fact]
+        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhen()
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(@"
+using System;
+
+namespace ExampleProject
+{
+    public class Query
+    {
+        public void Break()
+        {
+            if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""1"")
+            {
+                string someQuery = ""test"";
+                new Uri(new Uri(string.Empty), ""/API?"" + someQuery);
+            }
+            else
+            {
+                return;
+            }
+        }
+    }
+}");
+            var ifStatement = syntaxTree.GetRoot()
+                .DescendantNodes()
+                .Where(x => x is IfStatementSyntax)
+                .First();
+            var annotatedSyntaxTree = syntaxTree.GetRoot()
+                .ReplaceNode(
+                    ifStatement, 
+                    ifStatement.WithAdditionalAnnotations(new SyntaxAnnotation("MutantIf", "1"))
+                ).SyntaxTree;
+
+            var compiler = CSharpCompilation.Create("TestCompilation",
+                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                references: new List<PortableExecutableReference>() {
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+                });
+
+            var target = new RollbackProcess();
+
+            using (var ms = new MemoryStream())
+            {
+                var compileResult = compiler.Emit(ms);
+
+                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics);
+                
+                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+
+                rollbackedResult.Success.ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -98,7 +98,7 @@ namespace Stryker.Core.Compiling
                     _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
                 }
 
-                if (!brokenMutation.Contains(mutationIf))
+                if (!brokenMutations.Contains(mutationIf))
                 {
                     brokenMutations.Add(mutationIf);
                 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -97,7 +97,9 @@ namespace Stryker.Core.Compiling
                 {
                     _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
                 }
-                brokenMutations.Add(mutationIf);
+
+                if (!brokenMutation.Contains(mutationIf))
+                    brokenMutations.Add(mutationIf);
             }
             // mark the if statements to track
             var trackedTree = rollbackRoot.TrackNodes(brokenMutations);

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -99,7 +99,9 @@ namespace Stryker.Core.Compiling
                 }
 
                 if (!brokenMutation.Contains(mutationIf))
+                {
                     brokenMutations.Add(mutationIf);
+                }
             }
             // mark the if statements to track
             var trackedTree = rollbackRoot.TrackNodes(brokenMutations);


### PR DESCRIPTION
Fix #145 