### PR TITLE
chore(build): Use package version for sonarcloud project version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ stages:
         scannerMode: 'MSBuild'
         projectKey: 'stryker-net'
         projectName: 'Stryker .NET'
-        projectVersion: '$(Build.BuildNumber)'
+        projectVersion: '$(PackageVersion)'
     - task: DotNetCoreCLI@2
       inputs:
         command: 'build'


### PR DESCRIPTION
So that we can track differences over package versions instead of every build