### PR TITLE
fix(Missed compilation erros): Rollback two times instead of one

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
@@ -70,7 +70,7 @@ namespace ExampleProject
 }");
             var input = new MutationTestInput()
             {
-                ProjectInfo = new Core.Initialisation.ProjectInfo()
+                ProjectInfo = new ProjectInfo()
                 {
                     ProjectUnderTestAssemblyName = "The assembly name"
                 },
@@ -91,7 +91,8 @@ namespace ExampleProject
             {
                 Should.Throw<ApplicationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
             }
-            rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()), Times.Once);
+            rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()), 
+                Times.Exactly(2));
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -71,6 +71,19 @@ namespace Stryker.Core.Compiling
                 emitResult = rollbackProcessResult.Compilation.Emit(ms);
             }
 
+            if (!emitResult.Success)
+            {
+                LogEmitResult(emitResult);
+                // remove any left over broken mutations
+                rollbackProcessResult = _rollbackProcess.Start(rollbackProcessResult.Compilation, emitResult.Diagnostics, devMode);
+
+                // reset the memoryStream for the second compilation
+                ms.SetLength(0);
+
+                // third try compiling
+                emitResult = rollbackProcessResult.Compilation.Emit(ms);
+            }
+
             LogEmitResult(emitResult);
             if (!emitResult.Success)
             {

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -28,13 +28,12 @@ namespace Stryker.Core.Compiling
         public RollbackProcess()
         {
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<RollbackProcess>();
+            _rollbackedIds = new List<int>();
         }
 
         public RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics,
             bool devMode)
         {
-            _rollbackedIds = new List<int>();
-
             // match the diagnostics with their syntaxtrees
             var syntaxTreeMapping = new Dictionary<SyntaxTree, ICollection<Diagnostic>>();
             foreach (var syntaxTree in compiler.SyntaxTrees)
@@ -118,7 +117,6 @@ namespace Stryker.Core.Compiling
 
         private void ScanAllMutationsIfsAndIds(SyntaxNode node,  IDictionary<SyntaxNode, int> scan)
         {
-
             var id = ExtractMutationIfAndId(node);
             if (id != null)
             {


### PR DESCRIPTION
On large projects not all compilation errors are returned by the Roslyn compiler on the first compilation. The rollback process does not rollback all broken mutations on the rirst try. This PR adds a seconds rollback step to also catch all missed compilation errors.

closes #304 and possibly #18 