### PR TITLE
Remove reference to Stryker nuget package

### DIFF
--- a/integrationtests/IntegrationTests/Stryker.Core.IntegrationTest/ExampleProject/ExampleProject.XUnit/ExampleProject.XUnit.csproj
+++ b/integrationtests/IntegrationTests/Stryker.Core.IntegrationTest/ExampleProject/ExampleProject.XUnit/ExampleProject.XUnit.csproj
@@ -20,9 +20,4 @@
   <Target Name="PrintReferences" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences">
     <Message Text="@(_ResolveAssemblyReferenceResolvedFiles)" Importance="high" />
   </Target>
-  
-  <ItemGroup>
-	<PackageReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
-    <DotNetCliToolReference Include="StrykerMutator.DotNetCoreCli" Version="*" />
-</ItemGroup>
 </Project>


### PR DESCRIPTION
In the exampleproject a reference to the actual nuget package was present. This broke the integrationtest, but only after version 0.4 was released. The reference is still unneeded and should be removed. 

The fixing of 0.4 installation has already been adressed in #218 