### PR TITLE
fix(reporter names): Improve reporter names

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -64,7 +64,7 @@ During a mutation testrun one or more reporters can be enabled. A reporter will 
 dotnet stryker --reporters "['html', 'progress']"
 ```
 
-You can find a list of all available reporters and what output they product in the reporters section
+You can find a list of all available reporters and what output they product in the [reporter docs](/Reporters.md)
 
 Default: `"['cleartext', 'progress']"`
 
@@ -157,7 +157,7 @@ Example config file:
         "test-runner": "vstest",
         "reporters": [
             "progress",
-            "cleartext"
+            "html"
         ],
         "log-level": "info",
         "log-file":true,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -64,7 +64,7 @@ During a mutation testrun one or more reporters can be enabled. A reporter will 
 dotnet stryker --reporters "['html', 'progress']"
 ```
 
-You can find a list of all available reporters and what output they product in the [reporter docs](/Reporters.md)
+You can find a list of all available reporters and what output they product in the [reporter docs](/docs/Reporters.md)
 
 Default: `"['cleartext', 'progress']"`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,12 +61,12 @@ Default: `"30000"`
 During a mutation testrun one or more reporters can be enabled. A reporter will produce some kind of output during or after the mutation testrun.
 
 ```
-dotnet stryker --reporters "['Html', 'ConsoleProgressBar']"
+dotnet stryker --reporters "['html', 'progress']"
 ```
 
 You can find a list of all available reporters and what output they product in the reporters section
 
-Default: `"['ConsoleReport', 'ConsoleProgressBar']"`
+Default: `"['cleartext', 'progress']"`
 
 ## Logging to console
 To gain more insight in what Stryker does during a mutation testrun you can lower your loglevel.
@@ -156,8 +156,8 @@ Example config file:
     {
         "test-runner": "vstest",
         "reporters": [
-            "ConsoleProgressBar",
-            "ConsoleReport"
+            "progress",
+            "cleartext"
         ],
         "log-level": "info",
         "log-file":true,

--- a/docs/Reporters.md
+++ b/docs/Reporters.md
@@ -11,7 +11,7 @@ Stryker supports a variety of reporters. Enabled reporters will be activated dur
 The default reporters are:
 
 ```
-dotnet stryker --reporters "['ConsoleReport', 'ConsoleProgressBar']"
+dotnet stryker --reporters "['cleartext', 'progress']"
 ```
 
 ## Html reporter
@@ -29,7 +29,7 @@ Example:
 Stryker.NET default report. It displays all mutations right after the mutation testrun is done. Ideal for a quick run, as it leaves no file on your system.
 
 ```
-dotnet stryker --reporters "['ConsoleReport']"
+dotnet stryker --reporters "['cleartext']"
 ```
 
 Example:
@@ -42,7 +42,7 @@ Example:
 This reporter outputs the current status of the mutation testrun. It has a nice visual look so you can quickly see the progress. We recomend to use this reporter on large projects. It also shows an indication of the estimated time for Stryker.NET to complete.
 
 ```
-dotnet stryker --reporters "['ConsoleProgressBar']"
+dotnet stryker --reporters "['progress']"
 ```
 Example:
 
@@ -53,7 +53,7 @@ Example:
 A basic reporter do display the progress of the mutationtest run. It indicates very simple how many mutants have been tested and their status. This is ideal to use on build servers, as it has little/no performance loss while still giving insight.
 
 ```
-dotnet stryker --reporters "['ConsoleProgressDots']"
+dotnet stryker --reporters "['dots']"
 ```
 Example:
 
@@ -66,5 +66,5 @@ Where `"."` means killed, `"S"` means survived and `"T"` means timed out.
 This reporter outputs a json file with all mutation testrun info of the last run. The json is also used for the HTML reporter, but using this reporter you could use the file for your own purposes.
 
 ```
-dotnet stryker --reporters "['Json']"
+dotnet stryker --reporters "['json']"
 ```

--- a/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
@@ -1,9 +1,11 @@
-﻿using Stryker.Core.Options;
+﻿using Microsoft.Extensions.CommandLineUtils;
+using Stryker.Core.Options;
 using Stryker.Core.Reporters;
 using Stryker.Core.TestRunners;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Stryker.CLI
 {
@@ -23,8 +25,8 @@ namespace Stryker.CLI
         {
             ArgumentName = "--reporters",
             ArgumentShortName = "-r <reporters>",
-            ArgumentDescription = $@"Sets the reporter | { FormatOptionsString(_defaultOptions.Reporters.First(), (IEnumerable<Reporter>)Enum.GetValues(_defaultOptions.Reporters.First().GetType())) }]
-                                                This argument takes a json array as a value. Example: ['{ Reporter.ConsoleProgressDots }', '{ Reporter.Html }']",
+            ArgumentDescription = $@"Sets the reporter | { FormatOptionsString(_defaultOptions.Reporters, (IEnumerable<Reporter>)Enum.GetValues(typeof(Reporter)), new List<Reporter> { Reporter.ConsoleProgressBar, Reporter.ConsoleProgressDots, Reporter.ConsoleReport }) }]
+                                                This argument takes a json array as a value. Example: ['{ Reporter.Progress }', '{ Reporter.Html }']",
             DefaultValue = _defaultOptions.Reporters.Select(r => r.ToString()).ToArray(),
             JsonKey = "reporters"
         };
@@ -44,7 +46,7 @@ namespace Stryker.CLI
             ArgumentShortName = "-f",
             ArgumentDescription = "Makes the logger write to a file",
             DefaultValue = _defaultOptions.LogOptions.LogToFile,
-            ValueType = Microsoft.Extensions.CommandLineUtils.CommandOptionType.NoValue,
+            ValueType = CommandOptionType.NoValue,
             JsonKey = "log-file"
         };
 
@@ -55,7 +57,7 @@ namespace Stryker.CLI
             ArgumentDescription = @"Stryker automatically removes all mutations from a method if a failed mutation could not be rolled back
                                                 Setting this flag makes stryker not remove the mutations but rather break on failed rollbacks",
             DefaultValue = _defaultOptions.DevMode,
-            ValueType = Microsoft.Extensions.CommandLineUtils.CommandOptionType.NoValue,
+            ValueType = CommandOptionType.NoValue,
             JsonKey = "dev-mode"
         };
 
@@ -153,14 +155,41 @@ namespace Stryker.CLI
         {
             ArgumentName = "--test-runner",
             ArgumentShortName = "-tr",
-            ArgumentDescription = $"Choose which testrunner should be used to run your tests. | { FormatOptionsString(_defaultOptions.TestRunner, (IEnumerable<TestRunner>)Enum.GetValues(_defaultOptions.TestRunner.GetType())) }",
+            ArgumentDescription = $"Choose which testrunner should be used to run your tests. | { FormatOptionsString<TestRunner>(_defaultOptions.TestRunner, (IEnumerable<TestRunner>)Enum.GetValues(_defaultOptions.TestRunner.GetType())) }",
             DefaultValue = _defaultOptions.TestRunner.ToString(),
             JsonKey = "test-runner"
         };
 
         private static string FormatOptionsString<T>(T @default, IEnumerable<T> options)
         {
-            return $"Options[{@default.ToString()} (default), {string.Join(",", options.Where(o => o.ToString() != @default.ToString()))}]";
+            return FormatOptionsString<T, T>(@default, options);
+        }
+
+        private static string FormatOptionsString<T, Y>(T @default, IEnumerable<Y> options)
+        {
+            return FormatOptionsString(new List<T> { @default }, options, new List<Y>());
+        }
+
+        private static string FormatOptionsString<T, Y>(IEnumerable<T> @default, IEnumerable<Y> options, IEnumerable<Y> deprecated)
+        {
+            StringBuilder optionsString = new StringBuilder();
+
+            optionsString.Append($"Options[(default) [{string.Join(", ", @default)}], ");
+            string nonDefaultOptions = string.Join(
+            ", ",
+            options
+            .Where(o => !@default.Any(d => d.ToString() == o.ToString()))
+            .Where(o => !deprecated.Any(d => d.ToString() == o.ToString())));
+
+            if(deprecated.Any())
+            {
+                string deprecatedOptions = "(deprecated) " + string.Join(", (deprecated) ", options.Where(o => deprecated.Any(d => d.ToString() == o.ToString())));
+                optionsString.Append(string.Join(", ", nonDefaultOptions, deprecatedOptions));
+            }
+            
+            optionsString.Append("]");
+
+            return optionsString.ToString();
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -88,7 +88,7 @@ namespace Stryker.Core.Options
         {
             if (reporters == null)
             {
-                foreach (var reporter in new[] { Reporter.ConsoleProgressBar, Reporter.ConsoleReport })
+                foreach (var reporter in new[] { Reporter.Progress, Reporter.ClearText })
                 {
                     yield return reporter;
                 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
@@ -3,8 +3,11 @@
     public enum Reporter
     {
         All,
+        Progress,
         ConsoleProgressBar,
+        Dots,
         ConsoleProgressDots,
+        ClearText,
         ConsoleReport,
         Json,
         Html


### PR DESCRIPTION
Reporter names ConsoleReport, ConsoleProgressBar, ConsoleProgressDots replaced with cleartext, progress, dots.
Deprecated old names in help text and warn user about new reporter names
Fix #503