### PR TITLE
feat(mutation placing): Return default(T) after placing mutation to preserve linespans

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -524,6 +524,24 @@ static Mutator_Flag_MutatedStatics()
 }
 
         [Fact]
+        public void ShouldAddReturnDefaultToAsyncMethods()
+        {
+            string source = @"Task<bool> TestMethod()
+{
+    ;
+}";
+            string expected = @"Task<bool> TestMethod()
+{
+    ;
+    return default(bool);
+}";
+            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
+            actualNode.ShouldBeSemantically(expectedNode);
+            actualNode.ShouldNotContainErrors();
+        }
+
+        [Fact]
         public void ShouldNotAddReturnDefaultToMethodsWithReturnTypeVoid()
         {
             string source = @"void TestMethod()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -491,18 +491,37 @@ static Mutator_Flag_MutatedStatics()
 {
     var test3 = 2 + 5;
 }";
-            string expected = @"void TestMethod()
-{
-    var test3 = (StrykerNamespace.MutantControl.IsActive(0)?2 - 5:2 + 5);
-}";
-            expected = expected.Replace("StrykerNamespace", CodeInjection.HelperNamespace);
-            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
-            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
-            actualNode.ShouldBeSemantically(expectedNode);
-            actualNode.ShouldNotContainErrors();
+            _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
 
             var mutants = _target.GetLatestMutantBatch().ToList();
             mutants.ShouldHaveSingleItem().Mutation.OriginalNode.GetLocation().GetLineSpan().StartLinePosition.Line.ShouldBe(2);
+        }
+
+        [Fact]
+        public void MutationsShouldHaveLinespan2()
+        {
+            string source = @"using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestApp
+{
+    public static class ExampleExtension
+    {
+        public static bool InvokeIfNotNull(this Action a)
+        {
+            if (a == null) { return false; } else { a.Invoke(); return true; }
+        }
+    }
+}";
+            _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+
+            var mutants = _target.GetLatestMutantBatch().ToList();
+            mutants.Count.ShouldBe(4);
+            foreach(var mutant in mutants)
+            {
+                mutant.Mutation.OriginalNode.GetLocation().GetLineSpan().StartLinePosition.Line.ShouldBe(10);
+            }
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -478,7 +478,6 @@ static Mutator_Flag_MutatedStatics()
         request.Headers.Add((StrykerNamespace.MutantControl.IsActive(0)?"""":""Accept""), (StrykerNamespace.MutantControl.IsActive(1)?"""":""application / json; version = 1""));
         request.Headers.TryAddWithoutValidation((StrykerNamespace.MutantControl.IsActive(2)?"""":""Date""), date);
 }, ensureSuccessStatusCode: (StrykerNamespace.MutantControl.IsActive(3)?true:false));
-    return default(Task);
 }";
 
             ShouldMutateSourceToExpected(source, expected);
@@ -526,14 +525,49 @@ static Mutator_Flag_MutatedStatics()
         [Fact]
         public void ShouldAddReturnDefaultToAsyncMethods()
         {
-            string source = @"Task<bool> TestMethod()
+            string source = @"public async Task<bool> TestMethod()
 {
     ;
 }";
-            string expected = @"Task<bool> TestMethod()
+            string expected = @"public async Task<bool> TestMethod()
 {
     ;
     return default(bool);
+}";
+            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
+            actualNode.ShouldBeSemantically(expectedNode);
+            actualNode.ShouldNotContainErrors();
+        }
+
+        [Fact]
+        public void ShouldAddReturnDefaultToAsyncWithFullNamespaceMethods()
+        {
+            string source = @"public async System.Threading.Tasks.Task<bool> TestMethod()
+{
+    ;
+}";
+            string expected = @"public async System.Threading.Tasks.Task<bool> TestMethod()
+{
+    ;
+    return default(bool);
+}";
+            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
+            var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();
+            actualNode.ShouldBeSemantically(expectedNode);
+            actualNode.ShouldNotContainErrors();
+        }
+
+        [Fact]
+        public void ShouldNotAddReturnDefaultToAsyncTaskMethods()
+        {
+            string source = @"public async Task TestMethod()
+{
+    ;
+}";
+            string expected = @"public async Task TestMethod()
+{
+    ;
 }";
             var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(source).GetRoot());
             var expectedNode = CSharpSyntaxTree.ParseText(expected).GetRoot();

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -329,6 +329,7 @@ namespace Stryker.Core.Mutants
             {
                 TypeSyntax returnType = methodNode.ReturnType;
 
+                // the GenericNameSyntax node can be encapsulated by QualifiedNameSyntax nodes
                 var genericReturn = returnType.DescendantNodesAndSelf().OfType<GenericNameSyntax>().FirstOrDefault();
                 if (methodNode.Modifiers.Any(x => x.IsKind(SyntaxKind.AsyncKeyword)))
                 {

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -333,11 +333,11 @@ namespace Stryker.Core.Mutants
                 var genericReturn = returnType.DescendantNodesAndSelf().OfType<GenericNameSyntax>().FirstOrDefault();
                 if (methodNode.Modifiers.Any(x => x.IsKind(SyntaxKind.AsyncKeyword)))
                 {
-                    if (genericReturn != null && genericReturn.Identifier.ToString() == "Task")
+                    if (genericReturn != null)
                     {
                         // if the method is async and returns a generic task, make the return default return the underlying type
                         returnType = genericReturn.TypeArgumentList.Arguments.First();
-                    } else if (genericReturn == null)
+                    } else
                     {
                         // if the method is async but returns a non-generic task, don't add the return default
                         return currentNode;

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -325,7 +325,12 @@ namespace Stryker.Core.Mutants
             if (currentNode is MethodDeclarationSyntax methodNode && 
                 methodNode.ReturnType.ToString() != "void" && methodNode.Body != null)
             {
-                var newBody = methodNode.Body.AddStatements(SyntaxFactory.ReturnStatement(SyntaxFactory.DefaultExpression(methodNode.ReturnType)));
+                TypeSyntax returnType = methodNode.ReturnType;
+                if (returnType is GenericNameSyntax genericReturn && genericReturn.Identifier.ToString() == "Task")
+                {
+                    returnType = genericReturn.TypeArgumentList.Arguments.First();
+                }
+                var newBody = methodNode.Body.AddStatements(SyntaxFactory.ReturnStatement(SyntaxFactory.DefaultExpression(returnType)));
                 currentNode = currentNode.ReplaceNode(methodNode.Body, newBody);
             }
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -130,9 +130,8 @@ namespace Stryker.Core.Mutants
                     return MutateForStatement(forStatement, context);
             }
 
-            currentNode = AddReturnDefault(currentNode);
-
-            return MutateExpression(currentNode, context);
+            var mutatedNode = MutateExpression(currentNode, context);
+            return AddReturnDefault(mutatedNode);
         }
 
         private SyntaxNode MutateStaticConstructor(ConstructorDeclarationSyntax constructorDeclaration, MutationContext context)


### PR DESCRIPTION
Since #958 linespans have been wrong. That was seen in the html report.

It turned out that the return default should be placed after mutating a node and not before. Adding the return default messed up the syntax tree inside the mutations. 

Clearly the unit tests we currently have for linespans were not sufficient so I added another one that detects the current flaw.

closes #974