### PR TITLE
feat(sharp8.0 nullable): Compile with c# 8 nullable feature enabled

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/stryker-config.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/stryker-config.json
@@ -9,8 +9,8 @@
         ],
         "log-level": "info",
         "timeout-ms": 20000,
-        "files-to-exclude": [
-            "./Testing/"
+        "mutate": [
+            "!/Testing/"
         ],
         "excluded-mutations": [
             "string"

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcess.cs
@@ -59,7 +59,8 @@ namespace Stryker.Core.Compiling
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
                                                       allowUnsafe: true,
                                                       cryptoKeyFile: analyzerResult.SignAssembly ? analyzerResult.AssemblyOriginatorKeyFile : null,
-                                                      strongNameProvider: analyzerResult.SignAssembly ? new DesktopStrongNameProvider() : null),
+                                                      strongNameProvider: analyzerResult.SignAssembly ? new DesktopStrongNameProvider() : null,
+                                                      nullableContextOptions: NullableContextOptions.Enable),
                 references: _input.AssemblyReferences);
 
             RollbackProcessResult rollbackProcessResult;


### PR DESCRIPTION
fixes #716 

Nullable context is a C# 8 feature that has to be anabled in the compiler. On older project this produces a lot of warnings but should not produce any errors. As Stryker only looks at errors this should run fine.