### PR TITLE
fix(logging): Clean up oneline logger output by removing timestamp

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectComponents/ProjectComponentTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectComponents/ProjectComponentTests.cs
@@ -73,7 +73,6 @@ namespace StrykerNet.UnitTest.Initialisation.ProjectComponents
 
         [Theory]
         [InlineData(MutantStatus.Killed, 1)]
-        [InlineData(MutantStatus.RuntimeError, 1)]
         [InlineData(MutantStatus.Timeout, 1)]
         [InlineData(MutantStatus.Survived, 0)]
         [InlineData(MutantStatus.NotRun, 0)]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ConsoleDotReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ConsoleDotReporterTests.cs
@@ -12,7 +12,6 @@ namespace Stryker.Core.UnitTest.Reporters
 
         [Theory]
         [InlineData(MutantStatus.Killed, ".", "default")]
-        [InlineData(MutantStatus.RuntimeError, "E", "default")]
         [InlineData(MutantStatus.Survived, "S", "red")]
         [InlineData(MutantStatus.Timeout, "T", "default")]
         public void ConsoleDotReporter_ShouldPrintRightCharOnMutation(MutantStatus givenStatus, string expectedOutput, string color)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/MutantsResultReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/MutantsResultReporterTests.cs
@@ -28,63 +28,34 @@ namespace Stryker.Core.UnitTest.Reporters.Progress
                                                      _mutantRuntimeErrorLogger.Object);
         }
 
-        [Fact]
-        public void ReportMutantTestResult_ShouldLogEachTimeKilledMutantIsReported()
+        [Theory]
+        [InlineData(MutantStatus.Killed)]
+        [InlineData(MutantStatus.Survived)]
+        [InlineData(MutantStatus.Timeout)]
+        public void ReportMutantTestResult_ShouldLogEachTimeKilledMutantIsReported(MutantStatus status)
         {
             var mutantTestResult = new Mutant()
             {
-                ResultStatus = MutantStatus.Killed
+                ResultStatus = status
             };
 
             for (int i = 0; i < 5; i++)
             {
                 _mutantsResultReporter.ReportMutantTestResult(mutantTestResult);
-                _mutantKilledLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
-            }
-        }
 
-        [Fact]
-        public void ReportMutantTestResult_ShouldLogEachTimeSurvivedMutantIsReported()
-        {
-            var mutantTestResult = new Mutant()
-            {
-                ResultStatus = MutantStatus.Survived
-            };
-
-            for (int i = 0; i < 5; i++)
-            {
-                _mutantsResultReporter.ReportMutantTestResult(mutantTestResult);
-                _mutantSurvivedLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
-            }
-        }
-
-        [Fact]
-        public void ReportMutantTestResult_ShouldLogEachTimeTimeoutMutantIsReported()
-        {
-            var mutantTestResult = new Mutant()
-            {
-                ResultStatus = MutantStatus.Timeout
-            };
-
-            for (int i = 0; i < 5; i++)
-            {
-                _mutantsResultReporter.ReportMutantTestResult(mutantTestResult);
-                _mutantTimeoutLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
-            }
-        }
-
-        [Fact]
-        public void ReportMutantTestResult_ShouldLogEachTimeRuntimeErrorMutantIsReported()
-        {
-            var mutantTestResult = new Mutant()
-            {
-                ResultStatus = MutantStatus.RuntimeError
-            };
-
-            for (int i = 0; i < 5; i++)
-            {
-                _mutantsResultReporter.ReportMutantTestResult(mutantTestResult);
-                _mutantRuntimeErrorLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
+                // Verify the right oneline logger is called for each status
+                switch(status)
+                {
+                    case MutantStatus.Killed:
+                        _mutantKilledLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
+                        break;
+                    case MutantStatus.Survived:
+                        _mutantSurvivedLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
+                        break;
+                    case MutantStatus.Timeout:
+                        _mutantTimeoutLogger.Verify(x => x.ReplaceLog(It.IsAny<string>(), It.Is<object[]>(y => y.Length == 1 && (int)y.First() == i + 1)));
+                        break;
+                }
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressReporterTests.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using Stryker.Core.Mutants;
 using Stryker.Core.Reporters.Progress;
+using System.Linq;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.Reporters.Progress
@@ -23,11 +24,11 @@ namespace Stryker.Core.UnitTest.Reporters.Progress
         [Fact]
         public void ProgressReporter_ShouldCallBothReporters_OnReportInitialState()
         {
-            var totalNumberOfTests = 10;
+            var mutants = new Mutant[3] { new Mutant(), new Mutant(), new Mutant() };
 
-            _progressReporter.ReportInitialState(totalNumberOfTests);
+            _progressReporter.OnStartMutantTestRun(mutants);
             _mutantsResultReporter.Verify(x => x.ReportInitialState(), Times.Once);
-            _progressBarReporter.Verify(x => x.ReportInitialState(totalNumberOfTests), Times.Once);
+            _progressBarReporter.Verify(x => x.ReportInitialState(mutants.Length), Times.Once);
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectComponents/ProjectComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectComponents/ProjectComponent.cs
@@ -12,8 +12,7 @@ namespace Stryker.Core.Initialisation.ProjectComponent
         public IEnumerable<IReadOnlyMutant> TotalMutants => ReadOnlyMutants.Where(m => m.ResultStatus != MutantStatus.BuildError);
         public IEnumerable<IReadOnlyMutant> DetectedMutants => ReadOnlyMutants.Where(m => 
         m.ResultStatus == MutantStatus.Killed ||
-        m.ResultStatus == MutantStatus.Timeout ||
-        m.ResultStatus == MutantStatus.RuntimeError);
+        m.ResultStatus == MutantStatus.Timeout);
 
         // These delegates will get invoked while walking the tree during Display();
         public Display DisplayFile { get; set; }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantStatus.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantStatus.cs
@@ -6,7 +6,6 @@
         Killed,
         Survived,
         Timeout,
-        RuntimeError,
         BuildError
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/ConsoleDotProgressReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ConsoleDotProgressReporter.cs
@@ -32,9 +32,6 @@ namespace Stryker.Core.Reporters
                 case MutantStatus.Survived:
                     _chalk.Red("S");
                     break;
-                case MutantStatus.RuntimeError:
-                    _chalk.Default("E");
-                    break;
                 case MutantStatus.Timeout:
                     _chalk.Default("T");
                     break;

--- a/src/Stryker.Core/Stryker.Core/Reporters/ConsoleReportReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ConsoleReportReporter.cs
@@ -59,8 +59,7 @@ namespace Stryker.Core.Reporters
                 foreach (var mutant in current.TotalMutants)
                 {
                     if (mutant.ResultStatus == MutantStatus.Killed ||
-                    mutant.ResultStatus == MutantStatus.Timeout ||
-                    mutant.ResultStatus == MutantStatus.RuntimeError) {
+                    mutant.ResultStatus == MutantStatus.Timeout) {
                         _chalk.Green($"[{mutant.ResultStatus}] ");
                     } else
                     {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ConsoleOneLineLoggerFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ConsoleOneLineLoggerFactory.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Core;
 using Stryker.Core.Logging;
 
 namespace Stryker.Core.Reporters.Progress
@@ -10,9 +12,19 @@ namespace Stryker.Core.Reporters.Progress
 
     public class ConsoleOneLineLoggerFactory : IConsoleOneLineLoggerFactory
     {
+        private LoggerFactory _factory { get; set; }
+
+        public ConsoleOneLineLoggerFactory()
+        {
+            _factory = new LoggerFactory();
+            _factory.AddSerilog(new LoggerConfiguration()
+                .WriteTo.Console(outputTemplate: "{Message:lj}{NewLine}")
+                .CreateLogger());
+        }
+
         public IConsoleOneLineLogger Create()
         {
-            return new ConsoleOneLineLogger(ApplicationLogging.LoggerFactory.CreateLogger<ConsoleOneLineLogger>());
+            return new ConsoleOneLineLogger(_factory.CreateLogger<ConsoleOneLineLogger>());
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/MutantsResultReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/MutantsResultReporter.cs
@@ -29,16 +29,13 @@ namespace Stryker.Core.Reporters.Progress
             _mutantKilledLogger = mutantKilledLogger;
             _mutantSurvivedLogger = mutantSurvivedLogger;
             _mutantTimeoutLogger = mutantTimeoutLogger;
-            _mutantRuntimeErrorLogger = mutantRuntimeErrorLogger;
         }
 
         public void ReportInitialState()
         {
             _mutantKilledLogger.StartLog("Killed : {0}", 0);
             _mutantSurvivedLogger.StartLog("Survived: {0}", 0);
-
-            _mutantTimeoutLogger.StartLog("Time out : {0}", 0);
-            _mutantRuntimeErrorLogger.StartLog("Runtime error : {0}", 0);
+            _mutantTimeoutLogger.StartLog("Timeout : {0}", 0);
         }
 
         public void ReportMutantTestResult(IReadOnlyMutant mutantTestResult)
@@ -53,13 +50,9 @@ namespace Stryker.Core.Reporters.Progress
                     _mutantsSurvivedCount++;
                     _mutantSurvivedLogger.ReplaceLog("Survived: {0}", _mutantsSurvivedCount);
                     break;
-                case MutantStatus.RuntimeError:
-                    _mutantsRuntimeErrorCount++;
-                    _mutantRuntimeErrorLogger.ReplaceLog("Runtime error : {0}", _mutantsRuntimeErrorCount);
-                    break;
                 case MutantStatus.Timeout:
                     _mutantsTimeoutCount++;
-                    _mutantTimeoutLogger.ReplaceLog("Time out : {0}", _mutantsTimeoutCount);
+                    _mutantTimeoutLogger.ReplaceLog("Timeout : {0}", _mutantsTimeoutCount);
                     break;
             };
         }

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressReporter.cs
@@ -15,12 +15,6 @@ namespace Stryker.Core.Reporters.Progress
             _progressBarReporter = progressBarReporter;
         }
 
-        public void ReportInitialState(int totalNumberOfTests)
-        {
-            _progressBarReporter.ReportInitialState(totalNumberOfTests);
-            _mutantsResultReporter.ReportInitialState();
-        }
-
         public void OnMutantsCreated(IReadOnlyInputComponent reportComponent)
         {
         }


### PR DESCRIPTION
Logging template without timestamp for oneline logger. Looks cleaner.
Tests cleanup.
I have removed MutantStatus.RuntimeError since it cannot be detected anyway. It always showed count 0.