### PR TITLE
Handle AppendTargetFrameworkToOutputPath csproj property

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectFileReaderTests.cs
@@ -306,5 +306,64 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             result.TargetFramework.ShouldBe(target.Split(';')[0]);
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProjectFileReader_ShouldParseWhenAppendTargetFrameworkToOutputPathAvailable(bool append)
+        {
+            var xDocument = XDocument.Parse($@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <AppendTargetFrameworkToOutputPath>{append}</AppendTargetFrameworkToOutputPath>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
+        <PackageReference Include=""xunit"" Version=""2.3.1"" />
+        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
+        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
+    </ItemGroup>
+
+</Project>");
+
+            var result = new ProjectFileReader().ReadProjectFile(xDocument, null);
+
+            result.AppendTargetFrameworkToOutputPath.ShouldBe(append);
+        }
+
+        [Fact]
+        public void ProjectFileReader_ShouldReturnTrueIfAppendTargetFrameworkToOutputPathNotAvailable()
+        {
+            var xDocument = XDocument.Parse($@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
+        <PackageReference Include=""xunit"" Version=""2.3.1"" />
+        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
+        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
+    </ItemGroup>
+
+</Project>");
+
+            var result = new ProjectFileReader().ReadProjectFile(xDocument, null);
+
+            result.AppendTargetFrameworkToOutputPath.ShouldBe(true);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -142,7 +142,8 @@ namespace Stryker.Core.UnitTest.MutationTest
                     },
                     ProjectUnderTestAssemblyName = "ExampleProject",
                     ProjectUnderTestPath = Path.Combine(_filesystemRoot, "ExampleProject"),
-                    TargetFramework = "netcoreapp2.0"
+                    TargetFramework = "netcoreapp2.0",
+                    AppendTargetFrameworkToOutputPath = true
                 },
                 AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
             };

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -70,6 +70,7 @@ namespace Stryker.Core.Initialisation
                 ProjectUnderTestPath = projectUnderTestPath,
                 ProjectUnderTestAssemblyName = projectUnderTestInfo ?? Path.GetFileNameWithoutExtension(projectReferencePath),
                 ProjectUnderTestProjectName = Path.GetFileNameWithoutExtension(projectReferencePath),
+                AppendTargetFrameworkToOutputPath = currentProjectInfo.AppendTargetFrameworkToOutputPath
             };
         }
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFile.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFile.cs
@@ -5,5 +5,6 @@
         public string ProjectReference { get; set; }
         public string TargetFramework { get; set; }
         public string AssemblyName { get; set; }
+        public bool AppendTargetFrameworkToOutputPath { get; set; }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -26,11 +26,13 @@ namespace Stryker.Core.Initialisation
             var reference = FindProjectReference(projectFileContents, projectUnderTestNameFilter);
             var targetFramework = FindTargetFrameworkReference(projectFileContents);
             var assemblyName = FindAssemblyName(projectFileContents);
+            var appendTargetFrameworkToOutputPath = FindAppendTargetFrameworkToOutputPath(projectFileContents);
 
             return new ProjectFile()
             {
                 ProjectReference = reference,
                 TargetFramework = targetFramework,
+                AppendTargetFrameworkToOutputPath = appendTargetFrameworkToOutputPath
             };
         }
 
@@ -111,6 +113,16 @@ namespace Stryker.Core.Initialisation
             {
                 return document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "TargetFramework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value;
             }
+        }
+
+        private bool FindAppendTargetFrameworkToOutputPath(XDocument document)
+        {
+            if (document.Elements().Descendants("AppendTargetFrameworkToOutputPath").Any())
+            {
+                return Convert.ToBoolean(document.Elements().Descendants().Where(x => string.Equals(x.Name.LocalName, "AppendTargetFrameworkToOutputPath", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Value);
+            }
+
+            return true;
         }
 
         public string FindAssemblyName(XDocument document)

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -33,5 +33,10 @@ namespace Stryker.Core.Initialisation
         /// The Folder/File structure found in the project under test.
         /// </summary>
         public FolderComposite ProjectContents { get; set; }
+
+        /// <summary>
+        /// Indicates if Target Framework is append to output path.
+        /// </summary>
+        public bool AppendTargetFrameworkToOutputPath { get; set; }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestInput.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestInput.cs
@@ -30,7 +30,11 @@ namespace Stryker.Core.MutationTest
 
         public string GetInjectionPath()
         {
-            return Path.Combine(ProjectInfo.TestProjectPath, "bin", "Debug", ProjectInfo.TargetFramework, ProjectInfo.ProjectUnderTestAssemblyName + ".dll");
+            if (ProjectInfo.AppendTargetFrameworkToOutputPath)
+            {
+                return Path.Combine(ProjectInfo.TestProjectPath, "bin", "Debug", ProjectInfo.TargetFramework, ProjectInfo.ProjectUnderTestAssemblyName + ".dll");
+            }
+            return Path.Combine(ProjectInfo.TestProjectPath, "bin", "Debug", ProjectInfo.ProjectUnderTestAssemblyName + ".dll");
         }
     }
 }


### PR DESCRIPTION
If present and true or absent, build generate files to bin/Mode/targetFramework (ex: /bin/Deug/netcoreapp2.0)
Is set to false, build generate file to bin/Mode (ex: bin/Debug)

this fix the issue when AppendTargetFrameworkToOutputPath is set to false resulting to an System.UnauthorizedAccessException

Fix #272