### PR TITLE
fix(mutating): Make sure a broken mutation does not exist twice, so that we can roll back the mutation (#145)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -248,7 +248,7 @@ namespace ExampleProject
         }
 
         [Fact]
-        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhen()
+        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhenUriIsEmpty()
         {
             var syntaxTree = CSharpSyntaxTree.ParseText(@"
 using System;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -262,11 +262,12 @@ namespace ExampleProject
             if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""1"")
             {
                 string someQuery = ""test"";
-                new Uri(new Uri(string.Empty), ""/API?"" + someQuery);
+                new Uri(new Uri(string.Empty), ""/API?"" - someQuery);
             }
             else
             {
-                return;
+                string someQuery = ""test"";
+                new System.Uri(new System.Uri(string.Empty), ""/API?"" + someQuery);
             }
         }
     }
@@ -286,7 +287,8 @@ namespace ExampleProject
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
                 references: new List<PortableExecutableReference>() {
                     MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location),
                 });
 
             var target = new RollbackProcess();
@@ -300,6 +302,9 @@ namespace ExampleProject
                 var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
 
                 rollbackedResult.Success.ShouldBeTrue();
+                
+                // validate that only one of the compile errors marked the mutation as rollbacked.
+                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 1 });
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -246,5 +246,61 @@ namespace ExampleProject
                 fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
             }
         }
+
+        [Fact]
+        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhen()
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText(@"
+using System;
+
+namespace ExampleProject
+{
+    public class Query
+    {
+        public void Break()
+        {
+            if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""1"")
+            {
+                string someQuery = ""test"";
+                new Uri(new Uri(string.Empty), ""/API?"" + someQuery);
+            }
+            else
+            {
+                return;
+            }
+        }
+    }
+}");
+            var ifStatement = syntaxTree.GetRoot()
+                .DescendantNodes()
+                .Where(x => x is IfStatementSyntax)
+                .First();
+            var annotatedSyntaxTree = syntaxTree.GetRoot()
+                .ReplaceNode(
+                    ifStatement, 
+                    ifStatement.WithAdditionalAnnotations(new SyntaxAnnotation("MutantIf", "1"))
+                ).SyntaxTree;
+
+            var compiler = CSharpCompilation.Create("TestCompilation",
+                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                references: new List<PortableExecutableReference>() {
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+                });
+
+            var target = new RollbackProcess();
+
+            using (var ms = new MemoryStream())
+            {
+                var compileResult = compiler.Emit(ms);
+
+                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics);
+                
+                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+
+                rollbackedResult.Success.ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -98,7 +98,7 @@ namespace Stryker.Core.Compiling
                     _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
                 }
 
-                if (!brokenMutation.Contains(mutationIf))
+                if (!brokenMutations.Contains(mutationIf))
                 {
                     brokenMutations.Add(mutationIf);
                 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -63,24 +63,23 @@ namespace Stryker.Core.Compiling
             };
         }
 
-        private IfStatementSyntax FindMutationIf(SyntaxNode node)
+        private (IfStatementSyntax, int) FindMutationIfAndId(SyntaxNode node)
         {
             var annotation = node.GetAnnotations("MutantIf");
             if (annotation.Any() && node is IfStatementSyntax mutantIf)
             {
                 string data = annotation.First().Data;
                 int mutantId = int.Parse(data);
-                _rollbackedIds.Add(mutantId);
                 _logger.LogDebug("Found id {0} in MutantIf annotation", mutantId);
-                return mutantIf;
+                return (mutantIf, mutantId);
             }
             else
             {
                 if(node.Parent == null)
                 {
-                    return null; 
+                    return (null, 0); 
                 }
-                return FindMutationIf(node.Parent);
+                return FindMutationIfAndId(node.Parent);
             }
         }
 
@@ -92,8 +91,8 @@ namespace Stryker.Core.Compiling
             foreach (var diagnostic in diagnosticInfo)
             {
                 var brokenMutation = rollbackRoot.FindNode(diagnostic.Location.SourceSpan);
-                var mutationIf = FindMutationIf(brokenMutation);
-                if(mutationIf == null)
+                var (mutationIf, mutantId) = FindMutationIfAndId(brokenMutation);
+                if (mutationIf == null)
                 {
                     _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
                 }
@@ -101,6 +100,7 @@ namespace Stryker.Core.Compiling
                 if (!brokenMutations.Contains(mutationIf))
                 {
                     brokenMutations.Add(mutationIf);
+                    _rollbackedIds.Add(mutantId);
                 }
             }
             // mark the if statements to track

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -97,7 +97,9 @@ namespace Stryker.Core.Compiling
                 {
                     _logger.LogError("Unable to rollback mutation for node {0} with diagnosticmessage {1}", brokenMutation, diagnostic.GetMessage());
                 }
-                brokenMutations.Add(mutationIf);
+
+                if (!brokenMutation.Contains(mutationIf))
+                    brokenMutations.Add(mutationIf);
             }
             // mark the if statements to track
             var trackedTree = rollbackRoot.TrackNodes(brokenMutations);

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -99,7 +99,9 @@ namespace Stryker.Core.Compiling
                 }
 
                 if (!brokenMutation.Contains(mutationIf))
+                {
                     brokenMutations.Add(mutationIf);
+                }
             }
             // mark the if statements to track
             var trackedTree = rollbackRoot.TrackNodes(brokenMutations);


### PR DESCRIPTION
Reopen PR so someone else can pick up the changes that were left since @B1tF8er no longer has time to fix this. No sense throwing away the changes already made.

Fixes #145 Reopened from #148 