### PR TITLE
feat(mutation exclusion): mutants with ExcludeFromCodeCoverage attribute

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeFromCodeCoverageFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeFromCodeCoverageFilterTests.cs
@@ -1,0 +1,146 @@
+using System;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Shouldly;
+using Stryker.Core.MutantFilters;
+using Stryker.Core.Mutants;
+using Stryker.Core.Options;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.MutantFilters
+{
+    public static class ExcludeFromCodeCoverageFilterTests
+    {
+        [Fact]
+        public static void OnMethod()
+        {
+            // Arrange
+            var mutant = Create(@"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    [ExcludeFromCodeCoverage]
+    private void TestMethod()
+    {
+        var t = Enumerable.Range(0, 9).Where(x => x < 5).ToList();
+    }
+}", "<");
+
+            var sut = new ExcludeFromCodeCoverageFilter() as IMutantFilter;
+
+            // Act
+            var results = sut.FilterMutants(new[] {mutant}, null, new StrykerOptions());
+
+            // Assert
+            results.ShouldNotContain(mutant);
+        }
+
+        [Fact]
+        public static void OnProperty()
+        {
+            // Arrange
+            var mutant = Create(@"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    [ExcludeFromCodeCoverage]
+    private string TestProperty => ""something""
+}", "something");
+
+            var sut = new ExcludeFromCodeCoverageFilter() as IMutantFilter;
+
+            // Act
+            var results = sut.FilterMutants(new[] {mutant}, null, new StrykerOptions());
+
+            // Assert
+            results.ShouldNotContain(mutant);
+        }
+        
+        [Fact]
+        public static void OnClass()
+        {
+            // Arrange
+            var mutant = Create(@"
+[ExcludeFromCodeCoverage]
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        var t = Enumerable.Range(0, 9).Where(x => x < 5).ToList();
+    }
+}", "<");
+
+            var sut = new ExcludeFromCodeCoverageFilter();
+
+            // Act
+            var results = sut.FilterMutants(new[] {mutant}, null, new StrykerOptions());
+
+            // Assert
+            results.ShouldNotContain(mutant);
+        }
+        
+        [Fact]
+        public static void Not()
+        {
+            // Arrange
+            var mutant = Create(@"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        var t = Enumerable.Range(0, 9).Where(x => x < 5).ToList();
+    }
+}", "<");
+
+            var sut = new ExcludeFromCodeCoverageFilter();
+
+            // Act
+            var results = sut.FilterMutants(new[] {mutant}, null, new StrykerOptions());
+
+            // Assert
+            results.ShouldContain(mutant);
+        }
+        
+        [Theory]
+        [InlineData("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute")]
+        [InlineData("ExcludeFromCodeCoverageAttribute")]
+        [InlineData("ExcludeFromCodeCoverage")]
+        public static void Writings(string attr)
+        {
+            // Arrange
+            var mutant = Create($@"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{{
+    [{attr}]
+    private void TestMethod()
+    {{
+        var t = Enumerable.Range(0, 9).Where(x => x < 5).ToList();
+    }}
+}}", "<");
+
+            var sut = new ExcludeFromCodeCoverageFilter();
+
+            // Act
+            var results = sut.FilterMutants(new[] {mutant}, null, new StrykerOptions());
+
+            // Assert
+            results.ShouldNotContain(mutant);
+        }
+        
+        
+        private static Mutant Create(string source, string search)
+        {
+            var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+            var originalNode =
+                baseSyntaxTree.FindNode(new TextSpan(source.IndexOf(search, StringComparison.OrdinalIgnoreCase),
+                    5));
+
+            var mutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = originalNode,
+                }
+            };
+            return mutant;
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/ExcludeFromCodeCoverageFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/ExcludeFromCodeCoverageFilter.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Mutants;
+using Stryker.Core.Options;
+using Stryker.Core.ProjectComponents;
+
+namespace Stryker.Core.MutantFilters
+{
+    public class ExcludeFromCodeCoverageFilter : IMutantFilter
+    {
+        string IMutantFilter.DisplayName { get; } = "exclude from code coverage filter";
+
+        public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, FileLeaf file, StrykerOptions options)
+        {
+            return mutants.Where(m => !Exclude(m.Mutation.OriginalNode));
+        }
+
+        private static bool Exclude(SyntaxNode node)
+        {
+            return node != null && (HasExcludeFromCodeCoverageAttribute(node) || Exclude(node.Parent));
+        }
+
+        private static bool HasExcludeFromCodeCoverageAttribute(SyntaxNode node)
+        {
+            switch (node)
+            {
+                case MemberDeclarationSyntax m:
+                    return HasExcludeFromCodeCoverageAttribute(m);
+                default:
+                    return false;
+            }
+        }
+
+        private static bool HasExcludeFromCodeCoverageAttribute(MemberDeclarationSyntax m)
+        {
+            return m.AttributeLists
+                .SelectMany(attr => attr.Attributes)
+                .Any(attr => Regex.IsMatch(attr.ToString(),
+                    @"^(?:System\.Diagnostics\.CodeAnalysis\.)?ExcludeFromCodeCoverage(?:Attribute)?$"));
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -61,7 +61,8 @@ namespace Stryker.Core.MutationTest
                     new FilePatternMutantFilter(),
                     new IgnoredMethodMutantFilter(),
                     new ExcludeMutationMutantFilter(),
-                    new DiffMutantFilter(_options, new GitDiffProvider(_options))
+                    new DiffMutantFilter(_options, new GitDiffProvider(_options)),
+                    new ExcludeFromCodeCoverageFilter()
                 };
         }
 


### PR DESCRIPTION
If you choose to exclude something from coverage I think it makes sense to also exclude it from mutation testing.