### PR TITLE
fix: Dont fail compiling on warning diagnostics

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
@@ -3,9 +3,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Moq;
 using Shouldly;
 using Stryker.Core.Compiling;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.MutationTest;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
@@ -121,7 +121,7 @@ namespace ExampleProject
 
             using (var ms = new MemoryStream())
             {
-                Should.Throw<ApplicationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
+                Should.Throw<StrykerCompilationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
             }
             rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()),
                 Times.AtLeast(2));
@@ -286,7 +286,7 @@ namespace ExampleProject
 
             using (var ms = new MemoryStream())
             {
-                Should.Throw<ApplicationException>(()=> target.Compile(new Collection<SyntaxTree>() {syntaxTree}, ms, false));
+                Should.Throw<StrykerCompilationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -2,10 +2,10 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.Extensions.Logging;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Logging;
 using Stryker.Core.MutationTest;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -29,9 +29,9 @@ namespace Stryker.Core.Compiling
     /// </summary>
     public class CompilingProcess : ICompilingProcess
     {
-        private MutationTestInput _input { get; set; }
-        private IRollbackProcess _rollbackProcess { get; set; }
-        private ILogger _logger { get; set; }
+        private readonly MutationTestInput _input;
+        private readonly IRollbackProcess _rollbackProcess;
+        private readonly ILogger _logger;
 
         public CompilingProcess(MutationTestInput input,
             IRollbackProcess rollbackProcess)
@@ -74,7 +74,7 @@ namespace Stryker.Core.Compiling
             {
                 _logger.LogError("Failed to build the mutated assembly due to unrecoverable error: {0}",
                     emitResult.Diagnostics.First(diag => diag.Location == Location.None && diag.Severity == DiagnosticSeverity.Error));
-                throw new ApplicationException("General Build Failure detected.");
+                throw new StrykerCompilationException("General Build Failure detected.");
             }
 
             for (var count = 1; !emitResult.Success && count < 50; count++)
@@ -91,7 +91,7 @@ namespace Stryker.Core.Compiling
                 {
                     _logger.LogWarning($"{emitResultDiagnostic}");
                 }
-                throw new ApplicationException("Failed to restore build able state.");
+                throw new StrykerCompilationException("Failed to restore build able state.");
             }
             return new CompilingProcessResult()
             {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -68,11 +68,13 @@ namespace Stryker.Core.Compiling
             EmitResult emitResult;
             var retryCount = 1;
             (rollbackProcessResult, emitResult, retryCount) = TryCompilation(ms, compilation, null, devMode, retryCount);
-            if (!emitResult.Success && emitResult.Diagnostics.Any(diag => diag.Location == Location.None))
+
+            // If compiling failed and the diagnostics failure is not a warning, log and throw exception
+            if (!emitResult.Success && !emitResult.Diagnostics.First(diag => diag.Location == Location.None).ToString().StartsWith("warning"))
             {
-                _logger.LogError("Failed to build the mutated assembly due to unrecoverable error :{0}", 
+                _logger.LogError("Failed to build the mutated assembly due to unrecoverable error: {0}",
                     emitResult.Diagnostics.First(diag => diag.Location == Location.None));
-                throw new ApplicationException("General build failure.");
+                throw new ApplicationException("General Build Failure detected.");
             }
 
             for (var count = 1; !emitResult.Success && count < 50; count++)

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -70,11 +70,14 @@ namespace Stryker.Core.Compiling
             (rollbackProcessResult, emitResult, retryCount) = TryCompilation(ms, compilation, null, devMode, retryCount);
 
             // If compiling failed and the diagnostics failure is not a warning, log and throw exception
-            if (!emitResult.Success && !emitResult.Diagnostics.First(diag => diag.Location == Location.None).ToString().StartsWith("warning"))
+            if (!emitResult.Success && emitResult.Diagnostics.Any(diag => diag.Location == Location.None))
             {
-                _logger.LogError("Failed to build the mutated assembly due to unrecoverable error: {0}",
-                    emitResult.Diagnostics.First(diag => diag.Location == Location.None));
-                throw new ApplicationException("General Build Failure detected.");
+                if (!emitResult.Diagnostics.First(diag => diag.Location == Location.None).ToString().StartsWith("warning"))
+                {
+                    _logger.LogError("Failed to build the mutated assembly due to unrecoverable error: {0}",
+                        emitResult.Diagnostics.First(diag => diag.Location == Location.None));
+                    throw new ApplicationException("General Build Failure detected.");
+                }
             }
 
             for (var count = 1; !emitResult.Success && count < 50; count++)

--- a/src/Stryker.Core/Stryker.Core/Exceptions/StrykerCompilationException.cs
+++ b/src/Stryker.Core/Stryker.Core/Exceptions/StrykerCompilationException.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Text;
+
+namespace Stryker.Core.Exceptions
+{
+    /// <summary>
+    /// Represents errors which are related to roslyn compilation errors that we cannot fix, 
+    /// but the user might also might not be able to fix
+    /// </summary>
+    public class StrykerCompilationException : Exception
+    {
+        public string Details { get; }
+
+        public StrykerCompilationException(string message)
+            : base(message)
+        {
+        }
+
+        public StrykerCompilationException(string message, string details) : base(message)
+        {
+            Details = details;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine();
+            builder.AppendLine();
+            builder.AppendLine(Message);
+            builder.AppendLine();
+            if (!string.IsNullOrEmpty(Details))
+            {
+                builder.AppendLine(Details);
+            }
+            return builder.ToString();
+        }
+
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Exceptions/StrykerCompilationException.cs
+++ b/src/Stryker.Core/Stryker.Core/Exceptions/StrykerCompilationException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Stryker.Core.Exceptions
@@ -7,19 +8,34 @@ namespace Stryker.Core.Exceptions
     /// Represents errors which are related to roslyn compilation errors that we cannot fix, 
     /// but the user might also might not be able to fix
     /// </summary>
+    [Serializable]
     public class StrykerCompilationException : Exception
     {
-        public string Details { get; }
+        public StrykerCompilationException()
+            : base()
+        {
+        }
 
         public StrykerCompilationException(string message)
             : base(message)
         {
         }
 
-        public StrykerCompilationException(string message, string details) : base(message)
+        public StrykerCompilationException(string message, string details)
+            : base(message)
         {
             Details = details;
         }
+
+        public StrykerCompilationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected StrykerCompilationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        public string Details { get; }
 
         public override string ToString()
         {


### PR DESCRIPTION
Stryker failed to compile but also had a warning diagnostics error with location None. This warning was not the cause of the compilation failure. Stryker should not fail on warning diagnostics.