### PR TITLE
feat(input file resolver): directory contains more than one csproj

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -480,8 +480,8 @@ namespace Stryker.Core.UnitTest.Initialisation
             var target = new InputFileResolver(fileSystem);
 
             var actual = target.ScanProjectFile(Path.Combine(_filesystemRoot, "ExampleProject"));
-            
-            actual.ShouldBe("C:\\ExampleProject\\ExampleProject.csproj");
+
+            actual.ShouldBe(Path.Combine(_filesystemRoot, "ExampleProject", "ExampleProject.csproj"));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -446,5 +446,42 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             Assert.Throws<StrykerInputException>(() => target.ScanProjectFile(Path.Combine(_filesystemRoot, "ExampleProject")));
         }
+
+        [Fact]
+        public void InputFileResolver_ShouldNotThrowExceptionOnTwoProjectFilesInDifferentLocations()
+        {
+            string projectFile = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include=""Microsoft.NET.Test.Sdk"" Version = ""15.5.0"" />
+        <PackageReference Include=""xunit"" Version=""2.3.1"" />
+        <PackageReference Include=""xunit.runner.visualstudio"" Version=""2.3.1"" />
+        <DotNetCliToolReference Include=""dotnet-xunit"" Version=""2.3.1"" />
+    </ItemGroup>
+               
+    <ItemGroup>
+        <ProjectReference Include=""..\ExampleProject\ExampleProject.csproj"" />
+    </ItemGroup>
+                
+</Project>";
+            
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { Path.Combine(_filesystemRoot, "ExampleProject", "ExampleProject.csproj"), new MockFileData(projectFile)},
+                { Path.Combine(_filesystemRoot, "ExampleProject\\ExampleProject2", "ExampleProject2.csproj"), new MockFileData(projectFile)},
+                { Path.Combine(_filesystemRoot, "ExampleProject", "Recursive.cs"), new MockFileData("content")}
+            });
+
+            var target = new InputFileResolver(fileSystem);
+
+            var actual = target.ScanProjectFile(Path.Combine(_filesystemRoot, "ExampleProject"));
+            
+            actual.ShouldBe("C:\\ExampleProject\\ExampleProject.csproj");
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 
 namespace Stryker.Core.Initialisation
@@ -141,7 +142,13 @@ namespace Stryker.Core.Initialisation
             _logger.LogTrace("Scanned the current directory for *.csproj files: found {0}", projectFiles);
             if (projectFiles.Count() > 1)
             {
-                throw new StrykerInputException("Expected exactly one .csproj file, found more than one. Please fix your project contents");
+                var sb = new StringBuilder();
+                sb.AppendLine("Expected exactly one .csproj file, found more than one:");
+                foreach (var file in projectFiles)
+                    sb.AppendLine(file);
+                sb.AppendLine();
+                sb.AppendLine("Please fix your project contents");
+                throw new StrykerInputException(sb.ToString());
             }
             else if (!projectFiles.Any())
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -145,7 +145,9 @@ namespace Stryker.Core.Initialisation
                 var sb = new StringBuilder();
                 sb.AppendLine("Expected exactly one .csproj file, found more than one:");
                 foreach (var file in projectFiles)
+                {
                     sb.AppendLine(file);
+                }
                 sb.AppendLine();
                 sb.AppendLine("Please fix your project contents");
                 throw new StrykerInputException(sb.ToString());

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -138,7 +138,7 @@ namespace Stryker.Core.Initialisation
 
         public string ScanProjectFile(string currentDirectory)
         {
-            var projectFiles = _fileSystem.Directory.GetFiles(currentDirectory, "*.csproj", SearchOption.AllDirectories);
+            var projectFiles = _fileSystem.Directory.GetFiles(currentDirectory, "*.csproj");
             _logger.LogTrace("Scanned the current directory for *.csproj files: found {0}", projectFiles);
             if (projectFiles.Count() > 1)
             {


### PR DESCRIPTION
Hi, just thought maybe this error formatting 
```
   _____ _              _               _   _ ______ _______
  / ____| |            | |             | \ | |  ____|__   __|
 | (___ | |_ _ __ _   _| | _____ _ __  |  \| | |__     | |
  \___ \| __| '__| | | | |/ / _ \ '__| | . ` |  __|    | |
  ____) | |_| |  | |_| |   <  __/ |    | |\  | |____   | |
 |_____/ \__|_|   \__, |_|\_\___|_| (_)|_| \_|______|  |_|
                   __/ |
                  |___/


Version 0.9.0 (beta)

[21:19:14 INF] Time Elapsed 00:00:00.1008880
Stryker.NET failed to mutate your project. For more information see the logs below:

Expected exactly one .csproj file, found more than one:
/Users/robertlyson/projects/TestProject2/TestProject2/TestProject2.csproj
/Users/robertlyson/projects/TestProject2/TestProject2/published/TestProject2.csproj

Please fix your project contents
```
would be a good solution for https://github.com/stryker-mutator/stryker-net/issues/425.