### PR TITLE
build(deps): bump System.IO.Abstractions from 3.1.1 to 4.0.11

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="3.1.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="4.0.11" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -52,7 +52,7 @@
 	<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
 	<PackageReference Include="Serilog.Extensions.Logging.File" Version="1.1.0" />
 	<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-	<PackageReference Include="System.IO.Abstractions" Version="3.1.1" />
+	<PackageReference Include="System.IO.Abstractions" Version="4.0.11" />
   </ItemGroup>
 	
   <ItemGroup>


### PR DESCRIPTION
Fixes #436.

Updated System.IO.Abstractions to 4.0.11 but all tests were passing locally, so this is something different from #431 #432 #433.
Creating this MR to see how it looks like in CI.