### PR TITLE
docs(docs/Configuration.md) Add example config option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -282,6 +282,11 @@ Example config file:
         "excluded-mutations": [
             "string",
             "Logical operators"
+        ],
+        "ignore-methods": [
+            "*Log*",
+            "ToString",
+            "*HashCode*"
         ]
     }
 }


### PR DESCRIPTION
While working on a project with Stryker, I noticed that the option
ignore-methods was missing from the config, but it did work when I tried
it. So that's why I decided to add it in.