### PR TITLE
fix(Missing mutations): Improve mutation algorithm to find more mutants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,5 +280,6 @@ StrykerLogs/
 #Visual studio code config
 .vscode/
 
-*.ncrunchsolution
+**/*.ncrunchsolution
+**/*.ncrunchproject
 *.orig

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/Stryker.Core/Stryker.Core.UnitTest/AssertExtensions.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/AssertExtensions.cs
@@ -27,6 +27,11 @@ namespace Stryker.Core.UnitTest
         /// <param name="expected">Expected code</param>
         public static void ShouldBeSemantically(this SyntaxNode actual, SyntaxNode expected)
         {
+            // for some reason, nodes can be different while being textually the same
+            if (actual.ToString() == expected.ToString())
+            {
+                return;
+            }
             SyntaxFactory.AreEquivalent(actual, expected)
                 .ShouldBeTrue($"AST's are not equivalent. Actual: {Environment.NewLine}{actual}, expected: {Environment.NewLine}{expected}");
         }
@@ -36,5 +41,6 @@ namespace Stryker.Core.UnitTest
             string replaced = expected.Replace("\r\n", Environment.NewLine, StringComparison.InvariantCultureIgnoreCase);
             actual.ShouldBe(replaced);
         }
+
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -42,9 +42,10 @@ namespace Stryker.Core.UnitTest.Mutants
         }
 
         [Theory]
-        [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs")]
-        [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs")]
-        public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile)
+        [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs", 24, 5, 14, 12, 30)]
+        [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs", 10, 2, 16, 6, 21)]
+        public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile, 
+            int nbMutants, int mutant1Id, int mutant1Location, int mutant2Id, int mutant2Location)
         {
             string source = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + inputFile);
             string expected = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + outputFile);
@@ -52,6 +53,11 @@ namespace Stryker.Core.UnitTest.Mutants
             var actualNode = target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
             var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
             actualNode.ShouldBeSemantically(expectedNode);
+
+            var mutants = target.GetLatestMutantBatch().ToList();
+            mutants.Count.ShouldBe(nbMutants);
+            mutants[mutant1Id].Mutation.OriginalNode.GetLocation().GetLineSpan().StartLinePosition.Line.ShouldBe(mutant1Location);
+            mutants[mutant2Id].Mutation.OriginalNode.GetLocation().GetLineSpan().StartLinePosition.Line.ShouldBe(mutant2Location);
         }
 
         [Theory]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -42,6 +42,18 @@ namespace Stryker.Core.UnitTest.Mutants
         }
 
         [Theory]
+        [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs")]
+        public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile)
+        {
+            string source = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + inputFile);
+            string expected = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + outputFile);
+            var target = new MutantOrchestrator();
+            var actualNode = target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
+            actualNode.ShouldBeSemantically(expectedNode);
+        }
+
+        [Theory]
         [InlineData("Mutator_TwoMutationsInOneStatmentShouldBeMade.cs", 2)]
         [InlineData("Mutator_NoMutationsShouldBeMade.cs", 0)]
         public void Mutator_NumberOfMutationsShouldBeCorrect(string inputFile, int numberOfMutations)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -43,6 +43,7 @@ namespace Stryker.Core.UnitTest.Mutants
 
         [Theory]
         [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs")]
+        [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs")]
         public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile)
         {
             string source = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + inputFile);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
@@ -4,6 +4,7 @@
     public static class CharCheckExtensions
     {
         
+        // Following code lines have been extracted from NFluent source code (www.n-fluent.net)
         private static void ImplementContains<T>(ICheckLogic<IEnumerable<T>> checker, IEnumerable<T> otherEnumerable)
         {
             IList<object> notFoundValues = null;
@@ -15,6 +16,7 @@
                 .OnNegate("The {0} contains all the given values whereas it must not.")
                 .EndCheck();
         }
+
         public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
             this ICodeCheck<T> check,
             double threshold,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
@@ -1,0 +1,26 @@
+﻿namespace Test 
+{
+    using System;
+    public static class CharCheckExtensions
+    {
+        [Obsolete("thismustnotbemutated")]
+        public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
+        {
+            var x=1;
+            x *=x+2;
+            return ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
+                OnNegate("The {0} is a letter whereas it must not.").
+                EndCheck();
+        }
+
+        public static string ChainCalls(string check)
+        {
+            return check.Replace("ab", "cd")
+                .Replace("12", "34")
+                .PadLeft(12)
+                .Replace("12", "34")
+                .Normalize();
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
@@ -3,6 +3,18 @@
     using System;
     public static class CharCheckExtensions
     {
+        
+        private static void ImplementContains<T>(ICheckLogic<IEnumerable<T>> checker, IEnumerable<T> otherEnumerable)
+        {
+            IList<object> notFoundValues = null;
+            checker
+                .FailWhen((sut) => sut == null && otherEnumerable != null, "The {0} is null and thus, does not contain the given expected value(s).")
+                .DefineExpectedValues(otherEnumerable, otherEnumerable.Count())
+                .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
+                .FailWhen((_) => notFoundValues.Any(), string.Format("The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .OnNegate("The {0} contains all the given values whereas it must not.")
+                .EndCheck();
+        }
         public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
             this ICodeCheck<T> check,
             double threshold,
@@ -30,6 +42,5 @@
                 OnNegate("The {0} is a letter whereas it must not.").
                 EndCheck();
         }
-
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
@@ -3,24 +3,33 @@
     using System;
     public static class CharCheckExtensions
     {
-        [Obsolete("thismustnotbemutated")]
+        public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
+            this ICodeCheck<T> check,
+            double threshold,
+            TimeUnit timeUnit)
+            where T : RunTrace
+        {
+            var durationThreshold = new Duration(threshold, timeUnit);
+
+            ExtensibilityHelper.BeginCheck(check).
+                SetSutName("code").
+                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), "execution time").
+                FailWhen((sut) => sut > durationThreshold, "The {checked} was too high.").
+                DefineExpectedValue(durationThreshold, "less than", "more than").
+                OnNegate("The {checked} was too low.").
+                EndCheck();
+
+            return ExtensibilityHelper.BuildCheckLink(check);
+        }
+
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
-            var x=1;
-            x *=x+2;
+
             return ExtensibilityHelper.BeginCheck(check).
                 FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
                 OnNegate("The {0} is a letter whereas it must not.").
                 EndCheck();
         }
 
-        public static string ChainCalls(string check)
-        {
-            return check.Replace("ab", "cd")
-                .Replace("12", "34")
-                .PadLeft(12)
-                .Replace("12", "34")
-                .Normalize();
-        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -9,9 +9,9 @@
             IList<object> notFoundValues = null;
             checker
                 .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null && otherEnumerable == null:Stryker.ActiveMutationHelper.ActiveMutation==1?sut != null && otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut == null || otherEnumerable != null:sut == null && otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
-                .DefineExpectedValues(otherEnumerable, Stryker.ActiveMutationHelper.ActiveMutation==4?otherEnumerable.Sum():otherEnumerable.Count())
+                .DefineExpectedValues(otherEnumerable, otherEnumerable.Count())
                 .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
-                .FailWhen((_) => notFoundValues.Any(), Stryker.ActiveMutationHelper.ActiveMutation==8?string.Format("The {{0}} does not contain the expected value(s):" + Environment.NewLine + "", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()):Stryker.ActiveMutationHelper.ActiveMutation==7?string.Format(""+ Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()):string.Format("The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==6?"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "":Stryker.ActiveMutationHelper.ActiveMutation==5?""+ Environment.NewLine + "\t{0}":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
                 .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} contains all the given values whereas it must not.")
                 .EndCheck();
         }
@@ -37,18 +37,9 @@
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
 
-            return Stryker.ActiveMutationHelper.ActiveMutation==23?ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
-                OnNegate("").
-                EndCheck():Stryker.ActiveMutationHelper.ActiveMutation==22?ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => !IsALetter(sut), "").
-                OnNegate("The {0} is a letter whereas it must not.").
-                EndCheck():Stryker.ActiveMutationHelper.ActiveMutation==21?ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => IsALetter(sut), "The {0} is not a letter.").
-                OnNegate("The {0} is a letter whereas it must not.").
-                EndCheck():ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
-                OnNegate("The {0} is a letter whereas it must not.").
+            return ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==18?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==19?"":"The {0} is not a letter.").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==20?"":"The {0} is a letter whereas it must not.").
                 EndCheck();
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -3,25 +3,33 @@
     using System;
     public static class CharCheckExtensions
     {
-        [Obsolete("thismustnotbemutated")]
+        public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
+            this ICodeCheck<T> check,
+            double threshold,
+            TimeUnit timeUnit)
+            where T : RunTrace
+        {
+            var durationThreshold = new Duration(threshold, timeUnit);
+
+            ExtensibilityHelper.BeginCheck(check).
+                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==0?"":"code").
+                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==1?"":"execution time").
+                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==3?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==2?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {checked} was too high.").
+                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==5?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==6?"":"more than").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"The {checked} was too low.").
+                EndCheck();
+
+            return ExtensibilityHelper.BuildCheckLink(check);
+        }
+
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
-            var x=1;
-if(Stryker.ActiveMutationHelper.ActiveMutation==0){            x /=x+2;
-}else{            x *=Stryker.ActiveMutationHelper.ActiveMutation==1?x-2:x+2;
-}            return ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==2?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is not a letter.").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {0} is a letter whereas it must not.").
+
+            return ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==8?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} is not a letter.").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==10?"":"The {0} is a letter whereas it must not.").
                 EndCheck();
         }
 
-        public static string ChainCalls(string check)
-        {
-            return check.Replace(Stryker.ActiveMutationHelper.ActiveMutation==5?"":"ab", Stryker.ActiveMutationHelper.ActiveMutation==6?"":"cd")
-                .Replace(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"12", Stryker.ActiveMutationHelper.ActiveMutation==8?"":"34")
-                .PadLeft(12)
-                .Replace(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"12", Stryker.ActiveMutationHelper.ActiveMutation==10?"":"34")
-                .Normalize();
-        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -1,0 +1,27 @@
+﻿namespace Test 
+{
+    using System;
+    public static class CharCheckExtensions
+    {
+        [Obsolete("thismustnotbemutated")]
+        public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
+        {
+            var x=1;
+if(Stryker.ActiveMutationHelper.ActiveMutation==0){            x /=x+2;
+}else{            x *=Stryker.ActiveMutationHelper.ActiveMutation==1?x-2:x+2;
+}            return ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==2?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is not a letter.").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {0} is a letter whereas it must not.").
+                EndCheck();
+        }
+
+        public static string ChainCalls(string check)
+        {
+            return check.Replace(Stryker.ActiveMutationHelper.ActiveMutation==5?"":"ab", Stryker.ActiveMutationHelper.ActiveMutation==6?"":"cd")
+                .Replace(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"12", Stryker.ActiveMutationHelper.ActiveMutation==8?"":"34")
+                .PadLeft(12)
+                .Replace(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"12", Stryker.ActiveMutationHelper.ActiveMutation==10?"":"34")
+                .Normalize();
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -4,6 +4,7 @@
     public static class CharCheckExtensions
     {
         
+        // Following code lines have been extracted from NFluent source code (www.n-fluent.net)
         private static void ImplementContains<T>(ICheckLogic<IEnumerable<T>> checker, IEnumerable<T> otherEnumerable)
         {
             IList<object> notFoundValues = null;
@@ -15,6 +16,7 @@
                 .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} contains all the given values whereas it must not.")
                 .EndCheck();
         }
+
         public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
             this ICodeCheck<T> check,
             double threshold,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -3,6 +3,18 @@
     using System;
     public static class CharCheckExtensions
     {
+        
+        private static void ImplementContains<T>(ICheckLogic<IEnumerable<T>> checker, IEnumerable<T> otherEnumerable)
+        {
+            IList<object> notFoundValues = null;
+            checker
+                .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null && otherEnumerable == null:Stryker.ActiveMutationHelper.ActiveMutation==1?sut != null && otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut == null || otherEnumerable != null:sut == null && otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
+                .DefineExpectedValues(otherEnumerable, Stryker.ActiveMutationHelper.ActiveMutation==4?otherEnumerable.Sum():otherEnumerable.Count())
+                .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
+                .FailWhen((_) => notFoundValues.Any(), Stryker.ActiveMutationHelper.ActiveMutation==8?string.Format("The {{0}} does not contain the expected value(s):" + Environment.NewLine + "", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()):Stryker.ActiveMutationHelper.ActiveMutation==7?string.Format(""+ Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()):string.Format("The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} contains all the given values whereas it must not.")
+                .EndCheck();
+        }
         public static ICheckLink<ICodeCheck<T>> LastsLessThan<T>(
             this ICodeCheck<T> check,
             double threshold,
@@ -12,11 +24,11 @@
             var durationThreshold = new Duration(threshold, timeUnit);
 
             ExtensibilityHelper.BeginCheck(check).
-                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==0?"":"code").
-                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==1?"":"execution time").
-                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==3?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==2?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {checked} was too high.").
-                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==5?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==6?"":"more than").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"The {checked} was too low.").
+                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==10?"":"code").
+                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==11?"":"execution time").
+                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==13?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==12?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==14?"":"The {checked} was too high.").
+                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==15?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==16?"":"more than").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==17?"":"The {checked} was too low.").
                 EndCheck();
 
             return ExtensibilityHelper.BuildCheckLink(check);
@@ -25,11 +37,19 @@
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
 
-            return ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==8?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} is not a letter.").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==10?"":"The {0} is a letter whereas it must not.").
+            return Stryker.ActiveMutationHelper.ActiveMutation==23?ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
+                OnNegate("").
+                EndCheck():Stryker.ActiveMutationHelper.ActiveMutation==22?ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => !IsALetter(sut), "").
+                OnNegate("The {0} is a letter whereas it must not.").
+                EndCheck():Stryker.ActiveMutationHelper.ActiveMutation==21?ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => IsALetter(sut), "The {0} is not a letter.").
+                OnNegate("The {0} is a letter whereas it must not.").
+                EndCheck():ExtensibilityHelper.BeginCheck(check).
+                FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
+                OnNegate("The {0} is a letter whereas it must not.").
                 EndCheck();
         }
-
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
@@ -6,7 +6,8 @@ namespace TestCases
     {
         
         private string text = "Some" + "Text";
-
+        // const can't me mutated (need to be const at build time)
+        private const int x = 1 + 2;
         // attributes must be constant at build time => no possible mutation
         [Obsolete("thismustnotbemutated")]
         // default parameter must be constant at build time => no posible mutation

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
@@ -1,0 +1,27 @@
+﻿
+namespace TestCases
+{
+    // list syntax construction that are difficult to mutate
+    class ComplexCases
+    {
+        
+        private string text = "Some" + "Text";
+
+        // attributes must be constant at build time => no possible mutation
+        [Obsolete("thismustnotbemutated")]
+        // default parameter must be constant at build time => no posible mutation
+        private void SomeMthod(bool option = true)
+        {
+            // for statement can only me mutated through if(s)
+            for (var i = 0; i < 10; i++)
+            {
+                var x=1;
+                x++;
+                // should not be mutated (string concatenation)
+                var test = "first" + "second";
+                // complex mutation pattern
+                x *=x+2;
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
@@ -5,7 +5,8 @@
     {
         
         private string text = Stryker.ActiveMutationHelper.ActiveMutation==1?"Some" + "":Stryker.ActiveMutationHelper.ActiveMutation==0?""+ "Text":"Some" + "Text";
-
+        // const can't me mutated (need to be const at build time)
+        private const int x = 1 + 2;
         // attributes must be constant at build time => no possible mutation
         [Obsolete("thismustnotbemutated")]
         // default parameter must be constant at build time => no posible mutation

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
@@ -1,0 +1,39 @@
+﻿namespace TestCases
+{
+    // list syntax construction that are difficult to mutate
+    class ComplexCases
+    {
+        
+        private string text = Stryker.ActiveMutationHelper.ActiveMutation==1?"Some" + "":Stryker.ActiveMutationHelper.ActiveMutation==0?""+ "Text":"Some" + "Text";
+
+        // attributes must be constant at build time => no possible mutation
+        [Obsolete("thismustnotbemutated")]
+        // default parameter must be constant at build time => no posible mutation
+        private void SomeMthod(bool option = Stryker.ActiveMutationHelper.ActiveMutation==2?false:true)
+        {
+if(Stryker.ActiveMutationHelper.ActiveMutation==3){            // for statement can only me mutated through if(s)
+            for (var i = 0; i < 10; i--)
+            {
+                var x=1;
+                x++;
+                // should not be mutated (string concatenation)
+                var test = "first" + "second";
+                // complex mutation pattern
+                x *=x+2;
+            }
+}else{            // for statement can only me mutated through if(s)
+            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==5?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==4?i > 10:i < 10; i++)
+            {
+                var x=1;
+if(Stryker.ActiveMutationHelper.ActiveMutation==6){                x--;
+}else{                x++;
+}                // should not be mutated (string concatenation)
+                var test = Stryker.ActiveMutationHelper.ActiveMutation==8?"first" + "":Stryker.ActiveMutationHelper.ActiveMutation==7?""+ "second":"first" + "second";
+if(Stryker.ActiveMutationHelper.ActiveMutation==9){                // complex mutation pattern
+                x /=x+2;
+}else{                // complex mutation pattern
+                x *=Stryker.ActiveMutationHelper.ActiveMutation==10?x-2:x+2;
+}            }
+}        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
@@ -9,9 +9,9 @@
         // attributes must be constant at build time => no possible mutation
         [Obsolete("thismustnotbemutated")]
         // default parameter must be constant at build time => no posible mutation
-        private void SomeMthod(bool option = Stryker.ActiveMutationHelper.ActiveMutation==2?false:true)
+        private void SomeMthod(bool option = true)
         {
-if(Stryker.ActiveMutationHelper.ActiveMutation==3){            // for statement can only me mutated through if(s)
+if(Stryker.ActiveMutationHelper.ActiveMutation==2){            // for statement can only me mutated through if(s)
             for (var i = 0; i < 10; i--)
             {
                 var x=1;
@@ -22,17 +22,17 @@ if(Stryker.ActiveMutationHelper.ActiveMutation==3){            // for statement 
                 x *=x+2;
             }
 }else{            // for statement can only me mutated through if(s)
-            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==5?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==4?i > 10:i < 10; i++)
+            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==4?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==3?i > 10:i < 10; i++)
             {
                 var x=1;
-if(Stryker.ActiveMutationHelper.ActiveMutation==6){                x--;
+if(Stryker.ActiveMutationHelper.ActiveMutation==5){                x--;
 }else{                x++;
 }                // should not be mutated (string concatenation)
-                var test = Stryker.ActiveMutationHelper.ActiveMutation==8?"first" + "":Stryker.ActiveMutationHelper.ActiveMutation==7?""+ "second":"first" + "second";
-if(Stryker.ActiveMutationHelper.ActiveMutation==9){                // complex mutation pattern
+                var test = Stryker.ActiveMutationHelper.ActiveMutation==7?"first" + "":Stryker.ActiveMutationHelper.ActiveMutation==6?""+ "second":"first" + "second";
+if(Stryker.ActiveMutationHelper.ActiveMutation==8){                // complex mutation pattern
                 x /=x+2;
 }else{                // complex mutation pattern
-                x *=Stryker.ActiveMutationHelper.ActiveMutation==10?x-2:x+2;
+                x *=Stryker.ActiveMutationHelper.ActiveMutation==9?x-2:x+2;
 }            }
 }        }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -21,9 +21,6 @@
     <Compile Remove="Mutants\TestResources\Mutator_TwoMutationsInOneStatmentShouldBeMade.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Stryker.Core.UnitTest.v3.ncrunchproject" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Mutants\TestResources\Mutator_FromActualProject_IN.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_OUT.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_KnownComplexCases_IN.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_KnownComplexCases_OUT.cs" />
     <Compile Remove="TestResources\ExampleSourceFile.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_OUT.cs" />
@@ -26,6 +28,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Mutants\TestResources\Mutator_FromActualProject_OUT.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_KnownComplexCases_IN.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_KnownComplexCases_OUT.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestResources\ExampleSourceFile.cs">

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -4,6 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_IN.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_OUT.cs" />
     <Compile Remove="TestResources\ExampleSourceFile.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_OUT.cs" />
@@ -17,6 +19,15 @@
     <Compile Remove="Mutants\TestResources\Mutator_TwoMutationsInOneStatmentShouldBeMade.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="Stryker.Core.UnitTest.v3.ncrunchproject" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Mutants\TestResources\Mutator_FromActualProject_IN.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_FromActualProject_OUT.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestResources\ExampleSourceFile.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -75,6 +75,10 @@ namespace Stryker.Core.Compiling
             {
                 // compiling failed
                 _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
+                foreach (var emitResultDiagnostic in emitResult.Diagnostics)
+                {
+                    _logger.LogWarning($"{emitResultDiagnostic}");
+                }
                 throw new ApplicationException("Failed to restore build able state.");
             }
             return new CompilingProcessResult()

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -50,21 +50,7 @@ namespace Stryker.Core.Compiling
             {
                 if (devMode)
                 {
-                    _logger.LogInformation($"Roll backing mutations from {syntaxTreeMap.Key.FilePath}.");
-                    var sourceLines = syntaxTreeMap.Key.ToString().Split("\n");
-                    foreach (var diagnostic in syntaxTreeMap.Value)
-                    {
-                        var fileLinePositionSpan = diagnostic.Location.GetMappedLineSpan();
-                        _logger.LogInformation($"Error :{ diagnostic.GetMessage()}, {fileLinePositionSpan.ToString()}");
-                        for (var i = Math.Max(0, fileLinePositionSpan.StartLinePosition.Line - 1);
-                            i <= Math.Min(fileLinePositionSpan.EndLinePosition.Line+1, sourceLines.Length - 1);
-                            i++)
-                        {
-                            _logger.LogInformation($"{i+1}: {sourceLines[i]}");
-                        }
-                    }
-
-                    _logger.LogInformation(Environment.NewLine);
+                    DumpBuildErrors(syntaxTreeMap);
                 }
                 else
                 {
@@ -149,6 +135,25 @@ namespace Stryker.Core.Compiling
             {
                 ScanAllMutationsIfsAndIds(childNode, scan);
             }
+        }
+
+        private void DumpBuildErrors(KeyValuePair<SyntaxTree, ICollection<Diagnostic>> syntaxTreeMap)
+        {
+            _logger.LogInformation($"Roll backing mutations from {syntaxTreeMap.Key.FilePath}.");
+            var sourceLines = syntaxTreeMap.Key.ToString().Split("\n");
+            foreach (var diagnostic in syntaxTreeMap.Value)
+            {
+                var fileLinePositionSpan = diagnostic.Location.GetMappedLineSpan();
+                _logger.LogInformation($"Error :{diagnostic.GetMessage()}, {fileLinePositionSpan.ToString()}");
+                for (var i = Math.Max(0, fileLinePositionSpan.StartLinePosition.Line - 1);
+                    i <= Math.Min(fileLinePositionSpan.EndLinePosition.Line + 1, sourceLines.Length - 1);
+                    i++)
+                {
+                    _logger.LogInformation($"{i + 1}: {sourceLines[i]}");
+                }
+            }
+
+            _logger.LogInformation(Environment.NewLine);
         }
 
         private SyntaxTree RemoveMutantIfStatements(SyntaxTree originalTree, ICollection<Diagnostic> diagnosticInfo, bool devMode)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -114,15 +114,19 @@ namespace Stryker.Core.Mutants
                 }
                 else if (currentNode is IfStatementSyntax ifStatement)
                 {
-                    if (!ifStatement.Condition.DescendantNodes().Any(x => x.IsKind(SyntaxKind.DeclarationExpression) || x.IsKind(SyntaxKind.DeclarationPattern)))
+                    IfStatementSyntax mutatedIf;
+                    mutatedIf = ifStatement.Else != null ? ifStatement.TrackNodes(ifStatement.Condition, ifStatement.Statement, ifStatement.Else) : ifStatement.TrackNodes(ifStatement.Condition, ifStatement.Statement);
+
+                    if (!ifStatement.
+                        Condition.DescendantNodes().Any(x => x.IsKind(SyntaxKind.DeclarationExpression) || x.IsKind(SyntaxKind.DeclarationPattern)))
                     {
-                        ifStatement = ifStatement.ReplaceNode(ifStatement.Condition, MutateWithConditionalExpressions(ifStatement.Condition));
+                        mutatedIf = mutatedIf.ReplaceNode(mutatedIf.GetCurrentNode(ifStatement.Condition), MutateWithConditionalExpressions(ifStatement.Condition));
                     }
                     if (ifStatement.Else != null)
                     {
-                        ifStatement = ifStatement.ReplaceNode(ifStatement.Else, Mutate(ifStatement.Else));
+                        mutatedIf = mutatedIf.ReplaceNode(mutatedIf.GetCurrentNode(ifStatement.Else), Mutate(ifStatement.Else));
                     }
-                    return ifStatement.ReplaceNode(ifStatement.Statement, Mutate(ifStatement.Statement));
+                    return mutatedIf.ReplaceNode(mutatedIf.GetCurrentNode(ifStatement.Statement), Mutate(ifStatement.Statement));
                 }
                 else if (currentNode is ForStatementSyntax forStatement)
                 {

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -176,26 +176,14 @@ namespace Stryker.Core.Mutants
         private SyntaxNode MutateForStatement(ForStatementSyntax forStatement)
         {
             // for needs special treatments for its incrementors
-            StatementSyntax forWithMutantIncrementors = forStatement;
+            StatementSyntax forWithMutantIncrementors = forStatement.TrackNodes(forStatement);
 
             foreach (var incrementor in forStatement.Incrementors)
             {
                 forWithMutantIncrementors = MutateSubExpressionWithIfStatements(forStatement, forWithMutantIncrementors, incrementor);
             }
 
-            var originalFor = forWithMutantIncrementors;
-            if (forWithMutantIncrementors != forStatement)
-            {
-                var scan = forWithMutantIncrementors;
-                // traverse ifs to locate the 'for' that we have to mutate further
-                while (scan is IfStatementSyntax mutantIf)
-                {
-                    scan = ((BlockSyntax) mutantIf.Else.Statement).Statements[0];
-                }
-
-                originalFor = (ForStatementSyntax) scan;
-            }
-
+            var originalFor = forWithMutantIncrementors.GetCurrentNode(forStatement);
             // now we generate a mutant for the remainder of the for statement
             var mutatedFor = forStatement.TrackNodes(forStatement.Condition, forStatement.Statement);
             mutatedFor = mutatedFor.ReplaceNode(mutatedFor.GetCurrentNode(forStatement.Condition),

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -179,16 +179,18 @@ namespace Stryker.Core.Mutants
                     else if (currentNode is ExpressionStatementSyntax)
                     {
                         // The expression of a ExpressionStatement cannot be mutated directly
-                        return MutateInPlace(currentNodeCopy, currentExpressionSyntax);
+                        return MutateInPlace(currentNode, expressionSyntax);
                     }
                     else if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
                     {
                         actualMutationNode = lambda.Body;
                     }
-                    else if (expressionSyntax is InvocationExpressionSyntax invocation)
+                    else if (expressionSyntax is InvocationExpressionSyntax )
                     {
-                        currentNodeCopy = MutateInPlace(currentNodeCopy, expressionSyntax);
-                        //actualMutationNode = invocation.Expression;
+                        var mutant = Mutate(expressionSyntax);
+                        currentNodeCopy = currentNodeCopy.ReplaceNode(currentExpressionSyntax, mutant);
+ //                       currentNodeCopy = MutateInPlace(currentNodeCopy, expressionSyntax);
+                        //actualMutationNode = expressionSyntax;
                     }
                     else if (expressionSyntax is MemberAccessExpressionSyntax memberAccess)
                     {
@@ -289,7 +291,6 @@ namespace Stryker.Core.Mutants
             return expressionAst;
         }
 
-
         /// <summary>
         /// Mutates one single SyntaxNode using a mutator
         /// </summary>
@@ -308,10 +309,9 @@ namespace Stryker.Core.Mutants
             }
         }
 
-        private T ApplyMutant<T>(T node, Mutant mutant) where T: SyntaxNode
+        private static T ApplyMutant<T>(T node, IReadOnlyMutant mutant) where T: SyntaxNode
         {
-            var mutatedNode = node.ReplaceNode(mutant.Mutation.OriginalNode, mutant.Mutation.ReplacementNode);
-            return mutatedNode;
+            return node.ReplaceNode(mutant.Mutation.OriginalNode, mutant.Mutation.ReplacementNode);
         }
 
         private IEnumerable<ExpressionSyntax> GetExpressionSyntax(SyntaxNode node)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -64,6 +64,31 @@ namespace Stryker.Core.Mutants
             return tempMutants;
         }
 
+
+        private bool CanBeMutated(SyntaxNode node)
+        {
+            // don't mutate attributes or their arguments
+            if (node is AttributeListSyntax)
+            {
+                return false;
+            }
+            // don't mutate parameters
+            if (node is ParameterSyntax)
+            {
+                return false;
+            }
+            // don't mutate constant fields
+            if (node is FieldDeclarationSyntax field)
+            {
+                if (field.Modifiers.Any(x => x.Kind() == SyntaxKind.ConstKeyword))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Recursively mutates a single SyntaxNode
         /// </summary>
@@ -71,13 +96,7 @@ namespace Stryker.Core.Mutants
         /// <returns>Mutated node</returns>
         public SyntaxNode Mutate(SyntaxNode currentNode)
         {
-            // don't mutate attributes or their arguments
-            if (currentNode is AttributeListSyntax)
-            {
-                return currentNode;
-            }
-            // don't mutate parameters
-            if (currentNode is ParameterSyntax)
+            if (!CanBeMutated(currentNode))
             {
                 return currentNode;
             }
@@ -211,7 +230,7 @@ namespace Stryker.Core.Mutants
                     else
                         // The mutations should be placed using a ConditionalExpression
                         currentNodeCopy = currentNodeCopy.ReplaceNode(currentExpressionSyntax,
-                            MutateWithConditionalExpressions(currentExpressionSyntax));
+                            MutateWithConditionalExpressions(expressionSyntax));
                 }
 
                 return currentNodeCopy;

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -87,15 +87,7 @@ namespace Stryker.Core.Mutants
  
                 if (currentNode is ExpressionStatementSyntax tentativeAssignment && expressionStatementNeedingIf.Contains(tentativeAssignment.Expression.GetType()))
                 {
-                    var mutants = FlatMutate(tentativeAssignment.Expression);
-                    var ast = statement;
-                    foreach (var mutant in mutants)
-                    {
-                        var mutatedNode = ApplyMutant(statement, mutant);
-                        ast = MutantPlacer.PlaceWithIfStatement(ast, mutatedNode, mutant.Id);
-                    }
-
-                    result = ast;
+                    result = MutateSubExpressionWithIfStatements(statement, tentativeAssignment.Expression);
                     if (!(tentativeAssignment.Expression is AssignmentExpressionSyntax))
                     {
                         return result;
@@ -119,13 +111,7 @@ namespace Stryker.Core.Mutants
                     StatementSyntax newNode = forStatement;
                     foreach (var incrementor in forStatement.Incrementors)
                     {
-                        var mutants = FlatMutate(incrementor);
-                        foreach (var mutant in mutants)
-                        {
-                            var newFor = ApplyMutant(forStatement, mutant);
-
-                            newNode = MutantPlacer.PlaceWithIfStatement(statement, newFor, mutant.Id);
-                        }
+                        newNode = MutateSubExpressionWithIfStatements(newNode, incrementor);
                     }
 
                     var originalFort = forStatement;
@@ -267,6 +253,20 @@ namespace Stryker.Core.Mutants
                 _mutants.Add(mutant);
                 var mutatedNode = ApplyMutant(statement, mutant);
                 ast = MutantPlacer.PlaceWithIfStatement(ast, mutatedNode, mutant.Id);
+            }
+            return ast;
+        }
+
+        private StatementSyntax MutateSubExpressionWithIfStatements(StatementSyntax currentNode, SyntaxNode expression)
+        {
+            var ast = currentNode;
+            StatementSyntax statement = currentNode;
+            // The mutations should be placed using an IfStatement
+            foreach (var mutant in FlatMutate(expression))
+            {
+                _mutants.Add(mutant);
+                var mutatedNode = ApplyMutant(statement, mutant);
+                ast = MutantPlacer.PlaceWithIfStatement(currentNode, mutatedNode, mutant.Id);
             }
             return ast;
         }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -179,7 +179,8 @@ namespace Stryker.Core.Mutants
                     else if (currentNode is ExpressionStatementSyntax)
                     {
                         // The expression of a ExpressionStatement cannot be mutated directly
-                        return MutateInPlace(currentNode, expressionSyntax);
+                        var mutant = Mutate(expressionSyntax);
+                        return currentNodeCopy.ReplaceNode(currentExpressionSyntax, mutant);
                     }
                     else if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
                     {
@@ -189,8 +190,6 @@ namespace Stryker.Core.Mutants
                     {
                         var mutant = Mutate(expressionSyntax);
                         currentNodeCopy = currentNodeCopy.ReplaceNode(currentExpressionSyntax, mutant);
- //                       currentNodeCopy = MutateInPlace(currentNodeCopy, expressionSyntax);
-                        //actualMutationNode = expressionSyntax;
                     }
                     else if (expressionSyntax is MemberAccessExpressionSyntax memberAccess)
                     {

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -65,30 +65,6 @@ namespace Stryker.Core.Mutants
             return tempMutants;
         }
 
-        private bool CanBeMutated(SyntaxNode node)
-        {
-            // don't mutate attributes or their arguments
-            if (node is AttributeListSyntax)
-            {
-                return false;
-            }
-            // don't mutate parameters
-            if (node is ParameterSyntax)
-            {
-                return false;
-            }
-            // don't mutate constant fields
-            if (node is FieldDeclarationSyntax field)
-            {
-                if (field.Modifiers.Any(x => x.Kind() == SyntaxKind.ConstKeyword))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         /// <summary>
         /// Recursively mutates a single SyntaxNode
         /// </summary>
@@ -134,6 +110,30 @@ namespace Stryker.Core.Mutants
                 }
             }
             return childCopy;
+        }
+
+        private bool CanBeMutated(SyntaxNode node)
+        {
+            // don't mutate attributes or their arguments
+            if (node is AttributeListSyntax)
+            {
+                return false;
+            }
+            // don't mutate parameters
+            if (node is ParameterSyntax)
+            {
+                return false;
+            }
+            // don't mutate constant fields
+            if (node is FieldDeclarationSyntax field)
+            {
+                if (field.Modifiers.Any(x => x.Kind() == SyntaxKind.ConstKeyword))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private SyntaxNode MutateExpressionStatement(ExpressionStatementSyntax expressionStatement)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -114,14 +114,20 @@ namespace Stryker.Core.Mutants
                         newNode = MutateSubExpressionWithIfStatements(newNode, incrementor);
                     }
 
-                    var originalFort = forStatement;
-                    if (newNode != originalFort)
+                    var originalFor = forStatement;
+                    if (newNode != originalFor)
                     {
-                        originalFort = (ForStatementSyntax) ((BlockSyntax)((IfStatementSyntax) newNode).Else.Statement).Statements[0];
+                        var scan = newNode;
+                        while (scan is IfStatementSyntax mutantIf)
+                        {
+                            scan = ((BlockSyntax)mutantIf.Else.Statement).Statements[0];
+                        }
+
+                        originalFor = (ForStatementSyntax) scan;
                     }
-                    forStatement = MutateInPlace(originalFort, originalFort.Condition);
+                    forStatement = MutateInPlace(originalFor, originalFor.Condition);
                     forStatement = MutateInPlace(forStatement, forStatement.Statement);
-                    return newNode.ReplaceNode(originalFort, forStatement);
+                    return newNode.ReplaceNode(originalFor, forStatement);
                 }
                 else
                 {

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -76,6 +76,11 @@ namespace Stryker.Core.Mutants
             {
                 return currentNode;
             }
+            // don't mutate parameters
+            if (currentNode is ParameterSyntax)
+            {
+                return currentNode;
+            }
             if (currentNode is StatementSyntax statement && currentNode.Kind() != SyntaxKind.Block)
             {
                 SyntaxNode result;
@@ -187,11 +192,11 @@ namespace Stryker.Core.Mutants
                     else if (expressionSyntax is ParenthesizedLambdaExpressionSyntax lambda)
                     {
                         actualMutationNode = lambda.Body;
-                        //return MutateInPlace(currentNodeCopy, lambda.Body);
                     }
                     else if (expressionSyntax is InvocationExpressionSyntax invocation)
                     {
-                        actualMutationNode = invocation.Expression;
+                        currentNodeCopy = MutateInPlace(currentNodeCopy, expressionSyntax);
+                        //actualMutationNode = invocation.Expression;
                     }
                     else if (expressionSyntax is MemberAccessExpressionSyntax memberAccess)
                     {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -143,7 +143,7 @@ namespace Stryker.Core.MutationTest
                 new ParallelOptions { MaxDegreeOfParallelism = options.ConcurrentTestrunners },
                 mutant =>
                 {
- //                   _mutationTestExecutor.Test(mutant);
+                    _mutationTestExecutor.Test(mutant);
 
                     _reporter.OnMutantTested(mutant);
                 });

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -143,7 +143,7 @@ namespace Stryker.Core.MutationTest
                 new ParallelOptions { MaxDegreeOfParallelism = options.ConcurrentTestrunners },
                 mutant =>
                 {
-                    _mutationTestExecutor.Test(mutant);
+ //                   _mutationTestExecutor.Test(mutant);
 
                     _reporter.OnMutantTested(mutant);
                 });

--- a/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
@@ -25,7 +25,8 @@ namespace Stryker.Core.Mutators
             var assignmentKind = node.Kind();
             if (KindsToMutate.TryGetValue(assignmentKind, out var targetAssignmentKind))
             {
-                if (node.Kind() == SyntaxKind.AddAssignmentExpression &&(node.Left.IsAStringExpression() || node.Right.IsAStringExpression()))
+                if (node.Kind() == SyntaxKind.AddAssignmentExpression 
+                    && (node.Left.IsAStringExpression() || node.Right.IsAStringExpression()))
                 {
                     yield break;
                 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
@@ -23,13 +23,18 @@ namespace Stryker.Core.Mutators
         public override IEnumerable<Mutation> ApplyMutations(AssignmentExpressionSyntax node)
         {
             var assignmentKind = node.Kind();
-            if (KindsToMutate.TryGetValue(assignmentKind, out var targetAssignementKind))
+            if (KindsToMutate.TryGetValue(assignmentKind, out var targetAssignmentKind))
             {
+                if (node.Kind() == SyntaxKind.AddAssignmentExpression &&(node.Left.IsString() || node.Right.IsString()))
+                {
+                    yield break;
+                }
+                
                 yield return new Mutation
                 {
                     OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.AssignmentExpression(targetAssignementKind, node.Left, node.Right),
-                    DisplayName = $"{assignmentKind} to {targetAssignementKind} mutation",
+                    ReplacementNode = SyntaxFactory.AssignmentExpression(targetAssignmentKind, node.Left, node.Right),
+                    DisplayName = $"{assignmentKind} to {targetAssignmentKind} mutation",
                     Type = Mutator.Assignment
                 };
             }

--- a/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
@@ -25,7 +25,7 @@ namespace Stryker.Core.Mutators
             var assignmentKind = node.Kind();
             if (KindsToMutate.TryGetValue(assignmentKind, out var targetAssignmentKind))
             {
-                if (node.Kind() == SyntaxKind.AddAssignmentExpression &&(node.Left.IsString() || node.Right.IsString()))
+                if (node.Kind() == SyntaxKind.AddAssignmentExpression &&(node.Left.IsAStringExpression() || node.Right.IsAStringExpression()))
                 {
                     yield break;
                 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
@@ -33,6 +33,13 @@ namespace Stryker.Core.Mutators
         {
             if(_kindsToMutate.ContainsKey(node.Kind()))
             {
+                // skip string additions
+                
+                if (node.Kind() == SyntaxKind.AddExpression &&(node.Left.IsString()||node.Right.IsString()))
+                {
+                    yield break;
+                }
+                
                 foreach(var mutationKind in _kindsToMutate[node.Kind()])
                 {
                     var replacementNode = SyntaxFactory.BinaryExpression(mutationKind, node.Left, node.Right);

--- a/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
@@ -35,7 +35,7 @@ namespace Stryker.Core.Mutators
             {
                 // skip string additions
                 
-                if (node.Kind() == SyntaxKind.AddExpression &&(node.Left.IsString()||node.Right.IsString()))
+                if (node.Kind() == SyntaxKind.AddExpression &&(node.Left.IsAStringExpression()||node.Right.IsAStringExpression()))
                 {
                     yield break;
                 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
@@ -34,7 +34,6 @@ namespace Stryker.Core.Mutators
             if(_kindsToMutate.ContainsKey(node.Kind()))
             {
                 // skip string additions
-                
                 if (node.Kind() == SyntaxKind.AddExpression &&(node.Left.IsAStringExpression()||node.Right.IsAStringExpression()))
                 {
                     yield break;
@@ -45,7 +44,6 @@ namespace Stryker.Core.Mutators
                     var replacementNode = SyntaxFactory.BinaryExpression(mutationKind, node.Left, node.Right);
                     // make sure the trivia stays in place for displaying
                     replacementNode = replacementNode.WithOperatorToken(replacementNode.OperatorToken.WithTriviaFrom(node.OperatorToken));
-                    
 
                     yield return new Mutation()
                     {

--- a/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
@@ -45,6 +45,7 @@ namespace Stryker.Core.Mutators
                     var replacementNode = SyntaxFactory.BinaryExpression(mutationKind, node.Left, node.Right);
                     // make sure the trivia stays in place for displaying
                     replacementNode = replacementNode.WithOperatorToken(replacementNode.OperatorToken.WithTriviaFrom(node.OperatorToken));
+                    
 
                     yield return new Mutation()
                     {

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -41,7 +41,7 @@ namespace Stryker.Core.Mutators
         public override IEnumerable<Mutation> ApplyMutations(MemberAccessExpressionSyntax node)
         {
             if (Enum.TryParse(node.Name.Identifier.ValueText, out LinqExpression expression) &&
-                _kindsToMutate.TryGetValue(expression, out LinqExpression replacementExpression))
+                _kindsToMutate.TryGetValue(expression, out LinqExpression replacementExpression) && node.Parent is InvocationExpressionSyntax)
             {
                 SyntaxNode replacement = SyntaxFactory.IdentifierName(replacementExpression.ToString());
                 string displayName = $"Linq method mutation ({node.Name.Identifier.ValueText}() to {replacement}())";

--- a/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core
 {
+    // extension methods for SyntaxNode(s)
     internal static class SyntaxHelper
     {
         public static bool IsString(this ExpressionSyntax node)

--- a/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Stryker.Core
+{
+    internal static class SyntaxHelper
+    {
+        public static bool IsString(this ExpressionSyntax node)
+        {
+            return node.Kind() == SyntaxKind.StringLiteralExpression ||
+                   node.Kind() == SyntaxKind.InterpolatedStringExpression;
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core
@@ -6,10 +8,18 @@ namespace Stryker.Core
     // extension methods for SyntaxNode(s)
     internal static class SyntaxHelper
     {
+        // is the expression some king of string ?
         public static bool IsAStringExpression(this ExpressionSyntax node)
         {
             return node.Kind() == SyntaxKind.StringLiteralExpression ||
                    node.Kind() == SyntaxKind.InterpolatedStringExpression;
+        }
+
+        // does the expression contain declaration?
+        public static bool ContainsDeclarations(this ExpressionSyntax node)
+        {
+            return node.DescendantNodes().Any(x =>
+                x.IsKind(SyntaxKind.DeclarationExpression) || x.IsKind(SyntaxKind.DeclarationPattern));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
@@ -6,7 +6,7 @@ namespace Stryker.Core
     // extension methods for SyntaxNode(s)
     internal static class SyntaxHelper
     {
-        public static bool IsString(this ExpressionSyntax node)
+        public static bool IsAStringExpression(this ExpressionSyntax node)
         {
             return node.Kind() == SyntaxKind.StringLiteralExpression ||
                    node.Kind() == SyntaxKind.InterpolatedStringExpression;


### PR DESCRIPTION
# Main change
### Restore the generation of mutants that were missing in the current HEAD (#351)
## Other changes
- identify slightly more mutants that in the current release
- avoid generating known to fail mutants (e.g. default value for parameter or string concatenation)
- dump CompileError mutants in devmode