### PR TITLE
fix(dependency-resolver): Support backslash in ProjectReferences on Linux

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using Shouldly;
 using Stryker.Core.Initialisation;
 using System;
+using System.IO;
 using System.Xml.Linq;
 using Xunit;
 
@@ -35,7 +36,7 @@ namespace Stryker.Core.UnitTest.Initialisation
 </Project>");
             var result = new ProjectFileReader().ReadProjectFile(xDocument, null);
 
-            result.ProjectReference.ShouldBe(@"..\ExampleProject\ExampleProject.csproj");
+            result.ProjectReference.ShouldBe($"..{Path.DirectorySeparatorChar}ExampleProject{Path.DirectorySeparatorChar}ExampleProject.csproj");
             result.TargetFramework.ShouldBe(target);
         }
 
@@ -114,7 +115,7 @@ namespace Stryker.Core.UnitTest.Initialisation
     </ItemGroup>
 </Project>");
             var result = new ProjectFileReader().ReadProjectFile(xDocument, shouldMatch);
-            result.ProjectReference.ShouldBe(@"..\ExampleProject\ExampleProject.csproj");
+            result.ProjectReference.ShouldBe($"..{Path.DirectorySeparatorChar}ExampleProject{Path.DirectorySeparatorChar}ExampleProject.csproj");
         }
 
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Stryker.Core.Logging;
 using System;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -19,13 +20,13 @@ namespace Stryker.Core.Initialisation
         {
             _logger.LogDebug("Reading the project file {0}", projectFileContents.ToString());
 
-            var rererence = FindProjectReference(projectFileContents, projectUnderTestNameFilter);
+            var reference = FindProjectReference(projectFileContents, projectUnderTestNameFilter);
             var targetFramework = FindTargetFrameworkReference(projectFileContents);
             var assemblyName = FindAssemblyName(projectFileContents);
 
             return new ProjectFile()
             {
-                ProjectReference = rererence,
+                ProjectReference = reference,
                 TargetFramework = targetFramework
             };
         }
@@ -49,22 +50,30 @@ namespace Stryker.Core.Initialisation
                 else
                 {
                     var searchResult = projectReferences.Where(x => x.ToLower().Contains(projectUnderTestNameFilter.ToLower())).ToList();
-                    if(!searchResult.Any())
+                    if (!searchResult.Any())
                     {
                         throw new ArgumentException($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException: new Exception($"Found the following references: {referencesString}"));
                     } else if (searchResult.Count() > 1)
                     {
                         throw new ArgumentException($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException: new Exception($"Found the following references: {referencesString}"));
                     }
-                    return searchResult.Single();
+                    return ConvertPathSeparators(searchResult.Single());
                 }
             }
             else if (!projectReferences.Any())
             {
                 throw new NotSupportedException("No project references found in test project file, unable to find project to mutate.");
             }
-            return projectReferences.Single();
+            return ConvertPathSeparators(projectReferences.Single());
+        }
 
+        private static string ConvertPathSeparators(string filePath)
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                return filePath;
+            }
+            return filePath.Replace('\\', Path.DirectorySeparatorChar);
         }
 
         private string FindTargetFrameworkReference(XDocument document)

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -53,7 +53,8 @@ namespace Stryker.Core.Initialisation
                     if (!searchResult.Any())
                     {
                         throw new ArgumentException($"No project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, was the name spelled correctly?", innerException: new Exception($"Found the following references: {referencesString}"));
-                    } else if (searchResult.Count() > 1)
+                    }
+                    else if (searchResult.Count() > 1)
                     {
                         throw new ArgumentException($"More than one project reference matched your --project-file={projectUnderTestNameFilter} argument to specify the project to mutate, please specify the name more detailed", innerException: new Exception($"Found the following references: {referencesString}"));
                     }
@@ -69,11 +70,15 @@ namespace Stryker.Core.Initialisation
 
         private static string ConvertPathSeparators(string filePath)
         {
-            if (Path.DirectorySeparatorChar == '\\')
+            const char windowsDirectorySeparator = '\\';
+            if (Path.DirectorySeparatorChar == windowsDirectorySeparator)
             {
                 return filePath;
             }
-            return filePath.Replace('\\', Path.DirectorySeparatorChar);
+            else
+            {
+                return filePath.Replace(windowsDirectorySeparator, Path.DirectorySeparatorChar);
+            }
         }
 
         private string FindTargetFrameworkReference(XDocument document)


### PR DESCRIPTION
I decided to try running Stryker.NET on Linux, and it turned out to be really close to ready.  This pull request fixes what looks like the last remaining issue, which is that project file paths were always returned with the Windows directory separators. Fixes #120