### PR TITLE
feat(string mutator): Mutate string.Empty to string literal "Stryker was here!"

### DIFF
--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -102,10 +102,11 @@ Stryker supports a variety of mutators, which are listed below. Do you have a su
 | `Sum()`               | `Count()`             |
 | `Count()`             | `Sum()`               |
 
-## String Literals
+## String Literals and Constants
 | Original | Mutated |
 | ------------- | ------------- | 
 | `"foo"` | `""` |
-|  `""` | `"Stryker was here!"` |
+| `""` | `"Stryker was here!"` |
 | `$"foo {bar}"` | `$""` |
 | `@"foo"` | `@""` |
+| `string.Empty` | `"Stryker was here!"` |

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringEmptyMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringEmptyMutatorTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Stryker.Core.Mutators;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Mutators
+{
+    public class StringEmptyMutatorTests
+    {
+        [Fact]
+        public void ShouldMutateLowercaseString()
+        {
+            // Arrange
+            var node = SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.PredefinedType(
+                    SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                SyntaxFactory.IdentifierName("Empty"));
+            var mutator = new StringEmptyMutator();
+
+            // Act
+            var result = mutator.ApplyMutations(node).ToList();
+
+            // Assert
+            result.ShouldContain(
+                m => m.ReplacementNode is LiteralExpressionSyntax &&
+                     ((LiteralExpressionSyntax)m.ReplacementNode).Token.ValueText == "Stryker was here!");
+        }
+
+        [Fact]
+        public void ShouldNotMutateUppercaseString()
+        {
+            // Arrange
+            var node = SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName("String"),
+                SyntaxFactory.IdentifierName("Empty"));
+            var mutator = new StringEmptyMutator();
+
+            // Act
+            var result = mutator.ApplyMutations(node).ToList();
+
+            // Assert
+            result.ShouldNotContain(
+                m => m.ReplacementNode is LiteralExpressionSyntax &&
+                     ((LiteralExpressionSyntax)m.ReplacementNode).Token.ValueText == "Stryker was here!");
+        }
+
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -33,7 +33,7 @@ namespace Stryker.Core.Mutants
         private ILogger _logger { get; set; }
 
         private static readonly Type[] expressionStatementNeedingIf = { typeof(AssignmentExpressionSyntax), typeof(PostfixUnaryExpressionSyntax), typeof(PrefixUnaryExpressionSyntax)};
-        
+
         /// <param name="mutators">The mutators that should be active during the mutation process</param>
         public MutantOrchestrator(IEnumerable<IMutator> mutators = null)
         {
@@ -48,6 +48,7 @@ namespace Stryker.Core.Mutants
                     new CheckedMutator(),
                     new LinqMutator(),
                     new StringMutator(),
+                    new StringEmptyMutator(),
                     new InterpolatedStringMutator(),
                     new NegateConditionMutator(),
                 };

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringEmptyMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringEmptyMutator.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Mutants;
+
+namespace Stryker.Core.Mutators
+{
+    /// <summary>
+    /// Mutator that will mutate the access to <c>string.Empty</c> to a string that is not empty.
+    /// </summary>
+    /// <remarks>
+    /// Will only apply the mutation to the lowercase <c>string</c> since that is a reserved keyword in c# and can be distinguished from any variable or member access.
+    /// </remarks>
+    public class StringEmptyMutator : MutatorBase<MemberAccessExpressionSyntax>, IMutator
+    {
+        /// <inheritdoc />
+        public override IEnumerable<Mutation> ApplyMutations(MemberAccessExpressionSyntax node)
+        {
+            if (node.Expression is PredefinedTypeSyntax typeSyntax &&
+                typeSyntax.Keyword.ValueText == "string" &&
+                node.Name.Identifier.ValueText == nameof(string.Empty))
+            {
+                yield return new Mutation
+                {
+                    OriginalNode = node,
+                    ReplacementNode =
+                        SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                            SyntaxFactory.Literal("Stryker was here!")),
+                    DisplayName = @"String mutation",
+                    Type = Mutator.String
+                };
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -144,7 +144,7 @@ namespace Stryker.Core.TestRunners.VsTest
             var testResults = RunAllTests(testCases, envVars, GenerateRunSettings(timeoutMs, false), false);
 
             // For now we need to throw an OperationCanceledException when a testrun has timed out. 
-            // We know the testrun has timed out because we received less test results from the test run than there are test cases in the unit test project.
+            // We know the test run has timed out because we received less test results from the test run than there are test cases in the unit test project.
             var resultAsArray = testResults as TestResult[] ?? testResults.ToArray();
             if (resultAsArray.All(x => x.Outcome != TestOutcome.Failed) && resultAsArray.Count() < (testCases ?? _discoveredTests).Count())
             {


### PR DESCRIPTION
Added a mutator that mutates the member access to `string.Empty` to a string literal that is not empty (`"Stryker was here!"`).

This resolves #641.