### PR TITLE
docs: update docs for new website

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,3 +1,7 @@
+---
+custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs/Configuration.md
+---
+
 For .NET Core projects Stryker.NET can be run without any configuration. On .NET Framework projects the solution path is required.
 
 ## Use a config file

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,30 +1,5 @@
 For .NET Core projects Stryker.NET can be run without any configuration. On .NET Framework projects the solution path is required.
 
-The full list of Stryker.NET configuration options are:
-
-<!-- TOC -->
-- [Config file](#use-a-config-file)
-- [Solution path (required .NET Framework)](#solution-path)
-- [Project file (required on some projects)](#project-file)
-- [Mutation level](#mutation-level)
-- [Test runner](#specify-testrunner)
-- [Timeout time](#timeout-time)
-- [Reporters](#reporters)
-- [Test projects](#test-projects)
-- [Logging to console](#logging-to-console)
-- [Excluding mutations](#excluding-mutations)
-- [Excluding files (deprecated)](#excluding-files)
-- [Mutate](#mutate)
-- [Ignore methods](#ignore-methods)
-- [Custom tresholds](#custom-thresholds)
-- [Coverage analysis](#coverage-analysis)
-- [Abort testrun on test failure](#abort-test-on-fail)
-- [Diff based file exclusion](#diff)
-- [Git diff source](#git-source)
-- [Exclude files from git diff](#diff-ignore-files)
-- [EXPERIMENTAL: Dashboard compare](#experimental-dashboard-compare)
-<!-- /TOC -->
-
 ## Use a config file
 When using Stryker in a team we recomend using a config file. This way you ensure all team members use the same settings to run Stryker. The settings will also be picked up in pipelines. To use a config file create a file called `stryker-config.json` in the folder you run Stryker and add a configuration section called stryker-config. Then you can add the options you want to configure to the file.
 
@@ -152,7 +127,7 @@ dotnet stryker --reporters "['html', 'progress']"
 dotnet stryker -r "['html', 'progress']"
 ```
 
-You can find a list of all available reporters and what output they produce in the [reporter docs](/docs/Reporters.md)
+You can find a list of all available reporters and what output they produce in the [reporter docs](./Reporters.md)
 
 Default: `"['html', 'progress']"`
 
@@ -455,7 +430,7 @@ Defaut `"disk"`
 
 ## Configurating Dashboard location
 
-See: [Dashboard Reporter Settings](/docs/Reporters.md#dashboard-reporter)
+See: [Dashboard Reporter Settings](./Reporters.md#dashboard-reporter)
 
 ## Configuring Azure File Storage
 When using Azure File Storage as baseline storage location you are required to provide the following values.
@@ -492,4 +467,4 @@ dotnet stryker -compare -bsl AzureFileStorage -storage-url https://STORAGE_NAME.
 
 ## Using dashboard compare in a pull request pipeline
 
-See: [Using stryker in pipelines](/docs/Stryker-in-pipeline.md)
+See: [Using stryker in pipelines](./Stryker-in-pipeline.md)

--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -1,21 +1,5 @@
 Stryker supports a variety of mutators, which are listed below. Do you have a suggestion for a (new) mutator? Feel free to create an [issue](https://github.com/stryker-mutator/stryker-net/issues)!
 
-
-<!-- TOC -->
-- [Arithmetic Operators](#arithmetic-operators)
-- [Equality Operators](#equality-operators)
-- [Boolean Literals](#boolean-literals)
-- [Assignment statements](#assignment-statements)
-- [Collection initialization](#collection-initialization)
-- [Unary Operators](#unary-operators)
-- [Update Operators](#update-operators)
-- [Checked Statements](#checked-statements)
-- [Linq Methods](#linq-methods)
-- [String Literals and Constants](#string-literals-and-constants)
-- [Bitwise Operators](#bitwise-operators)
-- [Regular Expressions](#regular-expressions)
-<!-- /TOC -->
-
 ## Arithmetic Operators
 | Original | Mutated | 
 | ------------- | ------------- | 

--- a/docs/Mutators.md
+++ b/docs/Mutators.md
@@ -1,3 +1,7 @@
+---
+custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs/Mutators.md
+---
+
 Stryker supports a variety of mutators, which are listed below. Do you have a suggestion for a (new) mutator? Feel free to create an [issue](https://github.com/stryker-mutator/stryker-net/issues)!
 
 ## Arithmetic Operators

--- a/docs/Reporters.md
+++ b/docs/Reporters.md
@@ -1,14 +1,5 @@
 Stryker supports a variety of reporters. Enabled reporters will be activated during and after your Stryker run. 
 
-<!-- TOC -->
-- [Html reporter](#html-reporter)
-- [Dashboard reporter](#dashboard-reporter)
-- [Console reporter](#console-reporter)
-- [Progress reporter](#progress-reporter)
-- [Console dots reporter](#console-dots-reporter)
-- [Json reporter](#json-reporter)
-<!-- /TOC -->
-
 The default reporters are:
 
 ```

--- a/docs/Reporters.md
+++ b/docs/Reporters.md
@@ -1,3 +1,7 @@
+---
+custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs/Reporters.md
+---
+
 Stryker supports a variety of reporters. Enabled reporters will be activated during and after your Stryker run. 
 
 The default reporters are:

--- a/docs/Stryker-in-pipeline.md
+++ b/docs/Stryker-in-pipeline.md
@@ -1,5 +1,6 @@
 ---
 title: Installing Stryker in pipelines
+custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs/Stryker-in-pipeline.md
 ---
 
 When running stryker in your pipeline there are some things to take into consideration

--- a/docs/Stryker-in-pipeline.md
+++ b/docs/Stryker-in-pipeline.md
@@ -1,7 +1,9 @@
-# Running stryker in your pipeline
+---
+title: Installing Stryker in pipelines
+---
+
 When running stryker in your pipeline there are some things to take into consideration
 
-## Installing stryker in pipelines
 Due to the way dotnet core global tools are installed on the system a regular `dotnet tool install -g` is often not effective in pipelines.
 
 Instead use the `--tool-path` to install stryker in a local folder or use the project level install of dotnet core 3.0+
@@ -38,7 +40,7 @@ The following minimal steps are needed to use dashboard compare
 1. Set up authentication for the chosen storage provider 
 1. Set --dashboard-version to the name of the source branch (usually current branch)
 1. Set --git-source to the name of the target branch (usually master/main or development)
-1. Set any other options needed for your chosen storage provider (see: [Configuration](/docs/Configuration.md))
+1. Set any other options needed for your chosen storage provider (see: [Configuration](./Configuration.md))
 
 Example for azure devops with dashboard storage provider:
 ```


### PR DESCRIPTION
🙋‍♀️! This PR does a couple things with documentation:

- Fix some links to be relative instead of from the root
- Removes the table of contents. I can add them back if you want, but Docusaurus already has TOC's in the side
- Add a title meta-header to the `Stryker-in-pipeline.md`. The other files have nice capitalized names so they don't need it.
- Add custom-edit-urls to fix 'Edit this page' links

![image](https://user-images.githubusercontent.com/10114577/97006141-b17fd580-153f-11eb-8be1-6f6ee50659e6.png)

