### PR TITLE
chore: Add issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+- name: Chat with the team
+  url: https://join.slack.com/t/stryker-mutator/shared_invite/enQtOTUyMTYyNTg1NDQ0LTU4ODNmZDlmN2I3MmEyMTVhYjZlYmJkOThlNTY3NTM1M2QxYmM5YTM3ODQxYmJjY2YyYzllM2RkMmM1NjNjZjM
+  about: Join us on slack if you want to chat with the stryker team or other users.
+- name: Ask a Question
+  url: https://github.com/stryker-mutator/stryker-net/discussions/category_choices
+  about: Please ask and answer questions here.


### PR DESCRIPTION
Gives us something like this:

![image](https://user-images.githubusercontent.com/835562/96009022-65c18380-0dfd-11eb-839c-ca073adb41e6.png)