### PR TITLE
chore: fix minor spelling issues and typos in comments and log messages

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
@@ -32,7 +32,7 @@
         {
             ArgumentName = "--log-file",
             ArgumentShortName = "-f <useLogFile>",
-            ArgumentDescription = "Use log-file | Options [false (Default), true]",
+            ArgumentDescription = "Use logfile | Options [false (Default), true]",
             DefaultValue = false,
             JsonKey = "log-file"
         };
@@ -41,7 +41,7 @@
         {
             ArgumentName = "--timeout-ms",
             ArgumentShortName = "-t <ms>",
-            ArgumentDescription = "When passed, a logfile will be created for this mutationtest run on trace level",
+            ArgumentDescription = "When passed, a logfile will be created for this mutation test run on trace level",
             DefaultValue = 30000,
             JsonKey = "timeout-ms"
         };

--- a/src/Stryker.Core/Stryker.Core.UnitTest/AssertExtensions.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/AssertExtensions.cs
@@ -28,7 +28,7 @@ namespace Stryker.Core.UnitTest
         public static void ShouldBeSemantically(this SyntaxNode actual, SyntaxNode expected)
         {
             SyntaxFactory.AreEquivalent(actual, expected)
-                .ShouldBeTrue($"AST's are not equavalent. Actual: {Environment.NewLine}{actual}, expected: {Environment.NewLine}{expected}");
+                .ShouldBeTrue($"AST's are not equivalent. Actual: {Environment.NewLine}{actual}, expected: {Environment.NewLine}{expected}");
         }
 
         public static void ShouldBeWithNewlineReplace(this string actual, string expected)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
@@ -34,7 +34,7 @@ namespace ExampleProject
             {
                 ProjectInfo = new Core.Initialisation.ProjectInfo()
                 {
-                    ProjectUnderTestAssemblyName = "The asssembly name"
+                    ProjectUnderTestAssemblyName = "The assembly name"
                 },
                 AssemblyReferences = new List<PortableExecutableReference>() {
                     MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
@@ -71,7 +71,7 @@ namespace ExampleProject
             {
                 ProjectInfo = new Core.Initialisation.ProjectInfo()
                 {
-                    ProjectUnderTestAssemblyName = "The asssembly name"
+                    ProjectUnderTestAssemblyName = "The assembly name"
                 },
                 AssemblyReferences = new List<PortableExecutableReference>() {
                     MetadataReference.CreateFromFile(typeof(object).Assembly.Location)
@@ -112,7 +112,7 @@ namespace ExampleProject
             {
                 ProjectInfo = new Core.Initialisation.ProjectInfo()
                 {
-                    ProjectUnderTestAssemblyName = "The asssembly name"
+                    ProjectUnderTestAssemblyName = "The assembly name"
                 },
                 AssemblyReferences = new List<PortableExecutableReference>() {
                     MetadataReference.CreateFromFile(typeof(object).Assembly.Location)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/AssemblyReferenceResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/AssemblyReferenceResolverTests.cs
@@ -13,7 +13,7 @@ namespace Stryker.Core.UnitTest.Initialisation
 {
     /// <summary>
     /// msbuild will return a string with all referenced assemblies for the given test project. 
-    /// The AssemblyReferenceResolver should parse this string correctly into seperate dependencies for Roslyn.
+    /// The AssemblyReferenceResolver should parse this string correctly into separate dependencies for Roslyn.
     /// </summary>
     public class AssemblyReferenceResolverTests
     {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -16,7 +16,7 @@ namespace Stryker.Core.Compiling
     public interface ICompilingProcess
     {
         /// <summary>
-        /// Compiles the given input onto the memorysteam
+        /// Compiles the given input onto the memorystream
         /// </summary>
         /// <param name="ms">The memorystream to function as output</param>
         CompilingProcessResult Compile(IEnumerable<SyntaxTree> syntaxTrees, MemoryStream ms);

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -32,7 +32,7 @@ namespace Stryker.Core.Compiling
         {
             _rollbackedIds = new List<int>();
 
-            // match the diagnotics with their syntaxtrees
+            // match the diagnostics with their syntaxtrees
             var syntaxTreeMapping = new Dictionary<SyntaxTree, ICollection<Diagnostic>>();
             foreach (var syntaxTree in compiler.SyntaxTrees)
             {
@@ -56,7 +56,7 @@ namespace Stryker.Core.Compiling
                 compiler = compiler.ReplaceSyntaxTree(syntaxTreeMap.Key, updatedSyntaxTree);
             }
 
-            // by returning the same compiler object (with different syntax trees) the next compilation will use Roslyns incremental compilation
+            // by returning the same compiler object (with different syntax trees) the next compilation will use Roslyn's incremental compilation
             return new RollbackProcessResult() {
                 Compilation = compiler,
                 RollbackedIds = _rollbackedIds
@@ -95,7 +95,7 @@ namespace Stryker.Core.Compiling
                 var mutationIf = FindMutationIf(brokenMutation);
                 if(mutationIf == null)
                 {
-                    _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
+                    _logger.LogError("Unable to rollback mutation for node {0} with diagnostic message {1}", brokenMutation, diagnostic.GetMessage());
                 }
                 brokenMutations.Add(mutationIf);
             }
@@ -103,9 +103,9 @@ namespace Stryker.Core.Compiling
             var trackedTree = rollbackRoot.TrackNodes(brokenMutations);
             foreach (var brokenMutation in brokenMutations)
             {
-                // find the ifstatement in the new tree
+                // find the if statement in the new tree
                 var nodeToRemove = trackedTree.GetCurrentNode(brokenMutation);
-                // remove the ifstatement and update the tree
+                // remove the if statement and update the tree
                 trackedTree = trackedTree.ReplaceNode(nodeToRemove, nodeToRemove.Else.Statement);
             }
             return trackedTree.SyntaxTree;

--- a/src/Stryker.Core/Stryker.Core/Initialisation/AssemblyReferenceResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/AssemblyReferenceResolver.cs
@@ -67,7 +67,7 @@ namespace Stryker.Core.Initialisation
                 yield return _metadataReference.CreateFromFile(reference.Trim());
             }
 
-            // the last part contains the package dependencies, seperated by the path seperator char
+            // the last part contains the package dependencies, seperated by the path separator char
             foreach (var reference in GetAssemblyPathsFromOutput(rows.Last())
                 .Distinct()
                 .Where(x => Path.GetFileNameWithoutExtension(x) != projectUnderTestAssemblyName))

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -57,7 +57,7 @@ namespace Stryker.Core.Initialisation
         }
 
         /// <summary>
-        /// Resursively scans the given directory for files to mutate
+        /// Recursively scans the given directory for files to mutate
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectComponents/IReadOnlyInputComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectComponents/IReadOnlyInputComponent.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Stryker.Core.Initialisation.ProjectComponent
 {
     /// <summary>
-    /// This interface should only contain readonly properties to ensure that others than the mutationtest proces cannot modify components.
+    /// This interface should only contain readonly properties to ensure that others than the mutation test process cannot modify components.
     /// </summary>
     public interface IReadOnlyInputComponent
     {

--- a/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
@@ -1,7 +1,7 @@
 ﻿namespace Stryker.Core.Mutants
 {
     /// <summary>
-    /// This interface should only contain readonly properties to ensure that others than the mutationtest proces cannot modify mutants.
+    /// This interface should only contain readonly properties to ensure that others than the mutation test process cannot modify mutants.
     /// </summary>
     public interface IReadOnlyMutant
     {

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -34,7 +34,7 @@ namespace Stryker.Core.Mutants
         private ILogger _logger { get; set; }
 
         /// <param name="mutators">The mutators that should be active during the mutation process</param>
-        /// <param name="mutantFactory">An instance of the mutantFactory, use the same for every file to keep the mutationcount increment</param>
+        /// <param name="mutantFactory">An instance of the mutantFactory, use the same for every file to keep the mutation count increment</param>
         public MutantOrchestrator(IEnumerable<IMutator> mutators)
         {
             _mutators = mutators;
@@ -67,7 +67,7 @@ namespace Stryker.Core.Mutants
                 StatementSyntax ast = statement as StatementSyntax;
 
                 // this is a temporary fix for mutating LocalDeclarationStatements because mutating withing these statements breaks the application
-                // TODO: backlog item Ternary assignment statements mutaties
+                // TODO: backlog item Ternary assignment statements mutates
                 if (!(statement is LocalDeclarationStatementSyntax))
                 {
                     foreach (var mutant in currentNode.ChildNodes().SelectMany(FindMutants))

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -67,7 +67,7 @@ namespace Stryker.Core.Mutants
                 StatementSyntax ast = statement as StatementSyntax;
 
                 // this is a temporary fix for mutating LocalDeclarationStatements because mutating withing these statements breaks the application
-                // TODO: backlog item Ternary assignment statements mutates
+                // TODO: backlog item Ternary assignment statements mutations
                 if (!(statement is LocalDeclarationStatementSyntax))
                 {
                     foreach (var mutant in currentNode.ChildNodes().SelectMany(FindMutants))

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
@@ -7,7 +7,7 @@ using System;
 namespace Stryker.Core.MutationTest
 {
     /// <summary>
-    /// Executes exactly one mutationtest and stores the result
+    /// Executes exactly one mutation test and stores the result
     /// </summary>
     public interface IMutationTestExecutor
     {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestInput.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestInput.cs
@@ -17,7 +17,7 @@ namespace Stryker.Core.MutationTest
         public Initialisation.ProjectInfo ProjectInfo { get; set; }
 
         /// <summary>
-        /// The testrunner that will be used for the mutationtest run
+        /// The testrunner that will be used for the mutation test run
         /// </summary>
         public ITestRunner TestRunner { get; set; }
 

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -61,7 +61,7 @@ namespace Stryker.Core.MutationTest
                 var mutatedSyntaxTree = _orchestrator.Mutate(syntaxTree.GetRoot());
                 // Add the mutated syntax tree for compilation
                 mutatedSyntaxTrees.Add(mutatedSyntaxTree.SyntaxTree);
-                // Store the generated mutatants in the file
+                // Store the generated mutants in the file
                 file.Mutants = _orchestrator.GetLatestMutantBatch();
             }
 

--- a/src/Stryker.Core/Stryker.Core/Reporters/IReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/IReporter.cs
@@ -14,7 +14,7 @@ namespace Stryker.Core.Reporters
         void OnMutantsCreated(IReadOnlyInputComponent reportComponent);
         // Will get called when a mutation has been tested
         void OnMutantTested(IReadOnlyMutant result);
-        // Wille get callen when all mutations have been tested
+        // Will get called when all mutations have been tested
         void OnAllMutantsTested(IReadOnlyInputComponent reportComponent);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -47,7 +47,7 @@ namespace Stryker.Core
 
             try
             {
-                // initialyze 
+                // initialize
                 _reporter = ReporterFactory.Create(options.Reporter);
                 _initialisationProcess = _initialisationProcess ?? new InitialisationProcess(_reporter);
                 _input = _initialisationProcess.Initialize(options);
@@ -75,7 +75,7 @@ namespace Stryker.Core
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "An error occurred during the mutationtest run ");
+                logger.LogError(ex, "An error occurred during the mutation test run ");
                 throw;
             }
             finally {

--- a/src/Stryker.Core/Stryker.Core/Testing/ProcessExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/Testing/ProcessExecutor.cs
@@ -60,10 +60,10 @@ namespace Stryker.Core.Testing
 
         /// <summary>
         /// Starts a process with the given info. 
-        /// Checks for timeout after <paramref name="timeoutMS"/> miliseconds if the process is still running. 
+        /// Checks for timeout after <paramref name="timeoutMS"/> milliseconds if the process is still running. 
         /// </summary>
         /// <param name="info">The start info for the process</param>
-        /// <param name="timeoutMS">The miliseconds to check for a timeout</param>
+        /// <param name="timeoutMS">The milliseconds to check for a timeout</param>
         /// <exception cref="OperationCanceledException"></exception>
         /// <returns></returns>
         private ProcessResult RunProcess(ProcessStartInfo info, int timeoutMS)


### PR DESCRIPTION
I polish comments for better understanding.
I have doubt about 'mutationtest' term, but in all repos scope 'mutation test' is more related.
I hope, that PR can made project a little better.