### PR TITLE
fix(rollback): Only crash out of stryker run after last rollback retry attempt 

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CompilingProcessTests.cs
@@ -114,8 +114,8 @@ namespace ExampleProject
                 }
             };
             var rollbackProcessMock = new Mock<IRollbackProcess>(MockBehavior.Strict);
-            rollbackProcessMock.Setup(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()))
-                            .Returns((CSharpCompilation compilation, ImmutableArray<Diagnostic> diagnostics, bool devMode) =>
+            rollbackProcessMock.Setup(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>(), false))
+                            .Returns((CSharpCompilation compilation, ImmutableArray<Diagnostic> diagnostics, bool devMode, bool _) =>
                             new RollbackProcessResult()
                             {
                                 Compilation = compilation
@@ -127,7 +127,7 @@ namespace ExampleProject
             {
                 Should.Throw<StrykerCompilationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, false));
             }
-            rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<bool>()),
+            rollbackProcessMock.Verify(x => x.Start(It.IsAny<CSharpCompilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), false,false),
                 Times.AtLeast(2));
         }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -8,12 +8,13 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Stryker.Core.Exceptions;
 
 namespace Stryker.Core.Compiling
 {
     public interface IRollbackProcess
     {
-        RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics, bool devMode);
+        RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics, bool lastAttempt, bool devMode);
     }
     
     /// <summary>
@@ -30,7 +31,7 @@ namespace Stryker.Core.Compiling
             _rollbackedIds = new List<int>();
         }
 
-        public RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics,
+        public RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics, bool lastAttempt,
             bool devMode)
         {
             // match the diagnostics with their syntaxtrees
@@ -57,7 +58,7 @@ namespace Stryker.Core.Compiling
                 }
 
                 _logger.LogTrace("source {1}", syntaxTreeMap.Key.ToString());
-                var updatedSyntaxTree = RemoveMutantIfStatements(syntaxTreeMap.Key, syntaxTreeMap.Value, devMode);
+                var updatedSyntaxTree = RemoveMutantIfStatements(syntaxTreeMap.Key, syntaxTreeMap.Value, devMode, lastAttempt);
 
                 _logger.LogTrace("Rollbacked to {0}", updatedSyntaxTree.ToString());
 
@@ -100,10 +101,8 @@ namespace Stryker.Core.Compiling
                     _logger.LogDebug("Found id {0} in MutantIf annotation", mutantId);
                     return mutantId;
                 }
-                else
-                {
-                    return null;
-                }
+
+                return null;
             }
         }
 
@@ -155,7 +154,7 @@ namespace Stryker.Core.Compiling
             _logger.LogInformation(Environment.NewLine);
         }
 
-        private SyntaxTree RemoveMutantIfStatements(SyntaxTree originalTree, ICollection<Diagnostic> diagnosticInfo, bool devMode)
+        private SyntaxTree RemoveMutantIfStatements(SyntaxTree originalTree, ICollection<Diagnostic> diagnosticInfo, bool devMode, bool lastAttempt)
         {
             var rollbackRoot = originalTree.GetRoot();
             // find all if statements to remove
@@ -174,7 +173,7 @@ namespace Stryker.Core.Compiling
                     if (devMode)
                     {
                         _logger.LogCritical("Stryker.NET will stop (due to dev-mode option sets to true)");
-                        throw new ApplicationException("Internal error due to compile error.");
+                        throw new StrykerCompilationException("Internal error due to compile error.");
                     }
                     _logger.LogWarning("Safe Mode! Stryker will try to continue by rolling back all mutations in method. This should not happen, please report this as an issue on github with the previous error message.");
                     // backup, remove all mutants in the node
@@ -183,11 +182,11 @@ namespace Stryker.Core.Compiling
                     var initNode = FindEnclosingMember(brokenMutation) ?? brokenMutation;
                     ScanAllMutationsIfsAndIds(initNode, scan);
 
-                    if (!scan.Any())
+                    if (!scan.Any() && lastAttempt)
                     {
                         // Not able to rollback anything
                         _logger.LogCritical("Stryker.NET could not compile the project after mutation. This is probably an error for Stryker.NET and not your project. Please report this issue on github with the previous error message.");
-                        throw new ApplicationException("Internal error due to compile error.");
+                        throw new StrykerCompilationException("Internal error due to compile error.");
                     }
 
                     foreach (var entry in scan)

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -31,8 +31,7 @@ namespace Stryker.Core.Compiling
             _rollbackedIds = new List<int>();
         }
 
-        public RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics, bool lastAttempt,
-            bool devMode)
+        public RollbackProcessResult Start(CSharpCompilation compiler, ImmutableArray<Diagnostic> diagnostics, bool lastAttempt, bool devMode)
         {
             // match the diagnostics with their syntaxtrees
             var syntaxTreeMapping = new Dictionary<SyntaxTree, ICollection<Diagnostic>>();
@@ -58,7 +57,7 @@ namespace Stryker.Core.Compiling
                 }
 
                 _logger.LogTrace("source {1}", syntaxTreeMap.Key.ToString());
-                var updatedSyntaxTree = RemoveMutantIfStatements(syntaxTreeMap.Key, syntaxTreeMap.Value, devMode, lastAttempt);
+                var updatedSyntaxTree = RemoveMutantIfStatements(syntaxTreeMap.Key, syntaxTreeMap.Value, lastAttempt, devMode);
 
                 _logger.LogTrace("Rollbacked to {0}", updatedSyntaxTree.ToString());
 
@@ -154,7 +153,8 @@ namespace Stryker.Core.Compiling
             _logger.LogInformation(Environment.NewLine);
         }
 
-        private SyntaxTree RemoveMutantIfStatements(SyntaxTree originalTree, ICollection<Diagnostic> diagnosticInfo, bool devMode, bool lastAttempt)
+        private SyntaxTree RemoveMutantIfStatements(SyntaxTree originalTree, ICollection<Diagnostic> diagnosticInfo,
+            bool lastAttempt, bool devMode)
         {
             var rollbackRoot = originalTree.GetRoot();
             // find all if statements to remove
@@ -189,12 +189,12 @@ namespace Stryker.Core.Compiling
                         throw new StrykerCompilationException("Internal error due to compile error.");
                     }
 
-                    foreach (var entry in scan)
+                    foreach (var (key, value) in scan)
                     {
-                        if (!brokenMutations.Contains(entry.Key))
+                        if (!brokenMutations.Contains(key))
                         {
-                            brokenMutations.Add(entry.Key);
-                            _rollbackedIds.Add(entry.Value);
+                            brokenMutations.Add(key);
+                            _rollbackedIds.Add(value);
                         }
                     }
                 }


### PR DESCRIPTION
Fix #916 
Fix #929

Fix consists ensuring exception are raised only on the **last** attempt to compile.
This required adding this information (isLastAttempt) across a few calls and update related tests