### PR TITLE
feat(exclusions): Warn user on all mutations excluded

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -302,8 +302,8 @@ namespace Stryker.CLI.UnitTest
             int result = target.Run(new string[] { });
 
             mock.Verify();
-            Assert.Equal(1, target.ExitCode);
-            Assert.Equal(1, result);
+            target.ExitCode.ShouldBe(1);
+            result.ShouldBe(1);
         }
 
         [Fact]
@@ -318,8 +318,8 @@ namespace Stryker.CLI.UnitTest
             int result = target.Run(new string[] { });
 
             mock.Verify();
-            Assert.Equal(0, target.ExitCode);
-            Assert.Equal(0, result);
+            target.ExitCode.ShouldBe(0);
+            result.ShouldBe(0);
         }
 
         [Fact]
@@ -334,8 +334,8 @@ namespace Stryker.CLI.UnitTest
             int result = target.Run(new string[] { });
 
             mock.Verify();
-            Assert.Equal(0, target.ExitCode);
-            Assert.Equal(0, result);
+            target.ExitCode.ShouldBe(0);
+            result.ShouldBe(0);
         }
 
         [Fact]
@@ -351,8 +351,8 @@ namespace Stryker.CLI.UnitTest
             int result = target.Run(new string[] { });
 
             mock.Verify();
-            Assert.Equal(0, target.ExitCode);
-            Assert.Equal(0, result);
+            target.ExitCode.ShouldBe(0);
+            result.ShouldBe(0);
         }
 
         [Fact]

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -307,6 +307,22 @@ namespace Stryker.CLI.UnitTest
         }
 
         [Fact]
+        public void StrykerCLI_OnMutationScoreEqualToNullAndThresholdBreakEqualTo0_ShouldReturnExitCode0()
+        {
+            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+            StrykerOptions options = new StrykerOptions(thresholdBreak: 0);
+            StrykerRunResult strykerRunResult = new StrykerRunResult(options, null);
+            mock.Setup(x => x.RunMutationTest(It.IsAny<StrykerOptions>())).Returns(strykerRunResult).Verifiable();
+
+            var target = new StrykerCLI(mock.Object);
+            int result = target.Run(new string[] { });
+
+            mock.Verify();
+            Assert.Equal(0, target.ExitCode);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
         public void StrykerCLI_OnMutationScoreAboveThresholdBreak_ShouldReturnExitCode0()
         {
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -323,6 +323,22 @@ namespace Stryker.CLI.UnitTest
         }
 
         [Fact]
+        public void StrykerCLI_OnMutationScoreEqualToNullAndThresholdBreakAbove0_ShouldReturnExitCode0()
+        {
+            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+            StrykerOptions options = new StrykerOptions(thresholdBreak: 40);
+            StrykerRunResult strykerRunResult = new StrykerRunResult(options, null);
+            mock.Setup(x => x.RunMutationTest(It.IsAny<StrykerOptions>())).Returns(strykerRunResult).Verifiable();
+
+            var target = new StrykerCLI(mock.Object);
+            int result = target.Run(new string[] { });
+
+            mock.Verify();
+            Assert.Equal(0, target.ExitCode);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
         public void StrykerCLI_OnMutationScoreAboveThresholdBreak_ShouldReturnExitCode0()
         {
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -13,6 +13,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
+using Shouldly;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.MutationTest
@@ -336,7 +337,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 1)), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(mutant), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
-            Assert.Null(testResult.MutationScore);
+            testResult.MutationScore.ShouldBeNull();
         }
 
         [Fact]
@@ -385,7 +386,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 1)), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(It.IsAny<Mutant>()), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
-            Assert.Null(testResult.MutationScore);
+            testResult.MutationScore.ShouldBeNull();
         }
 
         [Fact]
@@ -436,7 +437,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 2)), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(It.IsAny<Mutant>()), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
-            Assert.Null(testResult.MutationScore);
+            testResult.MutationScore.ShouldBeNull();
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -287,7 +287,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             target.Test(options);
 
             executorMock.Verify(x => x.Test(mutant), Times.Once);
-            reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 1)), Times.Once);
+            reporterMock.Verify(x => x.OnStartMutantTestRun(It.IsAny<IList<Mutant>>()), Times.Once);
             reporterMock.Verify(x => x.OnMutantTested(mutant), Times.Once);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Once);
         }
@@ -336,7 +336,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             var testResult = target.Test(options);
 
             executorMock.Verify(x => x.Test(mutant), Times.Never);
-            reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 1)), Times.Never);
+            reporterMock.Verify(x => x.OnStartMutantTestRun(It.IsAny<IList<Mutant>>()), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(mutant), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
             testResult.MutationScore.ShouldBeNull();
@@ -385,7 +385,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             var testResult = target.Test(options);
 
             executorMock.Verify(x => x.Test(It.IsAny<Mutant>()), Times.Never);
-            reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 1)), Times.Never);
+            reporterMock.Verify(x => x.OnStartMutantTestRun(It.IsAny<IList<Mutant>>()), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(It.IsAny<Mutant>()), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
             testResult.MutationScore.ShouldBeNull();
@@ -436,7 +436,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             var testResult = target.Test(options);
 
             executorMock.Verify(x => x.Test(It.IsAny<Mutant>()), Times.Never);
-            reporterMock.Verify(x => x.OnStartMutantTestRun(It.Is<IList<Mutant>>(y => y.Count == 2)), Times.Never);
+            reporterMock.Verify(x => x.OnStartMutantTestRun(It.IsAny<IList<Mutant>>()), Times.Never);
             reporterMock.Verify(x => x.OnMutantTested(It.IsAny<Mutant>()), Times.Never);
             reporterMock.Verify(x => x.OnAllMutantsTested(It.IsAny<ProjectComponent>()), Times.Never);
             testResult.MutationScore.ShouldBeNull();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -23,12 +23,14 @@ namespace Stryker.Core.UnitTest.MutationTest
         private string _currentDirectory { get; set; }
         private string _filesystemRoot { get; set; }
         private string _sourceFile { get; set; }
+        private IEnumerable<PortableExecutableReference> _assemblies { get; set; }
 
         public MutationTestProcessTests()
         {
             _currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             _filesystemRoot = Path.GetPathRoot(_currentDirectory);
             _sourceFile = File.ReadAllText(_currentDirectory + "/TestResources/ExampleSourceFile.cs");
+            _assemblies = new ReferenceProvider().GetReferencedAssemblies();
         }
 
         [Fact]
@@ -53,7 +55,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                         }
                     },
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -130,7 +132,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                         }
                     },
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
 
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -200,7 +202,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                     TargetFramework = "netcoreapp2.0",
                     AppendTargetFrameworkToOutputPath = true
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
             var mockMutants = new Collection<Mutant>() { new Mutant() { Mutation = new Mutation() } };
 
@@ -265,7 +267,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                     ProjectUnderTestPath = Path.Combine(_filesystemRoot, "ExampleProject"),
                     TargetFramework = "netcoreapp2.0",
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             reporterMock.Setup(x => x.OnMutantTested(It.IsAny<Mutant>()));
@@ -314,7 +316,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                     ProjectUnderTestPath = Path.Combine(_filesystemRoot, "ExampleProject"),
                     TargetFramework = "netcoreapp2.0",
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             reporterMock.Setup(x => x.OnMutantTested(It.IsAny<Mutant>()));
@@ -363,7 +365,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                     ProjectUnderTestPath = Path.Combine(_filesystemRoot, "ExampleProject"),
                     TargetFramework = "netcoreapp2.0",
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             reporterMock.Setup(x => x.OnMutantTested(It.IsAny<Mutant>()));
@@ -414,7 +416,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                     ProjectUnderTestPath = Path.Combine(_filesystemRoot, "ExampleProject"),
                     TargetFramework = "netcoreapp2.0",
                 },
-                AssemblyReferences = new ReferenceProvider().GetReferencedAssemblies()
+                AssemblyReferences = _assemblies
             };
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             reporterMock.Setup(x => x.OnMutantTested(It.IsAny<Mutant>()));

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -138,6 +138,18 @@ namespace Stryker.Core.MutationTest
         public StrykerRunResult Test(StrykerOptions options)
         {
             var mutantsNotRun = _input.ProjectInfo.ProjectContents.Mutants.Where(x => x.ResultStatus == MutantStatus.NotRun).ToList();
+            if (!mutantsNotRun.Any())
+            {
+                if (_input.ProjectInfo.ProjectContents.Mutants.Any(x => x.ResultStatus == MutantStatus.Skipped))
+                {
+                    _logger.LogWarning("It looks like all mutants were excluded, try a re-run with less exclusion.");
+                }
+                else
+                {
+                    _logger.LogWarning("It\'s a mutant-free world, nothing to test.");
+                }
+                return new StrykerRunResult(options, null);
+            }
             _reporter.OnStartMutantTestRun(mutantsNotRun);
 
             Parallel.ForEach(mutantsNotRun,

--- a/src/Stryker.Core/Stryker.Core/StrykerRunResult.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunResult.cs
@@ -15,6 +15,11 @@ namespace Stryker.Core
 
         public bool IsScoreAboveThresholdBreak()
         {
+            if (MutationScore == null)
+            {
+                return _options.Thresholds.Break == 0;
+            }
+
             // Check if the mutation score is not below the threshold break
             return MutationScore >= _options.Thresholds.Break;
         }

--- a/src/Stryker.Core/Stryker.Core/StrykerRunResult.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunResult.cs
@@ -17,7 +17,8 @@ namespace Stryker.Core
         {
             if (MutationScore == null)
             {
-                return _options.Thresholds.Break == 0;
+                // Return true, because there were no mutations created.
+                return true;
             }
 
             // Check if the mutation score is not below the threshold break


### PR DESCRIPTION
Hi, 
I'm currently starting a new project and I disabled string mutations, It happened that those were only mutations in my project. So all mutations were skipped. I was surprised when Stryker exited with code 1, instead of 0, even that I had Threshold Break set to 0. 

I think that when there are no tests to run exit code should be 0 not 1. The issue, that I found is passing mutation score as nullable decimal `decimal?` to the `StrykerRunResult` when there are no mutations to run.
```csharp
public bool IsScoreAboveThresholdBreak()
{
    // Check if the mutation score is not below the threshold break
    //          null     >=   0  this is not true.
    return MutationScore >= _options.Thresholds.Break;
}
```
I added if statement that checks if `MutationScore` is `null`, and checks if Threshold.Break is set to 0.

```csharp
public bool IsScoreAboveThresholdBreak()
{
    if (MutationScore == null)
    {
        return _options.Thresholds.Break == 0;
    }

    // Check if the mutation score is not below the threshold break
    return MutationScore >= _options.Thresholds.Break;
}
```