### PR TITLE
fix(pipelines): Fix issue with global dotnet tools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,9 +89,9 @@ stages:
       inputs:
         command: custom
         custom: tool
-        arguments: install dotnet-stryker -g
+        arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
         includeNuGetOrg: true
-    - script: dotnet stryker --reporters "['dashboard', 'dots']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module cli --dashboard-api-key $(Stryker.Dashboard.Api.Key)
+    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker --reporters "['dashboard', 'dots']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module cli --dashboard-api-key $(Stryker.Dashboard.Api.Key)
       condition: succeeded()
       displayName: Run Stryker on Stryker.CLI
       workingDirectory: 'src\Stryker.CLI\Stryker.CLI.UnitTest'
@@ -106,9 +106,9 @@ stages:
       inputs:
         command: custom
         custom: tool
-        arguments: install dotnet-stryker -g
+        arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
         includeNuGetOrg: true
-    - script: dotnet stryker --reporters "['dashboard', 'dots', 'html']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module core --dashboard-api-key $(Stryker.Dashboard.Api.Key)
+    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker--reporters "['dashboard', 'dots', 'html']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module core --dashboard-api-key $(Stryker.Dashboard.Api.Key)
       condition: succeeded()
       displayName: Run Stryker on Stryker.Core
       workingDirectory: 'src\Stryker.Core\Stryker.Core.UnitTest'

--- a/pipeline-templates/prepare-integration-test-steps.yml
+++ b/pipeline-templates/prepare-integration-test-steps.yml
@@ -1,9 +1,4 @@
 steps:
-  - task: UseDotNet@2
-    displayName: 'Install dotnet core 3.1.x because agents are not up to date'
-    inputs:
-      version: 3.1.x
-
   - task: DotNetCoreCLI@2 # Microsoft broke implicit restore on build so let's just keep this here..
     displayName: 'Restore'
     inputs:
@@ -22,16 +17,16 @@ steps:
     inputs:
       command: custom
       custom: tool
-      arguments: install dotnet-stryker -g --version $(IntegrationTestVersion) --add-source $(MygetFeedUri)
+      arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --version $(IntegrationTestVersion) --add-source $(MygetFeedUri)
       includeNuGetOrg: false
       workingDirectory: 'pipeline-templates'
 
   - task: DotNetCoreCLI@2
-    displayName: 'Install integrationtest dotnet tool'
+    displayName: 'Install integrationtest dotnet tool (source)'
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
     inputs:
       command: custom
       custom: tool
-      arguments: install dotnet-stryker -g --version $(IntegrationTestVersion) --add-source $(AzureArtifactFeedUri)
+      arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools --version $(IntegrationTestVersion) --add-source $(AzureArtifactFeedUri)
       includeNuGetOrg: false
       workingDirectory: 'pipeline-templates'

--- a/pipeline-templates/run-integration-test-steps.yml
+++ b/pipeline-templates/run-integration-test-steps.yml
@@ -4,7 +4,7 @@ parameters:
   strykerCommands: ''
 
 steps:
-  - script: dotnet-stryker ${{ parameters.strykerCommands }} --dev-mode -f -l trace
+  - script: $(Agent.BuildDirectory)/tools/dotnet-stryker ${{ parameters.strykerCommands }} --dev-mode -f -l trace
     workingDirectory: ${{ parameters.workingDirectory }}
     displayName: 'Run integration test ${{ parameters.testName }}'
     failOnStderr: false


### PR DESCRIPTION
Fixes issue related to running global dotnet tools right after installing it on Azure Devops pipelines.

Issue and implemented solution are further here: https://github.com/dotnet/sdk/issues/8999

As of my experienced with this same issue on some other pipelines it seems to occur in "most of runs" but not in "all the runs". Still this solution of adding the `tool path` seems to solve it for good.

- **Broken pipeline run:**

https://dev.azure.com/stryker-mutator/Stryker/_build/results?buildId=5287&view=logs&j=6d77c950-6c97-5c0c-ab3e-a9679c1574a4&t=09a0e093-6c57-5708-b0cb-1cd3cc660dca

- **Task - Install dotnet-stryker:**

```
Since you just installed the .NET Core SDK, you will need to reopen the Command Prompt window before running the tool you installed.
```

- **Task - Run Stryker on Stryker.Core:**

```
Generating script.
Script contents:
dotnet stryker --reporters "['dashboard', 'dots', 'html']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module core --dashboard-api-key ***
========================== Starting Command Output ===========================
"C:\windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "D:\a\_temp\f9ad785c-7eb7-49d7-b9b7-457a6f706df9.cmd""
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET Core program, but dotnet-stryker does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```