### PR TITLE
fix(Handeling statements): ForStatements and ExpressionStatement mutated correctly

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -96,7 +96,7 @@ namespace ExampleProject
                 } 
                 while (first.Length < 2)
                 {
-                    return System.Environment.GetEnvironmentVariable(""ActiveMutation"") == ""7"" ? second - first : second + first;
+                    return (System.Environment.GetEnvironmentVariable(""ActiveMutation"") == ""7"" ? second - first : second + first);
                 }
                 return null;
             }
@@ -105,15 +105,15 @@ namespace ExampleProject
 }");
             var root = syntaxTree.GetRoot();
 
-            var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+            var mutantIf = root.DescendantNodes().OfType<IfStatementSyntax>().First();
             root = root.ReplaceNode(
-                mutantIf1,
-                mutantIf1.WithAdditionalAnnotations(new SyntaxAnnotation("MutationIf", "6"))
+                mutantIf,
+                mutantIf.WithAdditionalAnnotations(new SyntaxAnnotation("MutationIf", "6"))
             );
-            var mutantIf2 = root.DescendantNodes().OfType<ConditionalExpressionSyntax>().First();
+            var mutantCondition = root.DescendantNodes().First(x => x is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression is ConditionalExpressionSyntax);
             root = root.ReplaceNode(
-                mutantIf2,
-                mutantIf2.WithAdditionalAnnotations(new SyntaxAnnotation("MutationConditional", "7"))
+                mutantCondition,
+                mutantCondition.WithAdditionalAnnotations(new SyntaxAnnotation("MutationConditional", "7"))
             );
 
             var annotatedSyntaxTree = root.SyntaxTree;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/AddMutator.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/AddMutator.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Stryker.Core.Mutants;
 using Stryker.Core.Mutators;
 using System.Collections.Generic;
-using System.Net.Http;
 
 namespace Stryker.Core.UnitTest.Mutants
 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/AddMutator.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/AddMutator.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Stryker.Core.Mutants;
 using Stryker.Core.Mutators;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Stryker.Core.UnitTest.Mutants
 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -43,7 +43,7 @@ namespace Stryker.Core.UnitTest.Mutants
 
         [Theory]
         [InlineData("Mutator_FromActualProject_IN.cs", "Mutator_FromActualProject_OUT.cs", 18, 5, 14, 12, 31)]
-        [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs", 10, 2, 16, 6, 21)]
+        [InlineData("Mutator_KnownComplexCases_IN.cs", "Mutator_KnownComplexCases_OUT.cs", 15, 2, 12, 6, 25)]
         public void Mutator_TestResourcesInputShouldBecomeOutputForFullScope(string inputFile, string outputFile,
             int nbMutants, int mutant1Id, int mutant1Location, int mutant2Id, int mutant2Location)
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
@@ -30,7 +30,7 @@ namespace Stryker.Core.UnitTest.Mutants
                 1 + 8;
             }");
 
-            var removedResult = MutantPlacer.RemoveByIfStatement(result);
+            var removedResult = MutantPlacer.RemoveMutant(result);
 
             removedResult.ToString().ShouldBeSemantically(originalNode.ToString());
         }
@@ -52,9 +52,9 @@ namespace Stryker.Core.UnitTest.Mutants
 
             var result = MutantPlacer.PlaceWithConditionalExpression(originalNode, mutatedNode, id);
 
-            result.ToFullString().ShouldBeSemantically(@"System.Environment.GetEnvironmentVariable(""ActiveMutation"") == """ + id.ToString() + ") ? 1 - 8 : 1 + 8;");
+            result.ToFullString().ShouldBeSemantically(@"(System.Environment.GetEnvironmentVariable(""ActiveMutation"") == """ + id.ToString() + ") ? 1 - 8 : 1 + 8);");
 
-            var removedResult = MutantPlacer.RemoveByConditionalExpression(result);
+            var removedResult = MutantPlacer.RemoveMutant(result);
 
             removedResult.ToString().ShouldBeSemantically(originalNode.ToString());
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_AssignStatements_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_AssignStatements_OUT.cs
@@ -9,7 +9,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int a = 1;
-            int b = Stryker.ActiveMutationHelper.ActiveMutation==1?a -=1 + 2:a += Stryker.ActiveMutationHelper.ActiveMutation==0?1 -2:1 + 2;
+            int b = (Stryker.ActiveMutationHelper.ActiveMutation==1?a -=1 + 2:a += (Stryker.ActiveMutationHelper.ActiveMutation==0?1 -2:1 + 2));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_AssignStatements_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_AssignStatements_OUT.cs
@@ -9,7 +9,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int a = 1;
-            int b = Stryker.ActiveMutationHelper.ActiveMutation==1? a += 1 - 2 : Stryker.ActiveMutationHelper.ActiveMutation==0 ? a -= 1 + 2 : a += 1 + 2;
+            int b = Stryker.ActiveMutationHelper.ActiveMutation==1?a -=1 + 2:a += Stryker.ActiveMutationHelper.ActiveMutation==0?1 -2:1 + 2;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -9,10 +9,10 @@
         {
             IList<object> notFoundValues = null;
             checker
-                .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null && otherEnumerable == null:Stryker.ActiveMutationHelper.ActiveMutation==1?sut != null && otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut == null || otherEnumerable != null:sut == null && otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
+                .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null || otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut != null :sut == null && Stryker.ActiveMutationHelper.ActiveMutation==1?otherEnumerable == null:otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
                 .DefineExpectedValues(otherEnumerable, otherEnumerable.Count())
                 .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
-                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==5?"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "":Stryker.ActiveMutationHelper.ActiveMutation==4?""+ Environment.NewLine + "\t{0}":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + "\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + Stryker.ActiveMutationHelper.ActiveMutation==5?"":"\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
                 .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==6?"":"The {0} contains all the given values whereas it must not.")
                 .EndCheck();
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_FromActualProject_OUT.cs
@@ -9,11 +9,11 @@
         {
             IList<object> notFoundValues = null;
             checker
-                .FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null || otherEnumerable != null:Stryker.ActiveMutationHelper.ActiveMutation==0?sut != null :sut == null && Stryker.ActiveMutationHelper.ActiveMutation==1?otherEnumerable == null:otherEnumerable != null, Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s).")
+                .FailWhen((sut) => (Stryker.ActiveMutationHelper.ActiveMutation==2?sut == null || otherEnumerable != null:(Stryker.ActiveMutationHelper.ActiveMutation==0?sut != null :sut == null )&& (Stryker.ActiveMutationHelper.ActiveMutation==1?otherEnumerable == null:otherEnumerable != null)), (Stryker.ActiveMutationHelper.ActiveMutation==3?"":"The {0} is null and thus, does not contain the given expected value(s)."))
                 .DefineExpectedValues(otherEnumerable, otherEnumerable.Count())
                 .Analyze((sut, _) => notFoundValues = ExtractNotFoundValues(sut, otherEnumerable))
-                .FailWhen((_) => notFoundValues.Any(), string.Format(Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {{0}} does not contain the expected value(s):" + Environment.NewLine + Stryker.ActiveMutationHelper.ActiveMutation==5?"":"\t{0}", notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
-                .OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==6?"":"The {0} contains all the given values whereas it must not.")
+                .FailWhen((_) => notFoundValues.Any(), string.Format((Stryker.ActiveMutationHelper.ActiveMutation==4?"":"The {{0}} does not contain the expected value(s):" )+ Environment.NewLine + (Stryker.ActiveMutationHelper.ActiveMutation==5?"":"\t{0}"), notFoundValues.ToStringProperlyFormatted().DoubleCurlyBraces()))
+                .OnNegate((Stryker.ActiveMutationHelper.ActiveMutation==6?"":"The {0} contains all the given values whereas it must not."))
                 .EndCheck();
         }
 
@@ -26,11 +26,11 @@
             var durationThreshold = new Duration(threshold, timeUnit);
 
             ExtensibilityHelper.BeginCheck(check).
-                SetSutName(Stryker.ActiveMutationHelper.ActiveMutation==7?"":"code").
-                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), Stryker.ActiveMutationHelper.ActiveMutation==8?"":"execution time").
-                FailWhen((sut) => Stryker.ActiveMutationHelper.ActiveMutation==10?sut >= durationThreshold:Stryker.ActiveMutationHelper.ActiveMutation==9?sut < durationThreshold:sut > durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==11?"":"The {checked} was too high.").
-                DefineExpectedValue(durationThreshold, Stryker.ActiveMutationHelper.ActiveMutation==12?"":"less than", Stryker.ActiveMutationHelper.ActiveMutation==13?"":"more than").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==14?"":"The {checked} was too low.").
+                SetSutName((Stryker.ActiveMutationHelper.ActiveMutation==7?"":"code")).
+                CheckSutAttributes(sut =>  new Duration(sut.ExecutionTime, timeUnit), (Stryker.ActiveMutationHelper.ActiveMutation==8?"":"execution time")).
+                FailWhen((sut) => (Stryker.ActiveMutationHelper.ActiveMutation==10?sut >= durationThreshold:(Stryker.ActiveMutationHelper.ActiveMutation==9?sut < durationThreshold:sut > durationThreshold)), (Stryker.ActiveMutationHelper.ActiveMutation==11?"":"The {checked} was too high.")).
+                DefineExpectedValue(durationThreshold, (Stryker.ActiveMutationHelper.ActiveMutation==12?"":"less than"), (Stryker.ActiveMutationHelper.ActiveMutation==13?"":"more than")).
+                OnNegate((Stryker.ActiveMutationHelper.ActiveMutation==14?"":"The {checked} was too low.")).
                 EndCheck();
 
             return ExtensibilityHelper.BuildCheckLink(check);
@@ -39,8 +39,8 @@
         public static ICheckLink<ICheck<char>> IsALetter(this ICheck<char> check)
         {
             return ExtensibilityHelper.BeginCheck(check).
-                FailWhen(sut => Stryker.ActiveMutationHelper.ActiveMutation==15?IsALetter(sut):!IsALetter(sut), Stryker.ActiveMutationHelper.ActiveMutation==16?"":"The {0} is not a letter.").
-                OnNegate(Stryker.ActiveMutationHelper.ActiveMutation==17?"":"The {0} is a letter whereas it must not.").
+                FailWhen(sut => (Stryker.ActiveMutationHelper.ActiveMutation==15?IsALetter(sut):!IsALetter(sut)), (Stryker.ActiveMutationHelper.ActiveMutation==16?"":"The {0} is not a letter.")).
+                OnNegate((Stryker.ActiveMutationHelper.ActiveMutation==17?"":"The {0} is a letter whereas it must not.")).
                 EndCheck();
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementsShouldBe_Nested_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementsShouldBe_Nested_OUT.cs
@@ -9,31 +9,32 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int i = 0;
-            if (Stryker.ActiveMutationHelper.ActiveMutation == 0 ? i - 8 == 8 : i + 8 == 8)
+            if (Stryker.ActiveMutationHelper.ActiveMutation==0?i -8 :i + 8 == 8)
             {
-                i = Stryker.ActiveMutationHelper.ActiveMutation == 4 ? i - 1 : i + 1;
-                if (Stryker.ActiveMutationHelper.ActiveMutation == 5 ? i - 8 == 9 : i + 8 == 9)
+                i = Stryker.ActiveMutationHelper.ActiveMutation==4?i -1:i + 1;
+                if (Stryker.ActiveMutationHelper.ActiveMutation==5?i -8 :i + 8 == 9)
                 {
-                    i = Stryker.ActiveMutationHelper.ActiveMutation == 6 ? i - 1 : i + 1;
+                    i = Stryker.ActiveMutationHelper.ActiveMutation==6?i -1:i + 1;
                 };
             }
             else
             {
-                i = Stryker.ActiveMutationHelper.ActiveMutation == 1 ? i - 3 : i + 3;
-                if (Stryker.ActiveMutationHelper.ActiveMutation == 2 ? i == i - i - 8 : i == i + i - 8)
+                i = Stryker.ActiveMutationHelper.ActiveMutation==1?i -3:i + 3;
+                if (i == Stryker.ActiveMutationHelper.ActiveMutation==2?i -i :i + i - 8)
                 {
-                    i = Stryker.ActiveMutationHelper.ActiveMutation == 3 ? i - 1 : i + 1;
+                    i = Stryker.ActiveMutationHelper.ActiveMutation==3?i -1:i + 1;
                 };
             }
+
             if (!Out(out var test))
             {
-                return Stryker.ActiveMutationHelper.ActiveMutation == 7 ? i - 1 : i + 1;
-            }
-            if (i is int x)
-            {
-                return Stryker.ActiveMutationHelper.ActiveMutation == 8 ? x - 1 : x + 1;
+                return Stryker.ActiveMutationHelper.ActiveMutation==7?i -1:i + 1;
             }
 
+            if (i is int x)
+            {
+                return Stryker.ActiveMutationHelper.ActiveMutation==8?x -1:x + 1;
+            }
         }
 
         private bool Out(out string test)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementsShouldBe_Nested_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementsShouldBe_Nested_OUT.cs
@@ -9,31 +9,31 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int i = 0;
-            if (Stryker.ActiveMutationHelper.ActiveMutation==0?i -8 :i + 8 == 8)
+            if ((Stryker.ActiveMutationHelper.ActiveMutation==0?i -8 :i + 8 )== 8)
             {
-                i = Stryker.ActiveMutationHelper.ActiveMutation==4?i -1:i + 1;
-                if (Stryker.ActiveMutationHelper.ActiveMutation==5?i -8 :i + 8 == 9)
+                i = (Stryker.ActiveMutationHelper.ActiveMutation==4?i -1:i + 1);
+                if ((Stryker.ActiveMutationHelper.ActiveMutation==5?i -8 :i + 8 )== 9)
                 {
-                    i = Stryker.ActiveMutationHelper.ActiveMutation==6?i -1:i + 1;
+                    i = (Stryker.ActiveMutationHelper.ActiveMutation==6?i -1:i + 1);
                 };
             }
             else
             {
-                i = Stryker.ActiveMutationHelper.ActiveMutation==1?i -3:i + 3;
-                if (i == Stryker.ActiveMutationHelper.ActiveMutation==2?i -i :i + i - 8)
+                i = (Stryker.ActiveMutationHelper.ActiveMutation==1?i -3:i + 3);
+                if (i == (Stryker.ActiveMutationHelper.ActiveMutation==2?i -i :i + i )- 8)
                 {
-                    i = Stryker.ActiveMutationHelper.ActiveMutation==3?i -1:i + 1;
+                    i = (Stryker.ActiveMutationHelper.ActiveMutation==3?i -1:i + 1);
                 };
             }
 
             if (!Out(out var test))
             {
-                return Stryker.ActiveMutationHelper.ActiveMutation==7?i -1:i + 1;
+                return (Stryker.ActiveMutationHelper.ActiveMutation==7?i -1:i + 1);
             }
 
             if (i is int x)
             {
-                return Stryker.ActiveMutationHelper.ActiveMutation==8?x -1:x + 1;
+                return (Stryker.ActiveMutationHelper.ActiveMutation==8?x -1:x + 1);
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_IN.cs
@@ -4,7 +4,16 @@ namespace TestCases
     // list syntax construction that are difficult to mutate
     class ComplexCases
     {
-        
+
+        private void GoodLuck()
+        {
+            await SendRequest(url, HttpMethod.Get, (request) =>
+            {
+                request.Headers.Add("Accept", "application/json; version=1");
+                request.Headers.TryAddWithoutValidation("Date", datum);
+            }, ensureSuccessStatusCode: false);
+        }
+
         private string text = "Some" + "Text";
         // const can't me mutated (need to be const at build time)
         private const int x = 1 + 2;
@@ -22,6 +31,11 @@ namespace TestCases
                 var test = "first" + "second";
                 // complex mutation pattern
                 x *=x+2;
+            }
+
+            for (var j = 0;; j++)
+            {
+                break:
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
@@ -8,12 +8,12 @@
         {
             await SendRequest(url, HttpMethod.Get, (request) =>
             {
-                request.Headers.Add(Stryker.ActiveMutationHelper.ActiveMutation==0?"":"Accept", Stryker.ActiveMutationHelper.ActiveMutation==1?"":"application/json; version=1");
-                request.Headers.TryAddWithoutValidation(Stryker.ActiveMutationHelper.ActiveMutation==2?"":"Date", datum);
-            }, ensureSuccessStatusCode: Stryker.ActiveMutationHelper.ActiveMutation==3?true:false);
+                request.Headers.Add((Stryker.ActiveMutationHelper.ActiveMutation==0?"":"Accept"), (Stryker.ActiveMutationHelper.ActiveMutation==1?"":"application/json; version=1"));
+                request.Headers.TryAddWithoutValidation((Stryker.ActiveMutationHelper.ActiveMutation==2?"":"Date"), datum);
+            }, ensureSuccessStatusCode: (Stryker.ActiveMutationHelper.ActiveMutation==3?true:false));
         }
 
-        private string text = Stryker.ActiveMutationHelper.ActiveMutation==4?"":"Some" + Stryker.ActiveMutationHelper.ActiveMutation==5?"":"Text";
+        private string text = (Stryker.ActiveMutationHelper.ActiveMutation==4?"":"Some" )+ (Stryker.ActiveMutationHelper.ActiveMutation==5?"":"Text");
         // const can't me mutated (need to be const at build time)
         private const int x = 1 + 2;
         // attributes must be constant at build time => no possible mutation
@@ -32,17 +32,17 @@ if(Stryker.ActiveMutationHelper.ActiveMutation==6){            // for statement 
                 x *=x+2;
             }
 }else{            // for statement can only me mutated through if(s)
-            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==8?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==7?i > 10:i < 10; i++)
+            for (var i = 0; (Stryker.ActiveMutationHelper.ActiveMutation==8?i <= 10:(Stryker.ActiveMutationHelper.ActiveMutation==7?i > 10:i < 10)); i++)
             {
                 var x=1;
 if(Stryker.ActiveMutationHelper.ActiveMutation==9){                x--;
 }else{                x++;
 }                // should not be mutated (string concatenation)
-                var test = Stryker.ActiveMutationHelper.ActiveMutation==10?"":"first" + Stryker.ActiveMutationHelper.ActiveMutation==11?"":"second";
+                var test = (Stryker.ActiveMutationHelper.ActiveMutation==10?"":"first" )+ (Stryker.ActiveMutationHelper.ActiveMutation==11?"":"second");
 if(Stryker.ActiveMutationHelper.ActiveMutation==12){                // complex mutation pattern
                 x /=x+2;
 }else{                // complex mutation pattern
-                x *=Stryker.ActiveMutationHelper.ActiveMutation==13?x-2:x+2;
+                x *=(Stryker.ActiveMutationHelper.ActiveMutation==13?x-2:x+2);
 }            }
 }if(Stryker.ActiveMutationHelper.ActiveMutation==14){
             for (var j = 0;; j--)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_KnownComplexCases_OUT.cs
@@ -3,8 +3,17 @@
     // list syntax construction that are difficult to mutate
     class ComplexCases
     {
-        
-        private string text = Stryker.ActiveMutationHelper.ActiveMutation==1?"Some" + "":Stryker.ActiveMutationHelper.ActiveMutation==0?""+ "Text":"Some" + "Text";
+
+        private void GoodLuck()
+        {
+            await SendRequest(url, HttpMethod.Get, (request) =>
+            {
+                request.Headers.Add(Stryker.ActiveMutationHelper.ActiveMutation==0?"":"Accept", Stryker.ActiveMutationHelper.ActiveMutation==1?"":"application/json; version=1");
+                request.Headers.TryAddWithoutValidation(Stryker.ActiveMutationHelper.ActiveMutation==2?"":"Date", datum);
+            }, ensureSuccessStatusCode: Stryker.ActiveMutationHelper.ActiveMutation==3?true:false);
+        }
+
+        private string text = Stryker.ActiveMutationHelper.ActiveMutation==4?"":"Some" + Stryker.ActiveMutationHelper.ActiveMutation==5?"":"Text";
         // const can't me mutated (need to be const at build time)
         private const int x = 1 + 2;
         // attributes must be constant at build time => no possible mutation
@@ -12,7 +21,7 @@
         // default parameter must be constant at build time => no posible mutation
         private void SomeMthod(bool option = true)
         {
-if(Stryker.ActiveMutationHelper.ActiveMutation==2){            // for statement can only me mutated through if(s)
+if(Stryker.ActiveMutationHelper.ActiveMutation==6){            // for statement can only me mutated through if(s)
             for (var i = 0; i < 10; i--)
             {
                 var x=1;
@@ -23,18 +32,28 @@ if(Stryker.ActiveMutationHelper.ActiveMutation==2){            // for statement 
                 x *=x+2;
             }
 }else{            // for statement can only me mutated through if(s)
-            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==4?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==3?i > 10:i < 10; i++)
+            for (var i = 0; Stryker.ActiveMutationHelper.ActiveMutation==8?i <= 10:Stryker.ActiveMutationHelper.ActiveMutation==7?i > 10:i < 10; i++)
             {
                 var x=1;
-if(Stryker.ActiveMutationHelper.ActiveMutation==5){                x--;
+if(Stryker.ActiveMutationHelper.ActiveMutation==9){                x--;
 }else{                x++;
 }                // should not be mutated (string concatenation)
-                var test = Stryker.ActiveMutationHelper.ActiveMutation==7?"first" + "":Stryker.ActiveMutationHelper.ActiveMutation==6?""+ "second":"first" + "second";
-if(Stryker.ActiveMutationHelper.ActiveMutation==8){                // complex mutation pattern
+                var test = Stryker.ActiveMutationHelper.ActiveMutation==10?"":"first" + Stryker.ActiveMutationHelper.ActiveMutation==11?"":"second";
+if(Stryker.ActiveMutationHelper.ActiveMutation==12){                // complex mutation pattern
                 x /=x+2;
 }else{                // complex mutation pattern
-                x *=Stryker.ActiveMutationHelper.ActiveMutation==9?x-2:x+2;
+                x *=Stryker.ActiveMutationHelper.ActiveMutation==13?x-2:x+2;
 }            }
+}if(Stryker.ActiveMutationHelper.ActiveMutation==14){
+            for (var j = 0;; j--)
+            {
+                break:
+            }
+}else{
+            for (var j = 0;; j++)
+            {
+                break:
+            }
 }        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
@@ -9,12 +9,12 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int test = 10;
-            test = Stryker.ActiveMutationHelper.ActiveMutation == 0 ? test - i : test + i;
-            int testPlusTest = Stryker.ActiveMutationHelper.ActiveMutation == 1 ? test - test : test + test;
-            int b = Stryker.ActiveMutationHelper.ActiveMutation == 3 ? a += 1 - 2 : Stryker.ActiveMutationHelper.ActiveMutation == 2 ? a -= 1 + 2 : a += 1 + 2;
-            var (one, two) = Stryker.ActiveMutationHelper.ActiveMutation == 4 ? (1 - 1, "") : (1 + 1, "");
-            int Add(int x, int y) => Stryker.ActiveMutationHelper.ActiveMutation == 5 ? x - y : x + y;
-            Action act = () => Console.WriteLine(Stryker.ActiveMutationHelper.ActiveMutation == 6 ? 1 - 1 : 1 + 1, Stryker.ActiveMutationHelper.ActiveMutation == 7 ? 1 - 1 : 1 + 1);
+            test = Stryker.ActiveMutationHelper.ActiveMutation==0?test -i:test + i;
+            int testPlusTest = Stryker.ActiveMutationHelper.ActiveMutation==1?test -test:test + test;
+            int b = Stryker.ActiveMutationHelper.ActiveMutation==3?a -=1 + 2:a += Stryker.ActiveMutationHelper.ActiveMutation==2?1 -2:1 + 2;
+            var (one, two) = (Stryker.ActiveMutationHelper.ActiveMutation==4?1 -1:1 + 1, "");
+            int Add(int x, int y) => Stryker.ActiveMutationHelper.ActiveMutation==5?x -y:x + y;
+            Action act = () => Console.WriteLine(Stryker.ActiveMutationHelper.ActiveMutation==6?1 -1:1 + 1, Stryker.ActiveMutationHelper.ActiveMutation==7?1 -1:1 + 1);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs
@@ -9,12 +9,12 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         void TestMethod()
         {
             int test = 10;
-            test = Stryker.ActiveMutationHelper.ActiveMutation==0?test -i:test + i;
-            int testPlusTest = Stryker.ActiveMutationHelper.ActiveMutation==1?test -test:test + test;
-            int b = Stryker.ActiveMutationHelper.ActiveMutation==3?a -=1 + 2:a += Stryker.ActiveMutationHelper.ActiveMutation==2?1 -2:1 + 2;
-            var (one, two) = (Stryker.ActiveMutationHelper.ActiveMutation==4?1 -1:1 + 1, "");
-            int Add(int x, int y) => Stryker.ActiveMutationHelper.ActiveMutation==5?x -y:x + y;
-            Action act = () => Console.WriteLine(Stryker.ActiveMutationHelper.ActiveMutation==6?1 -1:1 + 1, Stryker.ActiveMutationHelper.ActiveMutation==7?1 -1:1 + 1);
+            test = (Stryker.ActiveMutationHelper.ActiveMutation==0?test -i:test + i);
+            int testPlusTest = (Stryker.ActiveMutationHelper.ActiveMutation==1?test -test:test + test);
+            int b = (Stryker.ActiveMutationHelper.ActiveMutation==3?a -=1 + 2:a += (Stryker.ActiveMutationHelper.ActiveMutation==2?1 -2:1 + 2));
+            var (one, two) = ((Stryker.ActiveMutationHelper.ActiveMutation==4?1 -1:1 + 1), "");
+            int Add(int x, int y) => (Stryker.ActiveMutationHelper.ActiveMutation==5?x -y:x + y);
+            Action act = () => Console.WriteLine((Stryker.ActiveMutationHelper.ActiveMutation==6?1 -1:1 + 1), (Stryker.ActiveMutationHelper.ActiveMutation==7?1 -1:1 + 1));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
@@ -10,8 +10,8 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         {
             string SomeLocalFunction()
             {
-                var test3 = Stryker.ActiveMutationHelper.ActiveMutation==0?2 -5:2 + 5;
-                return $"test{Stryker.ActiveMutationHelper.ActiveMutation==1?1 -test3:1 + test3}";
+                var test3 = (Stryker.ActiveMutationHelper.ActiveMutation==0?2 -5:2 + 5);
+                return $"test{(Stryker.ActiveMutationHelper.ActiveMutation==1?1 -test3:1 + test3)}";
             };
             Console.WriteLine(SomeLocalFunction());
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_SyntaxShouldBe_IfStatement_OUT.cs
@@ -10,8 +10,8 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
         {
             string SomeLocalFunction()
             {
-                var test3 = Stryker.ActiveMutationHelper.ActiveMutation==0 ?2-5:2 + 5;
-                return Stryker.ActiveMutationHelper.ActiveMutation==1?$"test{1 - test3}":$"test{1 + test3}";
+                var test3 = Stryker.ActiveMutationHelper.ActiveMutation==0?2 -5:2 + 5;
+                return $"test{Stryker.ActiveMutationHelper.ActiveMutation==1?1 -test3:1 + test3}";
             };
             Console.WriteLine(SomeLocalFunction());
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -6,13 +6,13 @@
   <ItemGroup>
     <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_FromActualProject_OUT.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_OUT.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_KnownComplexCases_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_KnownComplexCases_OUT.cs" />
     <Compile Remove="TestResources\ExampleSourceFile.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_AssignStatements_OUT.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_IN.cs" />
-    <Compile Remove="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_OUT.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_NoMutationsShouldBeMade.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_SyntaxShouldBe_ConditionalStatement_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs" />
@@ -25,6 +25,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Mutants\TestResources\Mutator_FromActualProject_OUT.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_OUT.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Mutants\TestResources\Mutator_KnownComplexCases_IN.cs">
@@ -40,9 +43,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_IN.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Mutants\TestResources\Mutator_IfStatementsShouldBe_Nested_OUT.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Mutants\TestResources\Mutator_SyntaxShouldBe_ConditionalStatement_OUT.cs">

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -206,16 +206,9 @@ namespace Stryker.Core.Compiling
                 // find the mutated node in the new tree
                 var nodeToRemove = trackedTree.GetCurrentNode(brokenMutation);
                 // remove the mutated node using its MutantPlacer remove method and update the tree
-                if (nodeToRemove is IfStatementSyntax)
-                {
-                    trackedTree = trackedTree.ReplaceNode(nodeToRemove, MutantPlacer.RemoveByIfStatement(nodeToRemove));
-                } else if (nodeToRemove is ConditionalExpressionSyntax)
-                {
-                    trackedTree = trackedTree.ReplaceNode(nodeToRemove, MutantPlacer.RemoveByConditionalExpression(nodeToRemove));
-                }
+                trackedTree = trackedTree.ReplaceNode(nodeToRemove, MutantPlacer.RemoveMutant(nodeToRemove));
             }
             return trackedTree.SyntaxTree;
         }
-
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -187,19 +187,22 @@ namespace Stryker.Core.Mutants
             // now we generate a mutant for the remainder of the for statement
 
             ForStatementSyntax mutatedFor;
+            StatementSyntax statementPart;
             if (forStatement.Condition == null)
             {
-                mutatedFor = forStatement.ReplaceNode(forStatement.Statement,
-                    Mutate(forStatement.Statement));
+                mutatedFor = forStatement;
+                statementPart = forStatement.Statement;
             }
             else
             {
                 mutatedFor = forStatement.TrackNodes(forStatement.Condition, forStatement.Statement);
                 mutatedFor = mutatedFor.ReplaceNode(mutatedFor.GetCurrentNode(forStatement.Condition),
                     Mutate(forStatement.Condition));
-                mutatedFor = mutatedFor.ReplaceNode(mutatedFor.GetCurrentNode(forStatement.Statement),
-                    Mutate(forStatement.Statement));
+                statementPart = mutatedFor.GetCurrentNode(forStatement.Statement);
             }
+
+            mutatedFor = mutatedFor.ReplaceNode(statementPart,
+                Mutate(forStatement.Statement));
             // and now we replace it
             return forWithMutantIncrementors.ReplaceNode(originalFor, mutatedFor);
         }
@@ -294,9 +297,7 @@ namespace Stryker.Core.Mutants
 
         private SyntaxNode MutateWithConditionalExpressions(ExpressionSyntax currentNode)
         {
-            var nodeToTracks = new List<SyntaxNode>(currentNode.ChildNodes());
-            nodeToTracks.Add(currentNode);
-            var expressionAst = currentNode.TrackNodes(nodeToTracks);
+            var expressionAst = currentNode.TrackNodes(currentNode.ChildNodes().Append(currentNode));
             foreach (var childNode in currentNode.ChildNodes())
             {
                 var mutatedChild = Mutate(childNode);


### PR DESCRIPTION
Fixes #412 and **should** fix #411.

## Fix for #411
Ensure mutation control is applied close to the mutant, usually next to the mutated expression part. This should fix #411 (tbc), it may slightly increase the number of mutants. As it changes the order of mutant generation, it impacts mutant id.

## Fix for #412 
Add tolerance for null Condition in ForStatementSyntax.
