### PR TITLE
build: Set build number to version number

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,4 @@
+name: $(Build.DefinitionName)-$(PackageVersion)$(rev:.r)
 resources:
 - repo: self
   clean: true


### PR DESCRIPTION
Sets the build number to `stryker-net-0.3.0.x` instead of the current date with a revision number.