### PR TITLE
fix(pipeline): Fix typo wich is breaking the pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ stages:
         custom: tool
         arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
         includeNuGetOrg: true
-    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker--reporters "['dashboard', 'dots', 'html']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module core --dashboard-api-key $(Stryker.Dashboard.Api.Key)
+    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker --reporters "['dashboard', 'dots', 'html']" --dashboard-project github.com/stryker-mutator/stryker-net --dashboard-version master --dashboard-module core --dashboard-api-key $(Stryker.Dashboard.Api.Key)
       condition: succeeded()
       displayName: Run Stryker on Stryker.Core
       workingDirectory: 'src\Stryker.Core\Stryker.Core.UnitTest'


### PR DESCRIPTION
There was a missing space between the calling of stryker and the first argument that is causing the pipeline to break.

https://dev.azure.com/stryker-mutator/Stryker/_build/results?buildId=5322&view=logs&j=6d77c950-6c97-5c0c-ab3e-a9679c1574a4&t=6be46d81-717b-5e63-da84-91412b35485c

**Task - Run Stryker on Stryker.Core**
```
 'D:\a\1/tools/dotnet-stryker--reporters' is not recognized as an internal or external command,
```