### PR TITLE
fix(Double mutations): On invocation expressions

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -42,7 +42,7 @@ namespace Stryker.Core.UnitTest.Mutants
         }
 
         [Theory]
-        [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs", 24, 5, 14, 12, 30)]
+        [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs", 18, 5, 14, 12, 31)]
         [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs", 10, 2, 16, 6, 21)]
         public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile, 
             int nbMutants, int mutant1Id, int mutant1Location, int mutant2Id, int mutant2Location)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_IN.cs
@@ -38,7 +38,6 @@
 
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
-
             return ExtensibilityHelper.BeginCheck(check).
                 FailWhen(sut => !IsALetter(sut), "The {0} is not a letter.").
                 OnNegate("The {0} is a letter whereas it must not.").

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -12,8 +12,8 @@
                 .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null && otherEnumerable == null:Stryker.ActiveMutationHelper.ActiveMutation==1?sut != null && otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut == null || otherEnumerable != null:sut == null && otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
                 .DefineExpectedValues(otherEnumerable, otherEnumerable.Count())
                 .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
-                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==6?"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "":Stryker.ActiveMutationHelper.ActiveMutation==5?""+ Environment.NewLine + "\t{0}":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
-                .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==9?"":"The {0} contains all the given values whereas it must not.")
+                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==5?"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "":Stryker.ActiveMutationHelper.ActiveMutation==4?""+ Environment.NewLine + "\t{0}":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==6?"":"The {0} contains all the given values whereas it must not.")
                 .EndCheck();
         }
 
@@ -26,11 +26,11 @@
             var durationThreshold = new Duration(threshold, timeUnit);
 
             ExtensibilityHelper.BeginCheck(check).
-                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==10?"":"code").
-                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==11?"":"execution time").
-                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==13?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==12?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==14?"":"The {checked} was too high.").
-                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==15?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==16?"":"more than").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==17?"":"The {checked} was too low.").
+                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"code").
+                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==8?"":"execution time").
+                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==10?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==9?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==11?"":"The {checked} was too high.").
+                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==12?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==13?"":"more than").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==14?"":"The {checked} was too low.").
                 EndCheck();
 
             return ExtensibilityHelper.BuildCheckLink(check);
@@ -38,10 +38,9 @@
 
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
-
             return ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==18?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==19?"":"The {0} is not a letter.").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==20?"":"The {0} is a letter whereas it must not.").
+                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==15?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==16?"":"The {0} is not a letter.").
+                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==17?"":"The {0} is a letter whereas it must not.").
                 EndCheck();
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -342,10 +342,6 @@ namespace Stryker.Core.Mutants
                 case nameof(InvocationExpressionSyntax):
                     var invocationExpression = node as InvocationExpressionSyntax;
                     yield return invocationExpression.Expression;
-                    foreach(var arg in invocationExpression.ArgumentList.Arguments.Select(x => x.Expression))
-                    {
-                        yield return arg;
-                    }
                     yield break;
             }
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -209,11 +209,12 @@ namespace Stryker.Core.Mutants
                 foreach (var expressionSyntax in expressions)
                 {
                     var currentExpressionSyntax = currentNodeCopy.GetCurrentNode(expressionSyntax);
-                    if (expressionSyntax is InvocationExpressionSyntax )
+                    if (expressionSyntax is InvocationExpressionSyntax)
                     {
                         // chained invocations, we will recurse
                         var mutant = Mutate(expressionSyntax);
                         currentNodeCopy = currentNodeCopy.ReplaceNode(currentExpressionSyntax, mutant);
+                        continue;
                     } 
                     SyntaxNode mutationCandidate = null;
                     
@@ -342,6 +343,10 @@ namespace Stryker.Core.Mutants
                 case nameof(InvocationExpressionSyntax):
                     var invocationExpression = node as InvocationExpressionSyntax;
                     yield return invocationExpression.Expression;
+                    foreach (var arg in invocationExpression.ArgumentList.Arguments.Select(x => x.Expression))
+                    {
+                        yield return arg;
+                    }
                     yield break;
             }
 


### PR DESCRIPTION
closes #395 
Resolution was to skip the iteration in the foreach. If the iteration continues the same node will be mutated again. Somehow the mutations ended up only once in code. But twice in the mutants array.

Fixed unit tests too.