### PR TITLE
Fix string interpolation mistake

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -90,9 +90,9 @@ namespace Stryker.CLI
         }
 
         private void HandleBreakingThresholdScore(StrykerOptions options, StrykerRunResult results) {
-            _logger.LogError(@"Final mutation score: {results.mutationScore} under breaking threshold value {options.ThresholdOptions.ThresholdBreak},
-                                ,setting exit code to 1 (failure).
-                                Improve the mutation score or set the `threshold-break` value lower to prevent this error in the future");
+            _logger.LogError($@"Final mutation score: {results.mutationScore * 100} under breaking threshold value {options.ThresholdOptions.ThresholdBreak}.
+Setting exit code to 1 (failure).
+Improve the mutation score or set the `threshold-break` value lower to prevent this error in the future.");
             this.ExitCode = 1;
         }
 


### PR DESCRIPTION
This string missed interpolation, so it actually printed:
```
Final mutation score: {results.mutationScore} under breaking threshold value {options.ThresholdOptions.ThresholdBreak},                                
                                ,setting exit code to 1 (failure).
                                Improve the mutation score or set the `threshold-break` value lower to prevent this error in the future
```
Now it prints:
```
Final mutation score: 11 under breaking threshold value 50,                                
Setting exit code to 1 (failure).
Improve the mutation score or set the `threshold-break` value lower to prevent this error in the future
```