### PR TITLE
docs(diff config) Extends documentation on diff

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -364,6 +364,10 @@ dotnet stryker -gs "development"
 
 Default: `master`
 
+This feature works based on file diffs, which means that all changed filles will have all of its possible mutants mutated.
+
+Also note that for changes on test files all mutants being tested in that file will be mutated.
+
 ## EXPERIMENTAL: Dashboard Compare
 Enabling the dashboard compare feature saves reports and re-uses the result when a mutant or it's tests are unchanged.
 


### PR DESCRIPTION
Improves documentation on how the diff feature actually works. 

Seems like some people (including myself) were not understanding the expected behavior of this feature, as ir can be seen in these issues: #1160 #1180 