### PR TITLE
feat(mutation exclusion): allow property members to be excluded by name

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -211,5 +211,67 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
             // Assert
             filteredMutants.ShouldContain(mutant);
         }
+        
+        [Fact]
+        public void MutantFilter_ShouldIgnoreProperty()
+        {
+            // Arrange
+            var source = @"
+public class IgnoredMethodMutantFilter_Properties
+{
+    public string Description { get; } = ""some input"";
+}";
+            var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+            var originalNode = baseSyntaxTree.FindNode(new TextSpan(source.IndexOf("Description", StringComparison.Ordinal), 1));
+
+            var mutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = originalNode,
+                }
+            };
+
+            var options = new StrykerOptions(ignoredMethods: new[] { "Description" });
+
+            var sut = new IgnoredMethodMutantFilter();
+
+            // Act
+            var filteredMutants = sut.FilterMutants(new[] { mutant }, null, options);
+
+            // Assert
+            filteredMutants.ShouldNotContain(mutant);
+        }
+        
+        [Fact]
+        public void MutantFilter_ShouldIgnoreExplicitImplementedProperty()
+        {
+            // Arrange
+            var source = @"
+public class IgnoredMethodMutantFilter_Properties : IRule
+{
+    string IRule.Description => ""some input"";
+}";
+            var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+            var originalNode = baseSyntaxTree.FindNode(new TextSpan(source.IndexOf("IRule.Description", StringComparison.Ordinal), 1));
+
+            var mutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = originalNode,
+                }
+            };
+
+            var options = new StrykerOptions(ignoredMethods: new[] { "Description" });
+
+            var sut = new IgnoredMethodMutantFilter();
+
+            // Act
+            var filteredMutants = sut.FilterMutants(new[] { mutant }, null, options);
+
+            // Assert
+            filteredMutants.ShouldNotContain(mutant);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
@@ -44,6 +44,11 @@ namespace Stryker.Core.MutantFilters
                 return options.IgnoredMethods.Any(r => r.IsMatch(methodName));
             }
 
+            if (syntaxNode is PropertyDeclarationSyntax property)
+            {
+                return options.IgnoredMethods.Any(r => r.IsMatch(property.Identifier.Text));
+            }
+
             // Traverse the tree upwards
             if (syntaxNode.Parent != null)
             {


### PR DESCRIPTION
I've some readonly properties that only provide metadata and would like to ignore:

```
        string IRule.Description => "some description that is pushed to the frontend";
        string IRule.Link => "https://google.com";
```