### PR TITLE
Fix: coverage failing on net full framework

### DIFF
--- a/src/Stryker.DataCollector/Stryker.DataCollector/CommunicationServer.cs
+++ b/src/Stryker.DataCollector/Stryker.DataCollector/CommunicationServer.cs
@@ -26,7 +26,7 @@ namespace Stryker.DataCollector
 
         public CommunicationServer(string name)
         {
-            PipeName = $"StrykerPipe.{name}.{Process.GetCurrentProcess().Id}.{AppDomain.CurrentDomain.Id}:{Interlocked.Increment(ref _instanceCounter)}";
+            PipeName = $"Stryker{name}_{Process.GetCurrentProcess().Id}_{AppDomain.CurrentDomain.Id}_{Interlocked.Increment(ref _instanceCounter)}";
         }
 
         public void SetLogger(Action<string> logger)


### PR DESCRIPTION
This PR contains only the fix for the problem with code coverage capture and Net Full Framework.
The problem seems to be that the name built for the pipe looked like an URL and triggered some security checks that ultimately prevented the pipe to be created.