### PR TITLE
feat(rollback mutations): Recompile 100 times

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
@@ -124,7 +124,7 @@ namespace ExampleProject
                 Should.Throw<ApplicationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
             }
             rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()),
-                Times.Exactly(2));
+                Times.AtLeast(2));
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -63,15 +63,15 @@ namespace Stryker.Core.Compiling
             // first try compiling
             var emitResult = compiler.Emit(ms, manifestResources: analyzerResult.Resources);
 
+            // compilation did not succeed, rollbacking failed mutations
             if (!emitResult.Success)
             {
-                // second try compiling
                 (rollbackProcessResult, emitResult) = RetryCompilation(ms, compiler, emitResult, devMode);
             }
 
-            if (!emitResult.Success)
+            // compilation still did not succeed. let's compile a couple times more for good measure
+            for (var count = 0; !emitResult.Success && count < 100; count++)
             {
-                // third try compiling
                 (rollbackProcessResult, emitResult) = RetryCompilation(ms, rollbackProcessResult.Compilation, emitResult, devMode);
             }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -63,16 +63,18 @@ namespace Stryker.Core.Compiling
             // first try compiling
             var emitResult = compiler.Emit(ms, manifestResources: analyzerResult.Resources);
 
+            var retryCount = 0;
             // compilation did not succeed, rollbacking failed mutations
             if (!emitResult.Success)
             {
-                (rollbackProcessResult, emitResult) = RetryCompilation(ms, compiler, emitResult, devMode);
+                retryCount = 1;
+                (rollbackProcessResult, emitResult, retryCount) = RetryCompilation(ms, compiler, emitResult, devMode, retryCount);
             }
 
             // compilation still did not succeed. let's compile a couple times more for good measure
             for (var count = 0; !emitResult.Success && count < 100; count++)
             {
-                (rollbackProcessResult, emitResult) = RetryCompilation(ms, rollbackProcessResult.Compilation, emitResult, devMode);
+                (rollbackProcessResult, emitResult, retryCount) = RetryCompilation(ms, rollbackProcessResult.Compilation, emitResult, devMode, retryCount);
             }
 
             LogEmitResult(emitResult);
@@ -93,10 +95,11 @@ namespace Stryker.Core.Compiling
             };
         }
 
-        private (RollbackProcessResult, EmitResult) RetryCompilation(MemoryStream ms,
+        private (RollbackProcessResult, EmitResult, int) RetryCompilation(MemoryStream ms,
             CSharpCompilation compilation,
             EmitResult previousEmitResult,
-            bool devMode)
+            bool devMode,
+            int retryCount)
         {
             LogEmitResult(previousEmitResult);
             // remove broken mutations
@@ -105,9 +108,10 @@ namespace Stryker.Core.Compiling
             // reset the memoryStream for the second compilation
             ms.SetLength(0);
 
-            // second try compiling
+            _logger.LogDebug($"Retrying compilation for {retryCount}{FirstSecondThird(retryCount)} time.");
+
             var emitResult = rollbackProcessResult.Compilation.Emit(ms, manifestResources: _input.ProjectInfo.ProjectUnderTestAnalyzerResult.Resources);
-            return (rollbackProcessResult, emitResult);
+            return (rollbackProcessResult, emitResult, ++retryCount);
         }
 
         private void LogEmitResult(EmitResult result)
@@ -125,6 +129,15 @@ namespace Stryker.Core.Compiling
             {
                 _logger.LogDebug("Compilation successful");
             }
+        }
+
+        private string FirstSecondThird(int number)
+        {
+            return
+                number > 3 ? "th" :
+                number == 3 ? "rd" :
+                number == 2 ? "nd" :
+                "st";
         }
     }
 }


### PR DESCRIPTION
The CompilingProcess has a hard-coded three retries to fix any
compiler errors that are fixed by recompiling. Instead, loop until
the recompile works, or until the recompile fails 100 times in a row.

Thanks to @Mobrockers for the assistance in with the variable
names to properly run the recompile.

Resolves one issue for #462.