### PR TITLE
chore: Switch from Microsoft.Extensions.CommandLineUtils to McMaster.Extensions.CommandLineUtils

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/CLIOption.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOption.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
 
 namespace Stryker.CLI
 {

--- a/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
+using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.Options;
 using Stryker.Core.Reporters;
 using Stryker.Core.TestRunners;

--- a/src/Stryker.CLI/Stryker.CLI/OptionsBuilder.cs
+++ b/src/Stryker.CLI/Stryker.CLI/OptionsBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Stryker.Core.Exceptions;

--- a/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
+++ b/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
   </ItemGroup>
 

--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using Stryker.CLI.NuGet;
 using Stryker.Core;


### PR DESCRIPTION
Fixes #278 

This is basically an in-place switch as McMaster.Extensions.CommandLineUtils is a fork of Microsoft.Extensions.CommandLineUtils. No code has been changed yet.