### PR TITLE
feat(Collection initializer mutator): Add mutator for collections and arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Right now, Stryker.NET supports the following mutations:
 - Equality Operators
 - Boolean Literals
 - Assignment statements
+- Collection initialization
 - Unary Operators
 - Update Operators
 - Checked Statements

--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -78,7 +78,7 @@ Stryker supports a variety of mutators, which are listed below. Do you have a su
 |`int[] numbers = { 1, 2 };`               | `int[] numbers = { };`               |
 |`new List<int> { 1, 2 };`                 | `new List<int> { };`                 |
 |`new Collection<int> { 1, 2 };`           | `new Collection<int> { };`           |
-|`new Dictionary<int, int> { { 1, 1 } };`  | `new Dictionary<int, int> { { } };`  |
+|`new Dictionary<int, int> { { 1, 1 } };`  | `new Dictionary<int, int> { };`      |
 
 ## Unary Operators
 |    Original   |   Mutated  | 

--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -76,7 +76,6 @@ Stryker supports a variety of mutators, which are listed below. Do you have a su
 | ---------------------------------------- | ------------------------------------ |
 |`new int[] { 1, 2 };`                     | `new int[] { };`                     |
 |`int[] numbers = { 1, 2 };`               | `int[] numbers = { };`               |
-|`new [] { 1, 2 };`                        | `new [] { };`                        |
 |`new List<int> { 1, 2 };`                 | `new List<int> { };`                 |
 |`new Collection<int> { 1, 2 };`           | `new Collection<int> { };`           |
 |`new Dictionary<int, int> { { 1, 1 } };`  | `new Dictionary<int, int> { { } };`  |

--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -6,6 +6,7 @@ Stryker supports a variety of mutators, which are listed below. Do you have a su
 - [Equality Operators](#equality-operators)
 - [Boolean Literals](#boolean-literals)
 - [Assignment statements](#assignment-statements)
+- [Collection initialization](#collection-initialization)
 - [Unary Operators](#unary-operators)
 - [Update Operators](#update-operators)
 - [Checked Statements](#checked-statements)
@@ -69,6 +70,16 @@ Stryker supports a variety of mutators, which are listed below. Do you have a su
 |`\|= `| `^= ` |
 |`^= ` | `\|= `|
 |`^= ` | `&= ` |
+
+## Collection initialization
+| Original | Mutated | 
+| ---------------------------------------- | ------------------------------------ |
+|`new int[] { 1, 2 };`                     | `new int[] { };`                     |
+|`int[] numbers = { 1, 2 };`               | `int[] numbers = { };`               |
+|`new [] { 1, 2 };`                        | `new [] { };`                        |
+|`new List<int> { 1, 2 };`                 | `new List<int> { };`                 |
+|`new Collection<int> { 1, 2 };`           | `new Collection<int> { };`           |
+|`new Dictionary<int, int> { { 1, 1 } };`  | `new Dictionary<int, int> { { } };`  |
 
 ## Unary Operators
 |    Original   |   Mutated  | 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -175,6 +175,37 @@ private bool Out(out string test)
         }
 
         [Fact]
+        void ShouldMutateArrayInitializer()
+        {
+            string source = @"public int[] Foo(){
+int[] test = { 1 };
+}";
+            string expected = @"public int[] Foo(){
+int[] test = (StrykerNamespace.MutantControl.IsActive(0)?{}:{ 1 });
+returndefault(int[] );}";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
+        void ShouldMutateArrayDeclaration()
+        {
+            string source = @"public int[] Foo() => new int[] { 1 };";
+            string expected = @"public int[] Foo() => (StrykerNamespace.MutantControl.IsActive(0)?new int[] {}:new int[] { 1 });";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
+        void ShouldMutateListCreation()
+        {
+            string source = @"public int[] Foo() => new List<int> { 1 };";
+            string expected = @"public int[] Foo() => (StrykerNamespace.MutantControl.IsActive(0)?new List<int> {}:new List<int> { 1 });";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
         public void ShouldMutateProperties()
         {
             string source = @"private string text = ""Some"" + ""Text"";";
@@ -311,17 +342,17 @@ Action act = () => Console.WriteLine((StrykerNamespace.MutantControl.IsActive(0)
         {
             string source = @"private void Linq()
         {
-            var array = new []{1,2};
+            var array = new []{1, 2};
 
             var alt1 = array.Count(x => x % 2 == 0);
             var alt2 = array.Min();
         }";
             string expected = @"private void Linq()
         {
-            var array = new []{1,2};
+            var array = (StrykerNamespace.MutantControl.IsActive(0)?new []{}:new []{1, 2});
 
-            var alt1 = (StrykerNamespace.MutantControl.IsActive(2)?array.Sum(x => x % 2 == 0):array.Count(x => (StrykerNamespace.MutantControl.IsActive(1)?x % 2 != 0:(StrykerNamespace.MutantControl.IsActive(0)?x * 2 :x % 2 )== 0)));
-            var alt2 = (StrykerNamespace.MutantControl.IsActive(3)?array.Max():array.Min());
+            var alt1 = (StrykerNamespace.MutantControl.IsActive(3)?array.Sum(x => x % 2 == 0):array.Count(x => (StrykerNamespace.MutantControl.IsActive(2)?x % 2 != 0:(StrykerNamespace.MutantControl.IsActive(1)?x * 2 :x % 2 )== 0)));
+            var alt2 = (StrykerNamespace.MutantControl.IsActive(4)?array.Max():array.Min());
         }";
 
             ShouldMutateSourceToExpected(source, expected);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -206,6 +206,15 @@ returndefault(int[] );}";
         }
 
         [Fact]
+        void ShouldNotMutateImplicitArrayCreation()
+        {
+            string source = @"public int[] Foo() => new [] { 1 };";
+            string expected = @"public int[] Foo() => new [] { 1 };";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
         public void ShouldMutateProperties()
         {
             string source = @"private string text = ""Some"" + ""Text"";";
@@ -349,10 +358,10 @@ Action act = () => Console.WriteLine((StrykerNamespace.MutantControl.IsActive(0)
         }";
             string expected = @"private void Linq()
         {
-            var array = (StrykerNamespace.MutantControl.IsActive(0)?new []{}:new []{1, 2});
+            var array = new []{1, 2};
 
-            var alt1 = (StrykerNamespace.MutantControl.IsActive(3)?array.Sum(x => x % 2 == 0):array.Count(x => (StrykerNamespace.MutantControl.IsActive(2)?x % 2 != 0:(StrykerNamespace.MutantControl.IsActive(1)?x * 2 :x % 2 )== 0)));
-            var alt2 = (StrykerNamespace.MutantControl.IsActive(4)?array.Max():array.Min());
+            var alt1 = (StrykerNamespace.MutantControl.IsActive(2)?array.Sum(x => x % 2 == 0):array.Count(x => (StrykerNamespace.MutantControl.IsActive(1)?x % 2 != 0:(StrykerNamespace.MutantControl.IsActive(0)?x * 2 :x % 2 )== 0)));
+            var alt2 = (StrykerNamespace.MutantControl.IsActive(3)?array.Max():array.Min());
         }";
 
             ShouldMutateSourceToExpected(source, expected);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ArrayCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ArrayCreationMutatorTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Stryker.Core.Mutators;
+using System;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Mutators
+{
+    public class ArrayCreationMutatorTests
+    {
+        [Fact]
+        public void ShouldRemoveValuesFromArrayCreation()
+        {
+            var expressionSyntax = SyntaxFactory.ParseExpression("new int[] { 1, 3 }") as ArrayCreationExpressionSyntax;
+
+            var target = new ArrayCreationMutator();
+
+            var result = target.ApplyMutations(expressionSyntax);
+
+            var mutation = result.ShouldHaveSingleItem();
+            mutation.DisplayName.ShouldBe("Array initializer mutation");
+
+            var replacement = mutation.ReplacementNode.ShouldBeOfType<ArrayCreationExpressionSyntax>();
+            replacement.Initializer.Expressions.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldRemoveValuesFromImplicitArrayCreation()
+        {
+            var expressionSyntax = SyntaxFactory.ParseExpression("new [] { 1, 3 }") as ImplicitArrayCreationExpressionSyntax;
+
+            var target = new ArrayCreationMutator();
+
+            var result = target.ApplyMutations(expressionSyntax);
+
+            var mutation = result.ShouldHaveSingleItem();
+            mutation.DisplayName.ShouldBe("Array initializer mutation");
+
+            var replacement = mutation.ReplacementNode.ShouldBeOfType<ImplicitArrayCreationExpressionSyntax>();
+            replacement.Initializer.Expressions.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldNotMutateEmptyInitializer()
+        {
+            var arrayCreationExpression = SyntaxFactory.ParseExpression("new int[] { }") as ArrayCreationExpressionSyntax;
+            var implicitArrayCreationExpression = SyntaxFactory.ParseExpression("new int[] { }") as ArrayCreationExpressionSyntax;
+
+            var target = new ArrayCreationMutator();
+
+            var result1 = target.ApplyMutations(arrayCreationExpression);
+            var result2 = target.ApplyMutations(implicitArrayCreationExpression);
+
+            result1.ShouldBeEmpty();
+            result2.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ArrayCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ArrayCreationMutatorTests.cs
@@ -26,7 +26,7 @@ namespace Stryker.Core.UnitTest.Mutators
         }
 
         [Fact]
-        public void ShouldRemoveValuesFromImplicitArrayCreation()
+        public void ShouldNotRemoveValuesFromImplicitArrayCreation()
         {
             var expressionSyntax = SyntaxFactory.ParseExpression("new [] { 1, 3 }") as ImplicitArrayCreationExpressionSyntax;
 
@@ -34,11 +34,7 @@ namespace Stryker.Core.UnitTest.Mutators
 
             var result = target.ApplyMutations(expressionSyntax);
 
-            var mutation = result.ShouldHaveSingleItem();
-            mutation.DisplayName.ShouldBe("Array initializer mutation");
-
-            var replacement = mutation.ReplacementNode.ShouldBeOfType<ImplicitArrayCreationExpressionSyntax>();
-            replacement.Initializer.Expressions.ShouldBeEmpty();
+            result.ShouldBeEmpty();
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/InitializerMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/InitializerMutatorTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Stryker.Core.Mutators;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Mutators
+{
+    public class InitializerMutatorTests
+    {
+        [Fact]
+        public void ShouldRemoveValuesFromArrayInitializer()
+        {
+            var initializerExpression = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression,
+                SyntaxFactory.SeparatedList(new List<ExpressionSyntax> {
+                    SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(5))
+                }));
+            var target = new InitializerMutator();
+
+            var result = target.ApplyMutations(initializerExpression);
+
+            var mutation = result.ShouldHaveSingleItem();
+            mutation.DisplayName.ShouldBe("Array initializer mutation");
+
+            var replacement = mutation.ReplacementNode.ShouldBeOfType<InitializerExpressionSyntax>();
+            replacement.Expressions.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldNotMutateEmptyInitializer()
+        {
+            var emptyInitializerExpression = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression,
+                SyntaxFactory.SeparatedList<ExpressionSyntax>());
+            var target = new InitializerMutator();
+
+            var result = target.ApplyMutations(emptyInitializerExpression);
+
+            result.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Stryker.Core.Mutators;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Mutators
+{
+    public class ObjectCreationMutatorTests
+    {
+        [Theory]
+        [InlineData("new List<int> { 1, 3 }")]
+        [InlineData("new Collection<int> { 1, 3 }")]
+        [InlineData(@"new Dictionary<int, StudentName>()
+        {
+            { 111, new StudentName { FirstName='Foo', LastName='Bar', ID=211 } }
+        };")]
+        public void ShouldRemoveValuesFromCollectionInitializer(string initializer)
+        {
+            var objectCreationExpression = SyntaxFactory.ParseExpression(initializer) as ObjectCreationExpressionSyntax;
+
+            var target = new ObjectCreationMutator();
+
+            var result = target.ApplyMutations(objectCreationExpression);
+
+            var mutation = result.ShouldHaveSingleItem();
+
+            var replacement = mutation.ReplacementNode.ShouldBeOfType<ObjectCreationExpressionSyntax>();
+            replacement.Initializer.Expressions.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldNotMutateEmptyInitializer()
+        {
+            var objectCreationExpression = SyntaxFactory.ParseExpression("new List<int> { }") as ObjectCreationExpressionSyntax;
+
+            var target = new ObjectCreationMutator();
+
+            var result = target.ApplyMutations(objectCreationExpression);
+
+            result.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantOrchestrator.cs
@@ -55,6 +55,9 @@ namespace Stryker.Core.Mutants
                     new StringEmptyMutator(),
                     new InterpolatedStringMutator(),
                     new NegateConditionMutator(),
+                    new InitializerMutator(),
+                    new ObjectCreationMutator(),
+                    new ArrayCreationMutator()
                 };
             Mutants = new Collection<Mutant>();
             Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutantOrchestrator>();

--- a/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Mutants;
+using System.Collections.Generic;
+
+namespace Stryker.Core.Mutators
+{
+    public class ArrayCreationMutator : MutatorBase<ExpressionSyntax>, IMutator
+    {
+        public override IEnumerable<Mutation> ApplyMutations(ExpressionSyntax node)
+        {
+            if (node is ArrayCreationExpressionSyntax arrayCreationNode && arrayCreationNode.Initializer.Expressions.Count > 0)
+            {
+                yield return new Mutation()
+                {
+                    OriginalNode = arrayCreationNode,
+                    ReplacementNode = arrayCreationNode.ReplaceNode(arrayCreationNode.Initializer, SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression)),
+                    DisplayName = "Array initializer mutation",
+                    Type = Mutator.Initializer
+                };
+            } else if (node is ImplicitArrayCreationExpressionSyntax implicitArrayCreationNode && implicitArrayCreationNode.Initializer.Expressions.Count > 0)
+            {
+                yield return new Mutation()
+                {
+                    OriginalNode = implicitArrayCreationNode,
+                    ReplacementNode = implicitArrayCreationNode.ReplaceNode(implicitArrayCreationNode.Initializer, SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression)),
+                    DisplayName = "Array initializer mutation",
+                    Type = Mutator.Initializer
+                };
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
@@ -19,21 +19,6 @@ namespace Stryker.Core.Mutators
                     DisplayName = "Array initializer mutation",
                     Type = Mutator.Initializer
                 };
-            } else if (node is ImplicitArrayCreationExpressionSyntax implicitArrayCreationNode && implicitArrayCreationNode.Initializer.Expressions.Count > 0)
-            {
-                var kind = implicitArrayCreationNode.Initializer.Expressions.First().Kind();
-                //var type = kind switch
-                //{
-                //    SyntaxKind.NumericLiteralExpression => 
-                //}
-
-                yield return new Mutation()
-                {
-                    OriginalNode = implicitArrayCreationNode,
-                    ReplacementNode = implicitArrayCreationNode.ReplaceNode(implicitArrayCreationNode.Initializer, SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression)),
-                    DisplayName = "Array initializer mutation",
-                    Type = Mutator.Initializer
-                };
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ArrayCreationMutator.cs
@@ -21,6 +21,12 @@ namespace Stryker.Core.Mutators
                 };
             } else if (node is ImplicitArrayCreationExpressionSyntax implicitArrayCreationNode && implicitArrayCreationNode.Initializer.Expressions.Count > 0)
             {
+                var kind = implicitArrayCreationNode.Initializer.Expressions.First().Kind();
+                //var type = kind switch
+                //{
+                //    SyntaxKind.NumericLiteralExpression => 
+                //}
+
                 yield return new Mutation()
                 {
                     OriginalNode = implicitArrayCreationNode,

--- a/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Mutants;
+using System.Collections.Generic;
+
+namespace Stryker.Core.Mutators
+{
+    public class InitializerMutator : MutatorBase<InitializerExpressionSyntax>, IMutator
+    {
+        public override IEnumerable<Mutation> ApplyMutations(InitializerExpressionSyntax node)
+        {
+            if (!(node.Parent is ArrayCreationExpressionSyntax) && !(node.Parent is ImplicitArrayCreationExpressionSyntax) && 
+                node.Kind() == SyntaxKind.ArrayInitializerExpression && node.Expressions.Count > 0)
+            {
+                yield return new Mutation()
+                {
+                    OriginalNode = node,
+                    ReplacementNode = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression),
+                    DisplayName = "Array initializer mutation",
+                    Type = Mutator.Initializer
+                };
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutators/Mutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/Mutator.cs
@@ -28,7 +28,9 @@ namespace Stryker.Core.Mutators
         [Description("String literals")]
         String,
         [Description("Bitwise operators")]
-        Bitwise
+        Bitwise,
+        [Description("Array initializer")]
+        Initializer
     }
 
     public static class EnumExtension

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Mutants;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stryker.Core.Mutators
+{
+    public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>, IMutator
+    {
+        public override IEnumerable<Mutation> ApplyMutations(ObjectCreationExpressionSyntax node)
+        {
+            if (node.Initializer?.Kind() == SyntaxKind.CollectionInitializerExpression && node.Initializer.Expressions.Count > 0)
+            {
+                yield return new Mutation()
+                {
+                    OriginalNode = node,
+                    ReplacementNode = node.ReplaceNode(node.Initializer, SyntaxFactory.InitializerExpression(SyntaxKind.CollectionInitializerExpression)),
+                    DisplayName = "Collection initializer mutation",
+                    Type = Mutator.Initializer
+                };
+            }
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Stryker.Core.Mutants;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Stryker.Core.Mutators
 {


### PR DESCRIPTION
This PR adds mutators for collections and arrays. 

I skipped the implicid array for now is it results in compile errors when mutated. We could mutate it by resolving its type and converting it to a typed array in the mutation. I'll create an issue for that.