### PR TITLE
feat(initialisation): Fail gracefully on incorrect targetframework in csproj

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -241,26 +241,33 @@ namespace Stryker.Core.Initialisation
                     ["netstandard"] = Framework.NetStandard,
                     ["net"] = Framework.NetClassic
                 };
-                var analysis = Regex.Match(TargetFrameworkVersionString ?? string.Empty, "(?<kind>\\D+)(?<version>[\\d\\.]+)");
-                if (analysis.Success && label.ContainsKey(analysis.Groups["kind"].Value))
+                try
                 {
-                    var version = analysis.Groups["version"].Value;
-                    if (!version.Contains('.'))
+                    var analysis = Regex.Match(TargetFrameworkVersionString ?? string.Empty, "(?<kind>\\D+)(?<version>[\\d\\.]+)");
+                    if (analysis.Success && label.ContainsKey(analysis.Groups["kind"].Value))
                     {
-                        if (version.Length == 2)
-                        // we have a aggregated version id
+                        var version = analysis.Groups["version"].Value;
+                        if (!version.Contains('.'))
                         {
-                            version = $"{version[0]}.{version.Substring(1)}";
+                            if (version.Length == 2)
+                            // we have a aggregated version id
+                            {
+                                version = $"{version[0]}.{version.Substring(1)}";
+                            }
+                            else if (version.Length == 3)
+                            {
+                                version = $"{version[0]}.{version[1]}.{version[2]}";
+                            }
                         }
-                        else if (version.Length == 3)
-                        {
-                            version = $"{version[0]}.{version[1]}.{version[2]}";
-                        }
+                        return (label[analysis.Groups["kind"].Value], new Version(version));
                     }
-                    return (label[analysis.Groups["kind"].Value], new Version(version));
-                }
 
-                return (Framework.Unknown, new Version());
+                    return (Framework.Unknown, new Version());
+                }
+                catch (ArgumentException exception)
+                {
+                    throw new ApplicationException($"Unable to parse framework version string {TargetFrameworkVersionString}.", exception);
+                }
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -264,7 +264,7 @@ namespace Stryker.Core.Initialisation
 
                     return (Framework.Unknown, new Version());
                 }
-                catch (ArgumentException exception)
+                catch (ArgumentException)
                 {
                     throw new StrykerInputException($"Unable to parse framework version string {TargetFrameworkVersionString}. Please fix the framework version in the csproj.");
                 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -266,7 +266,7 @@ namespace Stryker.Core.Initialisation
                 }
                 catch (ArgumentException exception)
                 {
-                    throw new ApplicationException($"Unable to parse framework version string {TargetFrameworkVersionString}.", exception);
+                    throw new StrykerInputException($"Unable to parse framework version string {TargetFrameworkVersionString}. Please fix the framework version in the csproj.");
                 }
             }
         }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Stryker.Core.Exceptions;
 
 namespace Stryker.Core.Initialisation
 {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
@@ -29,6 +29,7 @@ namespace Stryker.Core.TestRunners
             lock (_mutantToTests)
             {
                 return _mutantToTests.ContainsKey(mutant.Id) ? _mutantToTests[mutant.Id].Union(_testsWithoutCoverageInfos).ToList() : _testsWithoutCoverageInfos;
+
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
@@ -29,8 +29,6 @@ namespace Stryker.Core.TestRunners
             lock (_mutantToTests)
             {
                 return _mutantToTests.ContainsKey(mutant.Id) ? _mutantToTests[mutant.Id].Union(_testsWithoutCoverageInfos).ToList() : _testsWithoutCoverageInfos;
-
-                return _testsWithoutCoverageInfos;
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/TestCoverageInfos.cs
@@ -30,6 +30,7 @@ namespace Stryker.Core.TestRunners
             {
                 return _mutantToTests.ContainsKey(mutant.Id) ? _mutantToTests[mutant.Id].Union(_testsWithoutCoverageInfos).ToList() : _testsWithoutCoverageInfos;
 
+                return _testsWithoutCoverageInfos;
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -46,7 +46,6 @@ namespace Stryker.Core.TestRunners.VsTest
 
             TimeOut = testRunCompleteArgs.IsAborted;
 
-            TimeOut = testRunCompleteArgs.IsAborted;
 
             TimeOut = testRunCompleteArgs.IsAborted;
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Xml.Xsl;
 
 namespace Stryker.Core.TestRunners.VsTest
 {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -49,6 +49,8 @@ namespace Stryker.Core.TestRunners.VsTest
 
             TimeOut = testRunCompleteArgs.IsAborted;
 
+            TimeOut = testRunCompleteArgs.IsAborted;
+
             if (testRunCompleteArgs.Error != null)
             {
                 if (testRunCompleteArgs.Error.GetType() == typeof(TransationLayerException))

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -47,7 +47,6 @@ namespace Stryker.Core.TestRunners.VsTest
             TimeOut = testRunCompleteArgs.IsAborted;
 
 
-            TimeOut = testRunCompleteArgs.IsAborted;
 
             if (testRunCompleteArgs.Error != null)
             {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Xml.Xsl;
 
 namespace Stryker.Core.TestRunners.VsTest
 {
@@ -43,6 +44,8 @@ namespace Stryker.Core.TestRunners.VsTest
             {
                 CaptureTestResults(lastChunkArgs.NewTestResults);
             }
+
+            TimeOut = testRunCompleteArgs.IsAborted;
 
             TimeOut = testRunCompleteArgs.IsAborted;
 


### PR DESCRIPTION
Throws an exception with an explicit error message when failing to parse net framework version from the csproj

Fix #861 