### PR TITLE
fix: avoid mutating enum member declarations (fixes #1016)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -205,6 +205,11 @@ var (one, two) = ((StrykerNamespace.MutantControl.IsActive(0)?1 - 1:1 + 1), (Str
             ShouldMutateSourceToExpected(source, expected);
         }
 
+        /// <summary>
+        /// Verifies that <code>EnumMemberDeclarationSyntax</code> nodes are not mutated.
+        /// Mutating would introduce code like <code>StrykerXGJbRBlHxqRdD9O.MutantControl.IsActive(0) ? One + 1 : One - 1</code>
+        /// Since enum members need to be constants, this mutated code would not compile and print a warning.
+        /// </summary>
         [Fact]
         public void ShouldNotMutateEnum()
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -206,6 +206,15 @@ var (one, two) = ((StrykerNamespace.MutantControl.IsActive(0)?1 - 1:1 + 1), (Str
         }
 
         [Fact]
+        public void ShouldNotMutateEnum()
+        {
+            string source = @"private enum Numbers { One = 1, Two = One + 1 }";
+            string expected = @"private enum Numbers { One = 1, Two = One + 1 }";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
         public void ShouldNotMutateAttributes()
         {
             string source = @"[Obsolete(""thismustnotbemutated"")]

--- a/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/SyntaxHelper.cs
@@ -33,6 +33,7 @@ namespace Stryker.Core
                 // don't mutate constant fields
                 case FieldDeclarationSyntax field when field.Modifiers.Any(x => x.Kind() == SyntaxKind.ConstKeyword):
                 case RecursivePatternSyntax _:
+                case EnumMemberDeclarationSyntax _:
                     return false;
                 default:
                     return true;


### PR DESCRIPTION
This excludes EnumMemberDeclaration nodes from the nodes to be mutated, which will avoid compiler errors due to the mutation engine generating non-constant code at a place where constants must be used.