### PR TITLE
feat(unsafe blocks): recompile with unsafe=true

### DIFF
--- a/integrationtests/IntegrationTests/ExampleProject.XUnit/UnsafeCodeTest.cs
+++ b/integrationtests/IntegrationTests/ExampleProject.XUnit/UnsafeCodeTest.cs
@@ -1,0 +1,16 @@
+﻿using Xunit;
+
+namespace ExampleProject.XUnit
+{
+    public class UnsafeCodeTest
+    {
+        [Fact]
+        public void GetIndexOfArray()
+        {
+            int[] dummy = new int[] { 10, 20, 30 };
+            UnsafeCode unsafeCode = new UnsafeCode();
+            Assert.Equal(20, unsafeCode.GetElement(dummy, 1));
+            Assert.Equal(30, unsafeCode.GetElement(dummy, 2));
+        }
+    }
+}

--- a/integrationtests/IntegrationTests/ExampleProject/ExampleProject.csproj
+++ b/integrationtests/IntegrationTests/ExampleProject/ExampleProject.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/integrationtests/IntegrationTests/ExampleProject/UnsafeCode.cs
+++ b/integrationtests/IntegrationTests/ExampleProject/UnsafeCode.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ExampleProject
+{
+    public class UnsafeCode
+    {
+        public int GetElement(int[] arrayOfInt, int index)
+        {
+            unsafe
+            {
+                // Must pin object on heap so that it doesn't move while using interior pointers.
+                fixed (int* p = &arrayOfInt[0])
+                {
+                    return *(p + index);
+                }
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -51,7 +51,7 @@ namespace Stryker.Core.Compiling
         {
             var compiler = CSharpCompilation.Create(_input.ProjectInfo.ProjectUnderTestAssemblyName,
                 syntaxTrees: syntaxTrees,
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true),
                 references: _input.AssemblyReferences);
             RollbackProcessResult rollbackProcessResult = null;
 


### PR DESCRIPTION
To prevent errors during recompile, the option /allowUnsafe is set to true