### PR TITLE
fix(Lambda bug): Improved mutation algorithm

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_IN.cs
@@ -14,6 +14,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
             int b = a += 1 + 2;
             var (one, two) = (1 + 1, "");
             int Add(int x, int y) => x + y;
+            Action act = () => Console.WriteLine(1 + 1, 1 + 1);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
@@ -14,6 +14,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
             int b = Stryker.ActiveMutationHelper.ActiveMutation == 3 ? a += 1 - 2 : Stryker.ActiveMutationHelper.ActiveMutation == 2 ? a -= 1 + 2 : a += 1 + 2;
             var (one, two) = Stryker.ActiveMutationHelper.ActiveMutation == 4 ? (1 - 1, "") : (1 + 1, "");
             int Add(int x, int y) => Stryker.ActiveMutationHelper.ActiveMutation == 5 ? x - y : x + y;
+            Action act = () => Console.WriteLine(Stryker.ActiveMutationHelper.ActiveMutation == 6 ? 1 - 1 : 1 + 1, Stryker.ActiveMutationHelper.ActiveMutation == 7 ? 1 - 1 : 1 + 1);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -84,6 +84,10 @@ namespace Stryker.Core.Mutants
                         return MutateWithIfStatements(currentNode as ExpressionStatementSyntax);
                     }
                 }
+                if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
+                {
+                    return currentNode.ReplaceNode(lambda.Body, Mutate(lambda.Body));
+                }
                 // The mutations should be placed using a ConditionalExpression
                 return currentNode.ReplaceNode(expressionSyntax, MutateWithConditionalExpressions(expressionSyntax));
             }
@@ -207,6 +211,9 @@ namespace Stryker.Core.Mutants
                 case nameof(ExpressionStatementSyntax):
                     var expressionStatement = node as ExpressionStatementSyntax;
                     return expressionStatement.Expression;
+                case nameof(InvocationExpressionSyntax):
+                    var invocationExpression = node as InvocationExpressionSyntax;
+                    return invocationExpression.ArgumentList.Arguments.FirstOrDefault()?.Expression;
                 default:
                     return null;
             }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -69,30 +69,42 @@ namespace Stryker.Core.Mutants
         /// <returns>Mutated node</returns>
         public SyntaxNode Mutate(SyntaxNode currentNode)
         {
-            if (GetExpressionSyntax(currentNode) is var expressionSyntax && expressionSyntax != null)
+            var expressions = GetExpressionSyntax(currentNode).Where(x => x != null);
+            if (expressions.Any())
             {
-                if (currentNode is ExpressionStatementSyntax)
+                var currentNodeCopy = currentNode.TrackNodes(expressions);
+                foreach (var expressionSyntax in expressions)
                 {
-                    if (GetExpressionSyntax(expressionSyntax) is var subExpressionSyntax && subExpressionSyntax != null)
+                    var currentExpressionSyntax = currentNodeCopy.GetCurrentNode(expressionSyntax);
+                    if (currentNode is ExpressionStatementSyntax expressionStatement)
                     {
-                        // The expression of a ExpressionStatement cannot be mutated directly
-                        return currentNode.ReplaceNode(expressionSyntax, Mutate(expressionSyntax));
+                        if (GetExpressionSyntax(expressionStatement) is var subExpressionSyntax && subExpressionSyntax != null)
+                        {
+                            // The expression of a ExpressionStatement cannot be mutated directly
+                            return currentNodeCopy.ReplaceNode(currentExpressionSyntax, Mutate(currentExpressionSyntax));
+                        }
+                        else
+                        {
+                            // If the EpxressionStatement does not contain a expression that can be mutated with conditional expression...
+                            // it should be mutated with if statements
+                            return MutateWithIfStatements(currentNode as ExpressionStatementSyntax);
+                        }
+                    }
+                    else if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
+                    {
+                        return currentNode.ReplaceNode(lambda.Body, Mutate(lambda.Body));
                     } else
                     {
-                        // If the EpxressionStatement does not contain a expression that can be mutated with conditional expression...
-                        // it should be mutated with if statements
-                        return MutateWithIfStatements(currentNode as ExpressionStatementSyntax);
+                        // The mutations should be placed using a ConditionalExpression
+                        currentNodeCopy = currentNodeCopy.ReplaceNode(currentExpressionSyntax, MutateWithConditionalExpressions(currentExpressionSyntax));
                     }
                 }
-                if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
-                {
-                    return currentNode.ReplaceNode(lambda.Body, Mutate(lambda.Body));
-                }
-                // The mutations should be placed using a ConditionalExpression
-                return currentNode.ReplaceNode(expressionSyntax, MutateWithConditionalExpressions(expressionSyntax));
+                return currentNodeCopy;
             }
-            else if (currentNode is StatementSyntax statement && currentNode.Kind() != SyntaxKind.Block)
+
+            if (currentNode is StatementSyntax statement && currentNode.Kind() != SyntaxKind.Block)
             {
+                // Expression kinds that contain a body and can't have their scope changed should be mutated recursively
                 if (currentNode is LocalFunctionStatementSyntax localFunction)
                 {
                     return localFunction.ReplaceNode(localFunction.Body, Mutate(localFunction.Body));
@@ -192,30 +204,40 @@ namespace Stryker.Core.Mutants
             return mutatedNode;
         }
 
-        private ExpressionSyntax GetExpressionSyntax(SyntaxNode node)
+        private IEnumerable<ExpressionSyntax> GetExpressionSyntax(SyntaxNode node)
         {
             switch (node.GetType().Name)
             {
                 case nameof(LocalDeclarationStatementSyntax):
                     var localDeclarationStatement = node as LocalDeclarationStatementSyntax;
-                    return localDeclarationStatement.Declaration.Variables.First().Initializer?.Value;
+                    foreach(var expression in localDeclarationStatement.Declaration.Variables.Select(x => x.Initializer?.Value))
+                    {
+                        yield return expression;
+                    }
+                    yield break;
                 case nameof(AssignmentExpressionSyntax):
                     var assignmentExpression = node as AssignmentExpressionSyntax;
-                    return assignmentExpression.Right;
+                    yield return assignmentExpression.Right;
+                    yield break;
                 case nameof(ReturnStatementSyntax):
                     var returnStatement = node as ReturnStatementSyntax;
-                    return returnStatement.Expression;
+                    yield return returnStatement.Expression;
+                    yield break;
                 case nameof(LocalFunctionStatementSyntax):
                     var localFunction = node as LocalFunctionStatementSyntax;
-                    return localFunction.ExpressionBody?.Expression;
+                    yield return localFunction.ExpressionBody?.Expression;
+                    yield break;
                 case nameof(ExpressionStatementSyntax):
                     var expressionStatement = node as ExpressionStatementSyntax;
-                    return expressionStatement.Expression;
+                    yield return expressionStatement.Expression;
+                    yield break;
                 case nameof(InvocationExpressionSyntax):
                     var invocationExpression = node as InvocationExpressionSyntax;
-                    return invocationExpression.ArgumentList.Arguments.FirstOrDefault()?.Expression;
-                default:
-                    return null;
+                    foreach(var expression in invocationExpression.ArgumentList.Arguments.Select(x => x.Expression))
+                    {
+                        yield return expression;
+                    }
+                    yield break;
             }
         }
     }


### PR DESCRIPTION
closes #339 

Was not able to break up the `Mutate(SyntaxNode)` method since it has a high complexity in object references. We might need to look for a way to split this method.