### PR TITLE
fix(targetframeworkversion extraction): Correctly extract aggregated framework versions

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
@@ -40,7 +40,7 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var result = _target.InitialTest(testRunnerMock.Object);
 
-            result.ShouldBeInRange(1, 30, "This test contains a Thread.Sleep to simulate time passing as this test is testing that a stopwatch is used correctly to measure time.\n If this test is failing for unclear reasons, perhaps the computer running the test is too slow causing the time estimation to be off");
+            result.ShouldBeInRange(1, 200, "This test contains a Thread.Sleep to simulate time passing as this test is testing that a stopwatch is used correctly to measure time.\n If this test is failing for unclear reasons, perhaps the computer running the test is too slow causing the time estimation to be off");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -252,8 +252,7 @@ namespace Stryker.Core.Initialisation
                         {
                             version = $"{version[0]}.{version.Substring(1)}";
                         }
-
-                        if (version.Length == 3)
+                        else if (version.Length == 3)
                         {
                             version = $"{version[0]}.{version[1]}.{version[2]}";
                         }


### PR DESCRIPTION
Correctly extract where the aggregated version is two numbers.

net48 would end up as 4..8 instead of 4.8 due to double if