### PR TITLE
chore(nuget): license

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
+++ b/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
@@ -16,7 +16,7 @@
     <Product>Mutation Testing</Product>
     <Description>The Stryker.NET CLI tool. Install this tool to run stryker from the commandline.</Description>
     <PackageProjectUrl>https://stryker-mutator.io/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/stryker-mutator/stryker-net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIconUrl>https://raw.githubusercontent.com/stryker-mutator/stryker/master/stryker-80x80.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/stryker-mutator/stryker-net</RepositoryUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -33,5 +33,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Stryker.Core\Stryker.Core\Stryker.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\LICENS*" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -14,7 +14,7 @@
 	<PackageId>stryker</PackageId>
 	<Description>All stryker mutation test logic is contained in this library. This package does not include a runner. Use this package if you want to extend stryker with your own runner.</Description>
 	<PackageProjectUrl>https://stryker-mutator.io/</PackageProjectUrl>
-	<PackageLicenseUrl>https://github.com/stryker-mutator/stryker-net/blob/master/LICENSE</PackageLicenseUrl>
+	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	<PackageIconUrl>https://raw.githubusercontent.com/stryker-mutator/stryker/master/stryker-80x80.png</PackageIconUrl>
 	<RepositoryUrl>https://github.com/stryker-mutator/stryker-net</RepositoryUrl>
   </PropertyGroup>
@@ -54,4 +54,8 @@
 	<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
 	<PackageReference Include="System.IO.Abstractions" Version="3.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\..\LICENS*" Pack="true" PackagePath="" />
+	</ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -54,8 +54,8 @@
 	<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
 	<PackageReference Include="System.IO.Abstractions" Version="3.1.1" />
   </ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\..\..\LICENS*" Pack="true" PackagePath="" />
-	</ItemGroup>
+	
+  <ItemGroup>
+	  <None Include="..\..\..\LICENS*" Pack="true" PackagePath="" />
+  </ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -14,7 +14,7 @@
 	<PackageId>stryker</PackageId>
 	<Description>All stryker mutation test logic is contained in this library. This package does not include a runner. Use this package if you want to extend stryker with your own runner.</Description>
 	<PackageProjectUrl>https://stryker-mutator.io/</PackageProjectUrl>
-	  <PackageLicenseFile>LICENSE</PackageLicenseFile>
+	<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	<PackageIconUrl>https://raw.githubusercontent.com/stryker-mutator/stryker/master/stryker-80x80.png</PackageIconUrl>
 	<RepositoryUrl>https://github.com/stryker-mutator/stryker-net</RepositoryUrl>
   </PropertyGroup>


### PR DESCRIPTION
Hi 👋,

PR to address https://github.com/stryker-mutator/stryker-net/issues/410.

At a first glance this looks a little bit clumsy(LICENS*)
```
  <ItemGroup>
    <None Include="..\..\..\LICENS*" Pack="true" PackagePath="" />
  </ItemGroup>
```
but this is a work around for [known issue](https://github.com/NuGet/Home/issues/7601) allowing you to include license file which doesn't have an extension.