### PR TITLE
feat(coverage analysis): Implement defensive heuristics to cover when incorrect number of dynamic test cases are reported by testframework

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersShould.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersShould.cs
@@ -222,7 +222,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                             testRunEvents.HandleTestRunStatsChange(new TestRunChangedEventArgs(
                                 new TestRunStatistics(1, null), new[] { testResult }, null));
                             testRunEvents.HandleTestRunComplete(
-                                new TestRunCompleteEventArgs(new TestRunStatistics(1, null), false, false, null,
+                                new TestRunCompleteEventArgs(new TestRunStatistics(1, null), false, true, null,
                                     null, timer.Elapsed),
                                 null,
                                 null,
@@ -245,7 +245,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             {
                 var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner, OptimizationFlags.AbortTestOnKill);
 
-                mockVsTest.Setup(x => x.AbortTestRun()).Verifiable();
+                mockVsTest.Setup(x => x.CancelTestRun()).Verifiable();
                 mockVsTest.Setup(x =>
                     x.RunTestsWithCustomTestHost(
                         It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),
@@ -310,7 +310,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                 var result = runner.CaptureCoverage(false, false);
 
                 // only one mutant is covered
-                runner.CoveredMutants.ShouldHaveSingleItem();
+                runner.CoverageMutants.IsCovered(1).ShouldBeTrue();
 
                 // capture when ok
                 result.Success.ShouldBe(true);
@@ -359,7 +359,7 @@ namespace Stryker.Core.UnitTest.TestRunners
 
                 var result = runner.CaptureCoverage(false, false);
                 // one mutant is covered
-                runner.CoveredMutants.ShouldHaveSingleItem();
+                runner.CoverageMutants.IsCovered(1).ShouldBeTrue();
                 // it is covered by both tests
                 runner.CoverageMutants.GetTests(new Mutant() { Id = 1 }).ShouldBe(_testCases.Select(x => (TestDescription)x));
                 // verify Abort has been called

--- a/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
@@ -28,12 +28,7 @@ namespace Stryker.Core.TestRunners
         {
             lock (_mutantToTests)
             {
-                if (_mutantToTests.ContainsKey(mutant.Id))
-                {
-                    return _mutantToTests[mutant.Id].Union(_testsWithoutCoverageInfos).ToList();
-                }
-
-                return _testsWithoutCoverageInfos;
+                return _mutantToTests.ContainsKey(mutant.Id) ? _mutantToTests[mutant.Id].Union(_testsWithoutCoverageInfos).ToList() : _testsWithoutCoverageInfos;
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Xml.Xsl;
 
 namespace Stryker.Core.TestRunners.VsTest
 {
@@ -20,6 +21,8 @@ namespace Stryker.Core.TestRunners.VsTest
         public event EventHandler TestsFailed;
         public event EventHandler VsTestFailed;
         public List<TestResult> TestResults { get; }
+
+        public bool TimeOut { get; private set; }
 
         public RunEventHandler(AutoResetEvent waitHandle, ILogger logger, string runnerId)
         {
@@ -39,6 +42,8 @@ namespace Stryker.Core.TestRunners.VsTest
             {
                 CaptureTestResults(lastChunkArgs.NewTestResults);
             }
+
+            TimeOut = testRunCompleteArgs.IsAborted;
 
             if (testRunCompleteArgs.Error != null)
             {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Xml.Xsl;
 
 namespace Stryker.Core.TestRunners.VsTest
 {
@@ -22,7 +21,9 @@ namespace Stryker.Core.TestRunners.VsTest
         public event EventHandler VsTestFailed;
         public List<TestResult> TestResults { get; }
 
+
         public bool TimeOut { get; private set; }
+        public bool CancelRequested { get; set; }
 
         public RunEventHandler(AutoResetEvent waitHandle, ILogger logger, string runnerId)
         {
@@ -52,7 +53,7 @@ namespace Stryker.Core.TestRunners.VsTest
                     _logger.LogDebug(testRunCompleteArgs.Error, "VsTest may have crashed, triggering vstest restart!");
                     VsTestFailed?.Invoke(this, EventArgs.Empty);
                 }
-                else
+                else if (!CancelRequested)
                 {
                     _logger.LogWarning(testRunCompleteArgs.Error, "VsTest error occured. Please report the error at https://github.com/stryker-mutator/stryker-net/issues");
                 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -45,7 +45,7 @@ namespace Stryker.Core.TestRunners.VsTest
         private readonly int _id;
         private TestFramework _testFramework;
 
-        private bool _vsTestFailed = false;
+        private bool _vsTestFailed;
 
         private readonly ILogger _logger;
 
@@ -180,7 +180,7 @@ namespace Stryker.Core.TestRunners.VsTest
             // For now we need to throw an OperationCanceledException when a testrun has timed out. 
             // We know the test run has timed out because we received less test results from the test run than there are test cases in the unit test project.
             var resultAsArray = testResults as TestResult[] ?? testResults.ToArray();
-            if (resultAsArray.All(x => x.Outcome != TestOutcome.Failed) && aborted/*resultAsArray.Count() < (testCases ?? _discoveredTests).Count()*/)
+            if (resultAsArray.All(x => x.Outcome != TestOutcome.Failed) && aborted)
             {
                 throw new OperationCanceledException();
             }
@@ -263,6 +263,7 @@ namespace Stryker.Core.TestRunners.VsTest
         {
             // one test has failed, we can stop
             _logger.LogDebug($"{RunnerId}: At least one test failed, abort current test run.");
+            ((RunEventHandler) sender).CancelRequested = true;
             // we cancel the test. Avoid using 'Abort' method, as we use the Aborted status to identify timeouts.
             _vsTestConsole.CancelTestRun();
         }


### PR DESCRIPTION
This a defensive fix for issue #843. As discussed, when Stryker detects dynamic test case(s) it ensures each mutant is tested against those to prevent false survivor/non covered.

The 'timeout' detection logic has been revised for VsTest: we rely on the 'aborted' flag, as the number of testresults can be misleading when test cases are dynamic.

Minor refactoring/simplification were done along the way.