### PR TITLE
Implement console table report

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextReporterTests.cs
@@ -101,8 +101,8 @@ All mutants have been tested, and your mutation score has been calculated
 ┌─────────────┬──────────┬──────────┬───────────┬────────────┬──────────┬─────────┐
 │ File        │  % score │ # killed │ # timeout │ # survived │ # no cov │ # error │
 ├─────────────┼──────────┼──────────┼───────────┼────────────┼──────────┼─────────┤
-│ All files   │   100,00 │        1 │         0 │          0 │        0 │       0 │
-│ SomeFile.cs │   100,00 │        1 │         0 │          0 │        0 │       0 │
+│ All files   │   {100:N2} │        1 │         0 │          0 │        0 │       0 │
+│ SomeFile.cs │   {100:N2} │        1 │         0 │          0 │        0 │       0 │
 └─────────────┴──────────┴──────────┴───────────┴────────────┴──────────┴─────────┘
 ");
             chalkMock.Verify(x => x.Green(It.IsAny<string>()), Times.Exactly(2));
@@ -153,8 +153,8 @@ All mutants have been tested, and your mutation score has been calculated
 ┌─────────────┬──────────┬──────────┬───────────┬────────────┬──────────┬─────────┐
 │ File        │  % score │ # killed │ # timeout │ # survived │ # no cov │ # error │
 ├─────────────┼──────────┼──────────┼───────────┼────────────┼──────────┼─────────┤
-│ All files   │     0,00 │        0 │         0 │          1 │        0 │       0 │
-│ SomeFile.cs │     0,00 │        0 │         0 │          1 │        0 │       0 │
+│ All files   │     {0:N2} │        0 │         0 │          1 │        0 │       0 │
+│ SomeFile.cs │     {0:N2} │        0 │         0 │          1 │        0 │       0 │
 └─────────────┴──────────┴──────────┴───────────┴────────────┴──────────┴─────────┘
 ");
             // All percentages should be red and the [Survived] too

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextTreeReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextTreeReporterTests.cs
@@ -13,18 +13,18 @@ using Xunit;
 
 namespace Stryker.Core.UnitTest.Reporters
 {
-    public class ClearTextReporterTests
+    public class ClearTextTreeReporterTests
     {
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintOnReportDone()
+        public void ClearTextTreeReporter_ShouldPrintOnReportDone()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
             chalkMock.Setup(x => x.DarkGray(It.IsAny<string>())).Callback((string text) => { output += text; });
             chalkMock.Setup(x => x.Default(It.IsAny<string>())).Callback((string text) => { output += text; });
 
-            var target = new ClearTextReporter(new StrykerOptions(), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -36,7 +36,6 @@ namespace Stryker.Core.UnitTest.Reporters
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>() { }
             });
@@ -46,18 +45,14 @@ namespace Stryker.Core.UnitTest.Reporters
             output.ToString().ShouldBeWithNewlineReplace($@"
 
 All mutants have been tested, and your mutation score has been calculated
-┌─────────────┬──────────┬──────────┬───────────┬────────────┬──────────┬─────────┐
-│ File        │  % score │ # killed │ # timeout │ # survived │ # no cov │ # error │
-├─────────────┼──────────┼──────────┼───────────┼────────────┼──────────┼─────────┤
-│ All files   │      N/A │        0 │         0 │          0 │        0 │       0 │
-│ SomeFile.cs │      N/A │        0 │         0 │          0 │        0 │       0 │
-└─────────────┴──────────┴──────────┴───────────┴────────────┴──────────┴─────────┘
+RootFolder [0/0 (N/A)]
+└── SomeFile.cs [0/0 (N/A)]
 ");
             chalkMock.Verify(x => x.DarkGray(It.IsAny<string>()), Times.Exactly(2));
         }
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintKilledMutation()
+        public void ClearTextTreeReporter_ShouldPrintKilledMutation()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
@@ -75,7 +70,7 @@ All mutants have been tested, and your mutation score has been calculated
                 Type = Mutator.Arithmetic
             };
 
-            var target = new ClearTextReporter(new StrykerOptions(), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -87,7 +82,6 @@ All mutants have been tested, and your mutation score has been calculated
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>() { new Mutant() {
                 ResultStatus = MutantStatus.Killed, Mutation = mutation } }
@@ -98,18 +92,17 @@ All mutants have been tested, and your mutation score has been calculated
             output.ShouldBeWithNewlineReplace($@"
 
 All mutants have been tested, and your mutation score has been calculated
-┌─────────────┬──────────┬──────────┬───────────┬────────────┬──────────┬─────────┐
-│ File        │  % score │ # killed │ # timeout │ # survived │ # no cov │ # error │
-├─────────────┼──────────┼──────────┼───────────┼────────────┼──────────┼─────────┤
-│ All files   │   100,00 │        1 │         0 │          0 │        0 │       0 │
-│ SomeFile.cs │   100,00 │        1 │         0 │          0 │        0 │       0 │
-└─────────────┴──────────┴──────────┴───────────┴────────────┴──────────┴─────────┘
+RootFolder [1/1 ({1:P2})]
+└── SomeFile.cs [1/1 ({1:P2})]
+    └── [Killed] This name should display on line 1
+        ├── [-] 0 + 8
+        └── [+] 0 -8
 ");
-            chalkMock.Verify(x => x.Green(It.IsAny<string>()), Times.Exactly(2));
+            chalkMock.Verify(x => x.Green(It.IsAny<string>()), Times.Exactly(3));
         }
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintSurvivedMutation()
+        public void ClearTextTreeReporter_ShouldPrintSurvivedMutation()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
@@ -127,7 +120,7 @@ All mutants have been tested, and your mutation score has been calculated
                 Type = Mutator.Arithmetic
             };
 
-            var target = new ClearTextReporter(new StrykerOptions(), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -139,7 +132,6 @@ All mutants have been tested, and your mutation score has been calculated
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>() { new Mutant() {
                 ResultStatus = MutantStatus.Survived, Mutation = mutation } }
@@ -150,19 +142,18 @@ All mutants have been tested, and your mutation score has been calculated
             output.ShouldBeWithNewlineReplace($@"
 
 All mutants have been tested, and your mutation score has been calculated
-┌─────────────┬──────────┬──────────┬───────────┬────────────┬──────────┬─────────┐
-│ File        │  % score │ # killed │ # timeout │ # survived │ # no cov │ # error │
-├─────────────┼──────────┼──────────┼───────────┼────────────┼──────────┼─────────┤
-│ All files   │     0,00 │        0 │         0 │          1 │        0 │       0 │
-│ SomeFile.cs │     0,00 │        0 │         0 │          1 │        0 │       0 │
-└─────────────┴──────────┴──────────┴───────────┴────────────┴──────────┴─────────┘
+RootFolder [0/1 ({0:P2})]
+└── SomeFile.cs [0/1 ({0:P2})]
+    └── [Survived] This name should display on line 1
+        ├── [-] 0 + 8
+        └── [+] 0 -8
 ");
             // All percentages should be red and the [Survived] too
-            chalkMock.Verify(x => x.Red(It.IsAny<string>()), Times.Exactly(2));
+            chalkMock.Verify(x => x.Red(It.IsAny<string>()), Times.Exactly(3));
         }
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintRedUnderThresholdBreak()
+        public void ClearTextTreeReporter_ShouldPrintRedUnderThresholdBreak()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
@@ -181,7 +172,7 @@ All mutants have been tested, and your mutation score has been calculated
                 Type = Mutator.Arithmetic
             };
 
-            var target = new ClearTextReporter(new StrykerOptions(thresholdHigh: 80, thresholdLow: 70, thresholdBreak: 0), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(thresholdHigh: 80, thresholdLow: 70, thresholdBreak: 0), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -193,7 +184,6 @@ All mutants have been tested, and your mutation score has been calculated
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>()
                 {
@@ -207,11 +197,11 @@ All mutants have been tested, and your mutation score has been calculated
 
             target.OnAllMutantsTested(folder);
 
-            chalkMock.Verify(x => x.Red(It.IsAny<string>()), Times.Exactly(2));
+            chalkMock.Verify(x => x.Red(It.IsAny<string>()), Times.Exactly(4));
         }
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintYellowBetweenThresholdLowAndThresholdBreak()
+        public void ClearTextTreeReporter_ShouldPrintYellowBetweenThresholdLowAndThresholdBreak()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
@@ -231,7 +221,7 @@ All mutants have been tested, and your mutation score has been calculated
                 Type = Mutator.Arithmetic
             };
 
-            var target = new ClearTextReporter(new StrykerOptions(thresholdHigh: 90, thresholdLow: 70, thresholdBreak: 0), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(thresholdHigh: 90, thresholdLow: 70, thresholdBreak: 0), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -243,7 +233,6 @@ All mutants have been tested, and your mutation score has been calculated
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>()
                 {
@@ -261,7 +250,7 @@ All mutants have been tested, and your mutation score has been calculated
         }
 
         [Fact]
-        public void ClearTextReporter_ShouldPrintGreenAboveThresholdHigh()
+        public void ClearTextTreeReporter_ShouldPrintGreenAboveThresholdHigh()
         {
             string output = "";
             var chalkMock = new Mock<IChalk>(MockBehavior.Strict);
@@ -279,7 +268,7 @@ All mutants have been tested, and your mutation score has been calculated
                 Type = Mutator.Arithmetic
             };
 
-            var target = new ClearTextReporter(new StrykerOptions(), chalkMock.Object);
+            var target = new ClearTextTreeReporter(new StrykerOptions(), chalkMock.Object);
 
             var folder = new FolderComposite()
             {
@@ -291,7 +280,6 @@ All mutants have been tested, and your mutation score has been calculated
             {
                 Name = "SomeFile.cs",
                 RelativePath = "RootFolder/SomeFile.cs",
-                RelativePathToProjectFile = "SomeFile.cs",
                 FullPath = "C://RootFolder/SomeFile.cs",
                 Mutants = new Collection<Mutant>()
                 {
@@ -301,7 +289,7 @@ All mutants have been tested, and your mutation score has been calculated
 
             target.OnAllMutantsTested(folder);
 
-            chalkMock.Verify(x => x.Green(It.IsAny<string>()), Times.Exactly(2));
+            chalkMock.Verify(x => x.Green(It.IsAny<string>()), Times.Exactly(3));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
@@ -37,11 +37,12 @@ namespace Stryker.Core.UnitTest.Reporters
             result.Reporters.ShouldContain(r => r is HtmlReporter);
             result.Reporters.ShouldContain(r => r is ConsoleDotProgressReporter);
             result.Reporters.ShouldContain(r => r is ClearTextReporter);
+            result.Reporters.ShouldContain(r => r is ClearTextTreeReporter);
             result.Reporters.ShouldContain(r => r is ProgressReporter);
             result.Reporters.ShouldContain(r => r is DashboardReporter);
             result.Reporters.ShouldContain(r => r is GitBaselineReporter);
 
-            result.Reporters.Count().ShouldBe(7);
+            result.Reporters.Count().ShouldBe(8);
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
@@ -43,10 +43,10 @@ namespace Stryker.Core.ProjectComponents
             // only walk this branch of the tree if there are MutatedSyntaxTrees, otherwise we have nothing to display.
             if (MutatedSyntaxTrees.Any())
             {
-                // do not display root node
+                DisplayFolder(depth, this);
+
                 if (!string.IsNullOrEmpty(Name))
                 {
-                    DisplayFolder(depth, this);
                     depth++;
                 }
 

--- a/src/Stryker.Core/Stryker.Core/Reporters/ClearTextTreeReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ClearTextTreeReporter.cs
@@ -1,0 +1,197 @@
+﻿using Stryker.Core.Mutants;
+using Stryker.Core.Options;
+using Stryker.Core.ProjectComponents;
+using Stryker.Core.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Stryker.Core.Reporters
+{
+    /// <summary>
+    /// The clear text tree reporter, prints a tree structure with results.
+    /// </summary>
+    public class ClearTextTreeReporter : IReporter
+    {
+        private const string ContinueLine = "│   ";
+        private const string NoLine = "    ";
+        private const string BranchLine = "├── ";
+        private const string FinalBranchLine = "└── ";
+
+        private readonly IChalk _chalk;
+        private readonly StrykerOptions _options;
+
+        public ClearTextTreeReporter(StrykerOptions strykerOptions, IChalk chalk = null)
+        {
+            _options = strykerOptions;
+            _chalk = chalk ?? new Chalk();
+        }
+
+        public void OnMutantsCreated(IReadOnlyInputComponent reportComponent)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnStartMutantTestRun(IEnumerable<IReadOnlyMutant> mutantsToBeTested, IEnumerable<TestDescription> testDescriptions)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnMutantTested(IReadOnlyMutant result)
+        {
+            // This reporter does not report during the testrun
+        }
+
+        public void OnAllMutantsTested(IReadOnlyInputComponent reportComponent)
+        {
+            var rootFolderProcessed = false;
+
+            // setup display handlers
+            reportComponent.DisplayFolder = (int _, IReadOnlyInputComponent current) =>
+            {
+                // show depth
+                var continuationLines = ParentContinuationLines(current);
+
+                var stringBuilder = new StringBuilder();
+                foreach (var item in continuationLines.SkipLast(1))
+                {
+                    stringBuilder.Append(item ? ContinueLine : NoLine);
+                }
+
+                var folderLines = string.Empty;
+                if (continuationLines.Count > 0)
+                {
+                    folderLines = continuationLines.Last() ? BranchLine : FinalBranchLine;
+                }
+
+                var name = current.Name;
+                if (name == null && !rootFolderProcessed)
+                {
+                    name = "All files";
+                    rootFolderProcessed = true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    _chalk.Default($"{stringBuilder}{folderLines}{name}");
+                    DisplayComponent(current);
+                }
+            };
+
+            reportComponent.DisplayFile = (int _, IReadOnlyInputComponent current) =>
+            {
+                // show depth
+                var continuationLines = ParentContinuationLines(current);
+
+                var stringBuilder = new StringBuilder();
+                foreach (var item in continuationLines.SkipLast(1))
+                {
+                    stringBuilder.Append(item ? ContinueLine : NoLine);
+                }
+
+                _chalk.Default($"{stringBuilder}{(continuationLines.Last() ? BranchLine : FinalBranchLine)}{current.Name}");
+                DisplayComponent(current);
+
+                stringBuilder.Append(continuationLines.Last() ? ContinueLine : NoLine);
+
+                var prefix = stringBuilder.ToString();
+
+                foreach (var mutant in current.TotalMutants)
+                {
+                    var isLastMutant = current.TotalMutants.Last() == mutant;
+
+                    _chalk.Default($"{prefix}{(isLastMutant ? FinalBranchLine : BranchLine)}");
+
+                    switch (mutant.ResultStatus)
+                    {
+                        case MutantStatus.Killed:
+                        case MutantStatus.Timeout:
+                            _chalk.Green($"[{mutant.ResultStatus}]");
+                            break;
+                        case MutantStatus.NoCoverage:
+                            _chalk.Yellow($"[{mutant.ResultStatus}]");
+                            break;
+                        default:
+                            _chalk.Red($"[{mutant.ResultStatus}]");
+                            break;
+                    }
+
+                    _chalk.Default($" {mutant.Mutation.DisplayName} on line {mutant.Line}{Environment.NewLine}");
+                    _chalk.Default($"{prefix}{(isLastMutant ? NoLine : ContinueLine)}{BranchLine}[-] {mutant.Mutation.OriginalNode}{Environment.NewLine}");
+                    _chalk.Default($"{prefix}{(isLastMutant ? NoLine : ContinueLine)}{FinalBranchLine}[+] {mutant.Mutation.ReplacementNode}{Environment.NewLine}");
+                }
+            };
+
+            // print empty line for readability
+            _chalk.Default($"{Environment.NewLine}{Environment.NewLine}All mutants have been tested, and your mutation score has been calculated{Environment.NewLine}");
+
+            // start recursive invocation of handlers
+            reportComponent.Display(1);
+        }
+
+        private static List<bool> ParentContinuationLines(IReadOnlyInputComponent current)
+        {
+            var continuationLines = new List<bool>();
+
+            var node = (ProjectComponent)current;
+
+            if (node.Parent != null)
+            {
+                var isRootFile = node.RelativePath == node.RelativePathToProjectFile;
+                if (isRootFile)
+                {
+                    continuationLines.Add(true);
+                }
+                else
+                {
+                    while (node.Parent != null)
+                    {
+                        continuationLines.Add(node.Parent.Children.Last() != node);
+
+                        node = node.Parent;
+                    }
+
+                    continuationLines.Reverse();
+                }
+            }
+
+            return continuationLines;
+        }
+
+        private void DisplayComponent(IReadOnlyInputComponent inputComponent)
+        {
+            var mutationScore = inputComponent.GetMutationScore();
+
+            // Convert the threshold integer values to decimal values
+            _chalk.Default($" [{ inputComponent.DetectedMutants.Count()}/{ inputComponent.TotalMutants.Count()} ");
+
+            if (inputComponent is ProjectComponent projectComponent && projectComponent.FullPath != null && projectComponent.IsComponentExcluded(_options.FilePatterns))
+            {
+                _chalk.DarkGray($"(Excluded)");
+            }
+            else if (double.IsNaN(mutationScore))
+            {
+                _chalk.DarkGray($"(N/A)");
+            }
+            else
+            {
+                // print the score as a percentage
+                string scoreText = string.Format("({0:P2})", mutationScore);
+                if (inputComponent.CheckHealth(_options.Thresholds) is Health.Good)
+                {
+                    _chalk.Green(scoreText);
+                }
+                else if (inputComponent.CheckHealth(_options.Thresholds) is Health.Warning)
+                {
+                    _chalk.Yellow(scoreText);
+                }
+                else if (inputComponent.CheckHealth(_options.Thresholds) is Health.Danger)
+                {
+                    _chalk.Red(scoreText);
+                }
+            }
+            _chalk.Default($"]{Environment.NewLine}");
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Reporter.cs
@@ -8,6 +8,7 @@
         Dots,
         ConsoleProgressDots,
         ClearText,
+        ClearTextTree,
         ConsoleReport,
         Json,
         Html,

--- a/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
@@ -22,6 +22,7 @@ namespace Stryker.Core.Reporters
                 { Reporter.Dots, new ConsoleDotProgressReporter() },
                 { Reporter.Progress, CreateProgressReporter() },
                 { Reporter.ClearText, new ClearTextReporter(options) },
+                { Reporter.ClearTextTree, new ClearTextTreeReporter(options) },
                 { Reporter.Json, new JsonReporter(options) },
                 { Reporter.Html, new HtmlReporter(options) },
                 { Reporter.Dashboard, new DashboardReporter(options)},


### PR DESCRIPTION
* Renamed `ClearTextReporter` to `ClearTextTreeReporter`
* Added table report as `ClearTextReporter`

![image](https://user-images.githubusercontent.com/10671831/95630846-da559480-0a82-11eb-8961-1ae68dadef2c.png)

To get a "All files" line, I needed the root folder in the reporter, that was explicitly skipped previously.
This led to some changes (/improvements) to the tree report
* Show root folder with totals in tree
* Move root folder files to root in tree report

![image](https://user-images.githubusercontent.com/10671831/95630878-e93c4700-0a82-11eb-972e-2cd85f38bf27.png)

Ready for your feedback. 😄 

Should close #1238