### PR TITLE
Fix(Local functions): Local functions are mutated correctly

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
@@ -8,32 +8,10 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     {
         void TestMethod()
         {
-            if (Stryker.ActiveMutationHelper.ActiveMutation==1)
+            string SomeLocalFunction()
             {
-                string SomeLocalFunction()
-                {
-                    var test3 = 2 + 5;
-                    return $"test{1 - test3}";
-                }
-            }
-            else
-            {
-                if (Stryker.ActiveMutationHelper.ActiveMutation==0)
-                {
-                    string SomeLocalFunction()
-                    {
-                        var test3 = 2 - 5;
-                        return $"test{1 + test3}";
-                    }
-                }
-                else
-                {
-                    string SomeLocalFunction()
-                    {
-                        var test3 = 2 + 5;
-                        return $"test{1 + test3}";
-                    }
-                }
+                var test3 = Stryker.ActiveMutationHelper.ActiveMutation==0 ?2-5:2 + 5;
+                return Stryker.ActiveMutationHelper.ActiveMutation==1?$"test{1 - test3}":$"test{1 + test3}";
             };
             Console.WriteLine(SomeLocalFunction());
         }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -89,6 +89,10 @@ namespace Stryker.Core.Mutants
             }
             else if (currentNode is StatementSyntax statement && currentNode.Kind() != SyntaxKind.Block)
             {
+                if (currentNode is LocalFunctionStatementSyntax localFunction)
+                {
+                    return localFunction.ReplaceNode(localFunction.Body, Mutate(localFunction.Body));
+                }
                 return MutateWithIfStatements(statement);
             }
             else


### PR DESCRIPTION
Local functions were mutated with if statements. Now only their body is mutated. This leaves their scope unchanged fixing a bug. 

closes #321 