### PR TITLE
fix(vstest): Correctly determine targetframework for vstest configuration

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -64,7 +64,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var test = new ProjectAnalyzerResult(null, null)
             {
                 ProjectReferences = new List<string> { projectUnderTestPath },
-                TargetFrameworkString = version,
+                TargetFrameworkVersionString = version,
                 ProjectFilePath = alternateTestProjectPath,
                 References = new[] { "" }
             };
@@ -90,7 +90,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "" }
                 });
@@ -98,7 +98,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath
                 });
             var target = new InputFileResolver(fileSystem, projectFileReaderMock.Object);
@@ -128,7 +128,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = alternateTestProjectPath,
                     References = new string[] { "" }
                 });
@@ -136,7 +136,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "" }
                 });
@@ -144,7 +144,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath
                 });
             var target = new InputFileResolver(fileSystem, projectFileReaderMock.Object);
@@ -201,7 +201,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     Properties = new Dictionary<string, string>(),
                     References = new string[] { "" }
@@ -210,7 +210,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>()
                 });
@@ -257,7 +257,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     Properties = new Dictionary<string, string>(),
                     References = new string[] { "" }
@@ -266,7 +266,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>()
                 });
@@ -338,7 +338,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     Properties = new Dictionary<string, string>(),
                     References = new string[] { "" }
@@ -347,7 +347,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>(),
                 });
@@ -396,7 +396,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     Properties = new Dictionary<string, string>(),
                 });
@@ -404,7 +404,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>(),
                 });
@@ -456,7 +456,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "" }
                 });
@@ -464,7 +464,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>()
                     {
@@ -522,14 +522,14 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                 });
             projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null))
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath,
                     Properties = new Dictionary<string, string>(),
                 });
@@ -559,7 +559,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "" }
                 });
@@ -583,7 +583,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath
                 });
             var target = new InputFileResolver(fileSystem, projectFileReaderMock.Object);
@@ -606,7 +606,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "netcore2.1",
+                    TargetFrameworkVersionString = "netcore2.1",
                     ProjectFilePath = testProjectPath
                 });
             var target = new InputFileResolver(fileSystem, projectFileReaderMock.Object);
@@ -718,7 +718,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "Microsoft.VisualStudio.QualityTools.UnitTestFramework" }
                 });
@@ -743,7 +743,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     Properties = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { "IsTestProject", "true" } }),
                     References = new string[] { "" }
@@ -773,7 +773,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "net4.5",
+                    TargetFrameworkVersionString = "net4.5",
                     ProjectFilePath = testProjectPath,
                     Properties = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()),
                     References = new string[] { "" }
@@ -802,7 +802,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { "" },
-                    TargetFrameworkString = "net4.5",
+                    TargetFrameworkVersionString = "net4.5",
                     ProjectFilePath = testProjectPath,
                     Properties = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { "IsTestProject", "false" } }),
                     References = new string[0]
@@ -836,7 +836,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>() { projectUnderTestPath },
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = testProjectPath,
                     References = new string[] { "" }
                 });
@@ -844,7 +844,7 @@ Please specify a test project name filter that results in one project.
                 .Returns(new ProjectAnalyzerResult(null, null)
                 {
                     ProjectReferences = new List<string>(),
-                    TargetFrameworkString = "netcoreapp2.1",
+                    TargetFrameworkVersionString = "netcoreapp2.1",
                     ProjectFilePath = projectUnderTestPath
                 });
             var target = new InputFileResolver(fileSystem, projectFileReaderMock.Object);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersShould.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersShould.cs
@@ -66,12 +66,12 @@ namespace Stryker.Core.UnitTest.TestRunners
                 TestProjectAnalyzerResult = new ProjectAnalyzerResult(null, null)
                 {
                     AssemblyPath = _testAssemblyPath,
-                    TargetFrameworkString = "toto"
+                    TargetFrameworkVersionString = "toto"
                 },
                 ProjectUnderTestAnalyzerResult = new ProjectAnalyzerResult(null, null)
                 {
                     AssemblyPath = Path.Combine(filesystemRoot, "app", "bin", "Debug", "AppToTest.dll"),
-                    TargetFrameworkString = "toto"
+                    TargetFrameworkVersionString = "toto"
                 }
             };
             _fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -76,15 +76,31 @@ namespace Stryker.Core.Initialisation
             set => _properties = value;
         }
 
-        private string _targetFrameworkString;
+        private string _targetFrameworkVersionString;
 
-        public string TargetFrameworkString
+        /// <summary>
+        /// Reads the TargetFramework MSBuild property which includes the target framework and the target framework version
+        /// </summary>
+        /// <value>
+        /// The TargetFramework MSBuild property including the target framework. Example: netcoreapp3.0
+        /// </value>
+        public string TargetFrameworkVersionString
         {
-            get => _targetFrameworkString ?? _analyzerResult?.TargetFramework;
-            set => _targetFrameworkString = value;
+            get => _targetFrameworkVersionString ?? _analyzerResult?.TargetFramework;
+            set => _targetFrameworkVersionString = value;
         }
 
         private Framework _targetFramework = Framework.Unknown;
+
+        /// <summary>
+        /// Extracts a target <c>Framework</c> from the MSBuild property TargetFramework
+        /// </summary>
+        /// <value>
+        /// The target <c>Framework</c> of the project
+        /// </value>
+        /// <example>
+        /// Framework.NetClassic
+        /// </example>
         public Framework TargetFramework
         {
             get => _targetFramework == Framework.Unknown ? TargetFrameworkAndVersion.framework : _targetFramework;
@@ -93,6 +109,15 @@ namespace Stryker.Core.Initialisation
 
         private Version _targetFrameworkVersion;
 
+        /// <summary>
+        /// Extracts a target <c>Version</c> from the MSBuild property TargetFramework
+        /// </summary>
+        /// <value>
+        /// The <c>Version</c> of the target framework
+        /// </value>
+        /// <example>
+        /// 3.0
+        /// </example>
         public Version TargetFrameworkVersion
         {
             get => _targetFrameworkVersion ?? TargetFrameworkAndVersion.version;
@@ -197,6 +222,15 @@ namespace Stryker.Core.Initialisation
             set => _resources = value;
         }
 
+        /// <summary>
+        /// Extracts a target <c>Framework</c> and <c>Version</c> from the MSBuild property TargetFramework
+        /// </summary>
+        /// <returns>
+        /// A tuple of <c>Framework</c> and <c>Version</c> which together form the target framework and framework version of the project.
+        /// </returns>
+        /// <example>
+        /// <c>(Framework.NetCore, 3.0)</c>
+        /// </example>
         public (Framework framework, Version version) TargetFrameworkAndVersion
         {
             get
@@ -207,7 +241,7 @@ namespace Stryker.Core.Initialisation
                     ["netstandard"] = Framework.NetStandard,
                     ["net"] = Framework.NetClassic
                 };
-                var analysis = Regex.Match(TargetFrameworkString ?? string.Empty, "(?<kind>\\D+)(?<version>[\\d\\.]+)");
+                var analysis = Regex.Match(TargetFrameworkVersionString ?? string.Empty, "(?<kind>\\D+)(?<version>[\\d\\.]+)");
                 if (analysis.Success && label.ContainsKey(analysis.Groups["kind"].Value))
                 {
                     var version = analysis.Groups["version"].Value;

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -339,12 +339,12 @@ namespace Stryker.Core.TestRunners.VsTest
             switch (targetFramework)
             {
                 case Initialisation.Framework.NetCore:
-                    targetFrameworkVersionString = $".NETCoreApp,Version = v{_projectInfo.TestProjectAnalyzerResult.TargetFrameworkString}";
+                    targetFrameworkVersionString = $".NETCoreApp,Version = v{_projectInfo.TestProjectAnalyzerResult.TargetFrameworkVersion}";
                     break;
                 case Initialisation.Framework.NetStandard:
                     throw new StrykerInputException("Unsupported targetframework detected. A unit test project cannot be netstandard!: " + targetFramework);
                 default:
-                    targetFrameworkVersionString = $".NETFramework,Version = v{_projectInfo.TestProjectAnalyzerResult.TargetFrameworkString}";
+                    targetFrameworkVersionString = $".NETFramework,Version = v{_projectInfo.TestProjectAnalyzerResult.TargetFrameworkVersion}";
                     break;
             }
 


### PR DESCRIPTION
Fix #821 