### PR TITLE
feat(mutations): negate mutator

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Shouldly;
 using Stryker.Core.Mutants;
@@ -73,6 +74,20 @@ namespace Stryker.Core.UnitTest.Mutants
             var result = _target.Mutate(tree.GetRoot());
 
             _target.GetLatestMutantBatch().Count().ShouldBe(numberOfMutations);
+        }
+
+        [Theory]
+        [InlineData("Mutator_IfStatementWithoutMutation_IN.cs", "Mutator_IfStatementWithoutMutation_OUT.cs")]
+        public void NegateIfStatementWhenNoMutationFound(string inputFile, string outputFile)
+        {
+            string source = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + inputFile);
+            string expected = File.ReadAllText(_currentDirectory + "/Mutants/TestResources/" + outputFile);
+
+            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
+
+            actualNode.ShouldBeSemantically(expectedNode);
+            actualNode.ShouldNotContainErrors();
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementWithoutMutation_IN.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementWithoutMutation_IN.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StrykerNet.UnitTest.Mutants.TestResources
+{
+    public class TestClass
+    {
+        void TestMethod()
+        {
+            string str = "test";
+            if (str.Contains("t"))
+            {
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementWithoutMutation_OUT.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/TestResources/Mutator_IfStatementWithoutMutation_OUT.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StrykerNet.UnitTest.Mutants.TestResources
+{
+    public class TestClass
+    {
+        void TestMethod()
+        {
+            string str = "test";
+            if (!str.Contains("t"))
+            {
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -19,6 +19,8 @@
     <Compile Remove="Mutants\TestResources\Mutator_SyntaxShouldBe_IfStatement_IN.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_SyntaxShouldBe_IfStatement_OUT.cs" />
     <Compile Remove="Mutants\TestResources\Mutator_TwoMutationsInOneStatmentShouldBeMade.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_IfStatementWithoutMutation_IN.cs" />
+    <Compile Remove="Mutants\TestResources\Mutator_IfStatementWithoutMutation_OUT.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResources\StrongNameKeyFile.snk" />
@@ -26,6 +28,12 @@
   <ItemGroup>
     <Content Include="TestResources\StrongNameKeyFile.snk">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_IfStatementWithoutMutation_IN.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Mutants\TestResources\Mutator_IfStatementWithoutMutation_OUT.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -8,6 +8,7 @@ using Stryker.Core.Mutators;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Stryker.Core.Mutants
 {
@@ -161,8 +162,16 @@ namespace Stryker.Core.Mutants
 
             if (!ifStatement.Condition.ContainsDeclarations())
             {
+                var mutation = MutateExpressions(ifStatement.Condition);
+                var mutationFound = mutation == ifStatement.Condition;
+
+                if (!mutationFound)
+                {
+                    return ifStatement.WithCondition(SyntaxFactory.ParseExpression($"!{ifStatement.Condition}"));
+                }
+
                 mutatedIf = mutatedIf.ReplaceNode(mutatedIf.GetCurrentNode(ifStatement.Condition),
-                    MutateExpressions(ifStatement.Condition));
+                    mutation);
             }
 
             if (ifStatement.Else != null)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -163,7 +163,7 @@ namespace Stryker.Core.Mutants
             if (!ifStatement.Condition.ContainsDeclarations())
             {
                 var mutation = MutateExpressions(ifStatement.Condition);
-                var mutationFound = mutation == ifStatement.Condition;
+                var mutationFound = !SyntaxFactory.AreEquivalent(mutation, ifStatement.Condition);
 
                 if (!mutationFound)
                 {


### PR DESCRIPTION
PR for https://github.com/stryker-mutator/stryker-net/issues/444.
Based on suggestion made by @dupdob(https://github.com/stryker-mutator/stryker-net/issues/444#issuecomment-480286555).

Craeting nagated if condition looks a little bit odd right now
`SyntaxFactory.ParseExpression($"!{ifStatement.Condition}");`
but I couldn't find any better way to express `!` with Roslyn. Maybe you guys will come up with something better :)