### PR TITLE
feat(diff compare): Rename parameter git source to git diff target

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -582,9 +582,9 @@ namespace Stryker.CLI.UnitTest
         }
 
         [Theory]
-        [InlineData("--git-source")]
-        [InlineData("-gs")]
-        public void ShouldSetGitSourceWhenPassed(string argName)
+        [InlineData("--git-diff-target")]
+        [InlineData("-gdt")]
+        public void ShouldSetGitDiffTargetWhenPassed(string argName)
         {
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             StrykerOptions options = new StrykerOptions();

--- a/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CLIOptions.cs
@@ -144,11 +144,11 @@ namespace Stryker.CLI
 
         public static readonly CLIOption<string> GitDiffTarget = new CLIOption<string>
         {
-            ArgumentName = "--git-source",
-            ArgumentShortName = "-gs <branchName>",
-            ArgumentDescription = @"Sets the source branch to compare with the current codebase, used for calculating the difference when --diff is enabled.",
+            ArgumentName = "--git-diff-target",
+            ArgumentShortName = "-gdt <commitish>",
+            ArgumentDescription = @"Sets the source commitish (branch or commit) to compare with the current codebase, used for calculating the difference when --diff is enabled. Default: master",
             DefaultValue = _defaultOptions.GitDiffTarget,
-            JsonKey = "git-source"
+            JsonKey = "git-diff-target"
         };
 
         public static readonly CLIOption<string> CoverageAnalysis = new CLIOption<string>


### PR DESCRIPTION
closes #1230 
breaks: Parameter GitSource is replaced with GitDiffTarget