### PR TITLE
refactor(MutantFilters): Add MutantFilterFactory and BroadcastMutantFilter

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
@@ -65,26 +65,6 @@ namespace Stryker.Core.UnitTest.MutantFilters
         }
 
         [Fact]
-        public void ShouldMutateAllFilesWhenTurnedOff()
-        {
-            var options = new StrykerOptions(diff: false);
-            var diffProvider = new Mock<IDiffProvider>(MockBehavior.Strict);
-            string myFile = Path.Combine("C:/test/", "myfile.cs"); ;
-            diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult()
-            {
-                ChangedFiles = new Collection<string>()
-            });
-            var target = new DiffMutantFilter(diffProvider.Object);
-            var file = new FileLeaf { FullPath = myFile };
-
-            var mutant = new Mutant();
-
-            var filterResult = target.FilterMutants(new List<Mutant>() { mutant }, file, options);
-
-            filterResult.ShouldContain(mutant);
-        }
-
-        [Fact]
         public void ShouldMutateAllFilesWhenATestHasBeenChanged()
         {
             string testProjectPath = "C:/MyTests";

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
@@ -17,7 +17,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public static void ShouldHaveName()
         {
-            var target = new DiffMutantFilter(new StrykerOptions(), null) as IMutantFilter;
+            var target = new DiffMutantFilter(null) as IMutantFilter;
             target.DisplayName.ShouldBe("git diff file filter");
         }
 
@@ -31,7 +31,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             {
                 ChangedFiles = new Collection<string>()
             });
-            var target = new DiffMutantFilter(options, diffProvider.Object);
+            var target = new DiffMutantFilter(diffProvider.Object);
             var file = new FileLeaf { FullPath = myFile };
 
             var mutant = new Mutant();
@@ -54,7 +54,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
                     myFile
                 }
             });
-            var target = new DiffMutantFilter(options, diffProvider.Object);
+            var target = new DiffMutantFilter(diffProvider.Object);
             var file = new FileLeaf { FullPath = myFile };
 
             var mutant = new Mutant();
@@ -74,7 +74,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             {
                 ChangedFiles = new Collection<string>()
             });
-            var target = new DiffMutantFilter(options, diffProvider.Object);
+            var target = new DiffMutantFilter(diffProvider.Object);
             var file = new FileLeaf { FullPath = myFile };
 
             var mutant = new Mutant();
@@ -97,9 +97,10 @@ namespace Stryker.Core.UnitTest.MutantFilters
                 ChangedFiles = new Collection<string>()
                 {
                     myTest
-                }
+                },
+                TestsChanged = true
             });
-            var target = new DiffMutantFilter(options, diffProvider.Object);
+            var target = new DiffMutantFilter(diffProvider.Object);
 
             // check the diff result for a file not inside the test project
             var file = new FileLeaf { FullPath = Path.Combine("C:/NotMyTests", "myfile.cs") };

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
@@ -1,0 +1,60 @@
+﻿using Stryker.Core.MutantFilters;
+using Stryker.Core.Options;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Shouldly;
+using System.Linq;
+
+namespace Stryker.Core.UnitTest.MutantFilters
+{
+    public class MutantFilterFactoryTests
+    {
+        [Fact]
+        public void MutantFilterFactory_Creates_of_type_BroadcastFilter()
+        {
+            var result = MutantFilterFactory.Create(new StrykerOptions());
+
+            result.ShouldBeOfType<BroadcastMutantFilter>();
+        }
+
+        [Fact]
+        public void Create_Throws_ArgumentNullException_When_Stryker_Options_Is_Null()
+        {
+            var result = Should.Throw<ArgumentNullException>(() => MutantFilterFactory.Create(null));
+        }
+
+        [Fact]
+        public void MutantFilterFactory_Creates_Standard_Mutant_Filters()
+        {
+            // Arrange
+            var strykerOptions = new StrykerOptions(diff: false);
+
+            // Act
+            var result = MutantFilterFactory.Create(strykerOptions);
+
+            // Assert
+            var resultAsBroadcastFilter = result as BroadcastMutantFilter;
+
+            resultAsBroadcastFilter.MutantFilters.Count().ShouldBe(4);
+        }
+
+        [Fact]
+        public void MutantFilterFactory_Creates_DiffMutantFilter_When_Diff_Enabled()
+        {
+            // Arrange
+            var strykerOptions = new StrykerOptions(diff: true);
+
+            // Act
+            var result = MutantFilterFactory.Create(strykerOptions);
+
+            // Assert
+            var resultAsBroadcastFilter = result as BroadcastMutantFilter;
+
+            resultAsBroadcastFilter.MutantFilters.Count().ShouldBe(5);
+
+            resultAsBroadcastFilter.MutantFilters.Where(x => x.GetType() == typeof(DiffMutantFilter)).Count().ShouldBe(1);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
@@ -6,6 +6,8 @@ using System.Text;
 using Xunit;
 using Shouldly;
 using System.Linq;
+using Moq;
+using Stryker.Core.DiffProviders;
 
 namespace Stryker.Core.UnitTest.MutantFilters
 {
@@ -45,6 +47,10 @@ namespace Stryker.Core.UnitTest.MutantFilters
         {
             // Arrange
             var strykerOptions = new StrykerOptions(diff: true);
+
+            var diffProviderMock = new Mock<IDiffProvider>(MockBehavior.Loose);
+
+            MutantFilterFactory.SetDiffProvider(diffProviderMock.Object);
 
             // Act
             var result = MutantFilterFactory.Create(strykerOptions);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
@@ -50,10 +50,8 @@ namespace Stryker.Core.UnitTest.MutantFilters
 
             var diffProviderMock = new Mock<IDiffProvider>(MockBehavior.Loose);
 
-            MutantFilterFactory.SetDiffProvider(diffProviderMock.Object);
-
             // Act
-            var result = MutantFilterFactory.Create(strykerOptions);
+            var result = MutantFilterFactory.Create(strykerOptions, diffProviderMock.Object);
 
             // Assert
             var resultAsBroadcastFilter = result as BroadcastMutantFilter;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -121,7 +121,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                 compilingProcessMock.Object,
                 fileSystem,
                 options,
-                Enumerable.Empty<IMutantFilter>());
+                new BroadcastMutantFilter(Enumerable.Empty<IMutantFilter>()));
 
             // start mutation process
             target.Mutate();
@@ -217,7 +217,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                 compilingProcessMock.Object,
                 fileSystem,
                 options,
-                new[] { mutantFilterMock.Object });
+                new BroadcastMutantFilter(new[] { mutantFilterMock.Object }));
 
             // start mutation process
             target.Mutate();
@@ -302,7 +302,7 @@ namespace Stryker.Core.UnitTest.MutationTest
                 compilingProcessMock.Object,
                 fileSystem,
                 options,
-                Enumerable.Empty<IMutantFilter>());
+                new BroadcastMutantFilter(Enumerable.Empty<IMutantFilter>()));
 
             target.Mutate();
 
@@ -432,7 +432,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             var target = new MutationTestProcess(input,
                 reporterMock.Object,
                 executorMock.Object,
-                mutantFilters: Enumerable.Empty<IMutantFilter>(),
+                mutantFilter: new BroadcastMutantFilter(Enumerable.Empty<IMutantFilter>()),
                 options: options);
 
             target.Test(options);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -43,4 +43,7 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="MutantFilters\" />
+  </ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -43,7 +43,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="MutantFilters\" />
-  </ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/BroadcastMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/BroadcastMutantFilter.cs
@@ -1,0 +1,42 @@
+﻿using Stryker.Core.Mutants;
+using Stryker.Core.Options;
+using Stryker.Core.ProjectComponents;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Stryker.Core.MutantFilters
+{
+    public class BroadcastMutantFilter : IMutantFilter
+    {
+        public IEnumerable<IMutantFilter> MutantFilters { get; }
+        public BroadcastMutantFilter(IEnumerable<IMutantFilter> mutantFilters)
+        {
+            MutantFilters = mutantFilters;
+        }
+
+        public string DisplayName => "broadcast filter";
+
+        public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, FileLeaf file, StrykerOptions options)
+        {
+            IEnumerable<Mutant> filteredMutants = mutants;
+
+            foreach (var mutantFilter in MutantFilters)
+            {
+                var current = mutantFilter.FilterMutants(mutants, file, options);
+
+                foreach (var skippedMutant in filteredMutants.Except(current))
+                {
+                    if (skippedMutant.ResultStatus == MutantStatus.NotRun)
+                    {
+                        skippedMutant.ResultStatus = MutantStatus.Ignored;
+                        skippedMutant.ResultStatusReason = $"Removed by {mutantFilter.DisplayName}";
+                    }
+                }
+
+                filteredMutants = current;
+            }
+
+            return filteredMutants;
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/DiffMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/DiffMutantFilter.cs
@@ -12,17 +12,14 @@ namespace Stryker.Core.MutantFilters
         private readonly DiffResult _diffResult;
         public string DisplayName => "git diff file filter";
 
-        public DiffMutantFilter(StrykerOptions options, IDiffProvider diffProvider)
+        public DiffMutantFilter(IDiffProvider diffProvider)
         {
-            if (options.DiffEnabled)
-            {
-                _diffResult = diffProvider.ScanDiff();
-            }
+                _diffResult = diffProvider?.ScanDiff();
         }
 
         public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, FileLeaf file, StrykerOptions options)
         {
-            if (options.DiffEnabled && !_diffResult.TestsChanged)
+            if (!_diffResult.TestsChanged)
             {
                 if (_diffResult.ChangedFiles.Contains(file.FullPath))
                 {

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -14,7 +14,7 @@ namespace Stryker.Core.MutantFilters
         {
             if(options == null)
             {
-                throw new ArgumentNullException($"{nameof(options)} cannot be null");
+                throw new ArgumentNullException(nameof(options));
             }
 
             return new BroadcastMutantFilter(DetermineEnabledMutantFilters(options));

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -10,13 +10,18 @@ namespace Stryker.Core.MutantFilters
     {
         public static IMutantFilter Create(StrykerOptions options)
         {
+            if(options == null)
+            {
+                throw new ArgumentNullException($"{nameof(options)} cannot be null");
+            }
+
             return new BroadcastMutantFilter(DetermineEnabledMutantFilters(options));
         }
 
         private static IEnumerable<IMutantFilter> DetermineEnabledMutantFilters(StrykerOptions options)
         {
             var enabledFilters = new List<IMutantFilter> {
-            new FilePatternMutantFilter(),
+                    new FilePatternMutantFilter(),
                     new IgnoredMethodMutantFilter(),
                     new ExcludeMutationMutantFilter(),
                     new ExcludeFromCodeCoverageFilter()

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -1,0 +1,36 @@
+﻿using Stryker.Core.DiffProviders;
+using Stryker.Core.Options;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Stryker.Core.MutantFilters
+{
+    public static class MutantFilterFactory
+    {
+        public static IMutantFilter Create(StrykerOptions options)
+        {
+            return new BroadcastMutantFilter(DetermineEnabledMutantFilters(options));
+        }
+
+        private static IEnumerable<IMutantFilter> DetermineEnabledMutantFilters(StrykerOptions options)
+        {
+            var enabledFilters = new List<IMutantFilter> {
+            new FilePatternMutantFilter(),
+                    new IgnoredMethodMutantFilter(),
+                    new ExcludeMutationMutantFilter(),
+                    new ExcludeFromCodeCoverageFilter()
+                };
+
+            if (options.DiffEnabled)
+            {
+                enabledFilters.Add(new DiffMutantFilter(new GitDiffProvider(options)));
+            }
+            
+
+            return enabledFilters;
+
+           
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -7,14 +7,16 @@ namespace Stryker.Core.MutantFilters
 {
     public static class MutantFilterFactory
     {
-        public static IDiffProvider DiffProvider { get; private set; }
+        private static IDiffProvider _diffProvider;
 
-        public static IMutantFilter Create(StrykerOptions options)
+        public static IMutantFilter Create(StrykerOptions options, IDiffProvider diffProvider = null)
         {
             if(options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
+
+            _diffProvider = diffProvider ?? new GitDiffProvider(options);
 
             return new BroadcastMutantFilter(DetermineEnabledMutantFilters(options));
         }
@@ -30,18 +32,10 @@ namespace Stryker.Core.MutantFilters
 
             if (options.DiffEnabled)
             {
-                enabledFilters.Add(new DiffMutantFilter(DiffProvider ?? new GitDiffProvider(options)));
+                enabledFilters.Add(new DiffMutantFilter(_diffProvider));
             }
             
-
             return enabledFilters;
-
-           
-        }
-
-        public static void SetDiffProvider(IDiffProvider diffProvider)
-        {
-            DiffProvider = diffProvider;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -2,7 +2,6 @@
 using Stryker.Core.Options;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Stryker.Core.MutantFilters
 {

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -8,6 +8,8 @@ namespace Stryker.Core.MutantFilters
 {
     public static class MutantFilterFactory
     {
+        public static IDiffProvider DiffProvider { get; private set; }
+
         public static IMutantFilter Create(StrykerOptions options)
         {
             if(options == null)
@@ -29,13 +31,18 @@ namespace Stryker.Core.MutantFilters
 
             if (options.DiffEnabled)
             {
-                enabledFilters.Add(new DiffMutantFilter(new GitDiffProvider(options)));
+                enabledFilters.Add(new DiffMutantFilter(DiffProvider ?? new GitDiffProvider(options)));
             }
             
 
             return enabledFilters;
 
            
+        }
+
+        public static void SetDiffProvider(IDiffProvider diffProvider)
+        {
+            DiffProvider = diffProvider;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Stryker.Core.Compiling;
-using Stryker.Core.DiffProviders;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Logging;
 using Stryker.Core.MutantFilters;


### PR DESCRIPTION
closes #1054 

After merging this PR the following things will be refactored:

* Resposibility of creating `MutantFilters` is moved to a seperate `MutantFilterFactory`.
* Looping over the `MutantFitlers` no longer happens in `MutationTestProcess` but is done using a `BroadcastMutantFilter`.
* The `DiffMutantFilter` no longer is responsible for checking whether the `Diff` feature is enabled.