### PR TITLE
Add regex look ahead and behind mutators

### DIFF
--- a/src/Stryker.RegexMutators/Stryker.RegexMutators.UnitTest/Mutators/LookAroundMutatorTest.cs
+++ b/src/Stryker.RegexMutators/Stryker.RegexMutators.UnitTest/Mutators/LookAroundMutatorTest.cs
@@ -1,0 +1,89 @@
+﻿using RegexParser.Nodes;
+using Shouldly;
+using Stryker.RegexMutators.Mutators;
+using System.Collections.Generic;
+using System.Linq;
+using RegexParser.Nodes.GroupNodes;
+using Xunit;
+
+namespace Stryker.RegexMutators.UnitTest.Mutators
+{
+    public class LookAroundMutatorTest
+    {
+        [Fact]
+        public void FlipsPositiveLookAheadToNegativeLookAhead()
+        {
+            // Arrange
+            var foo = new List<RegexNode>
+            {
+                new CharacterNode('f'), 
+                new CharacterNode('o'), 
+                new CharacterNode('o')
+            };
+            var lookaroundGroupNode = new LookaroundGroupNode(true, true, foo);
+            var rootNode = new ConcatenationNode(lookaroundGroupNode);
+            var target = new LookAroundMutator();
+
+            var expectedResults = new List<string>
+            {
+                "(?!foo)",
+                "(?<=foo)"
+            };
+
+            // Act
+            var mutations = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
+
+            // Assert
+            var index = 0;
+            var originalQuantifier = "(?=foo)";
+            foreach (var mutation in mutations)
+            {
+                mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
+                mutation.ReplacementNode.ToString().ShouldBe(expectedResults[index]);
+                mutation.ReplacementPattern.ShouldBe(expectedResults[index]);
+                mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
+                mutation.Description.ShouldBe($"Quantifier \"{originalQuantifier}\" was replaced with \"{expectedResults[index]}\" at offset 0.");
+                index++;
+            }
+            mutations.Count.ShouldBe(2);
+        }
+        
+        [Fact]
+        public void FlipsNegativeLookAheadToPositiveLookAhead()
+        {
+            // Arrange
+            var foo = new List<RegexNode>
+            {
+                new CharacterNode('f'), 
+                new CharacterNode('o'), 
+                new CharacterNode('o')
+            };
+            var lookaroundGroupNode = new LookaroundGroupNode(true, false, foo);
+            var rootNode = new ConcatenationNode(lookaroundGroupNode);
+            var target = new LookAroundMutator();
+
+            var expectedResults = new List<string>
+            {
+                "(?=foo)",
+                "(?<!foo)"
+            };
+
+            // Act
+            var mutations = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
+
+            // Assert
+            var index = 0;
+            var originalQuantifier = "(?!foo)";
+            foreach (var mutation in mutations)
+            {
+                mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
+                mutation.ReplacementNode.ToString().ShouldBe(expectedResults[index]);
+                mutation.ReplacementPattern.ShouldBe(expectedResults[index]);
+                mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
+                mutation.Description.ShouldBe($"Quantifier \"{originalQuantifier}\" was replaced with \"{expectedResults[index]}\" at offset 0.");
+                index++;
+            }
+            mutations.Count.ShouldBe(2);
+        }
+    }
+}

--- a/src/Stryker.RegexMutators/Stryker.RegexMutators.UnitTest/Mutators/LookAroundMutatorTest.cs
+++ b/src/Stryker.RegexMutators/Stryker.RegexMutators.UnitTest/Mutators/LookAroundMutatorTest.cs
@@ -11,7 +11,7 @@ namespace Stryker.RegexMutators.UnitTest.Mutators
     public class LookAroundMutatorTest
     {
         [Fact]
-        public void FlipsPositiveLookAheadToNegativeLookAhead()
+        public void FlipsPositiveLookBehindToNegativeLookBehind()
         {
             // Arrange
             var foo = new List<RegexNode>
@@ -20,32 +20,20 @@ namespace Stryker.RegexMutators.UnitTest.Mutators
                 new CharacterNode('o'), 
                 new CharacterNode('o')
             };
-            var lookaroundGroupNode = new LookaroundGroupNode(true, true, foo);
+            var lookaroundGroupNode = new LookaroundGroupNode(false, true, foo);
             var rootNode = new ConcatenationNode(lookaroundGroupNode);
             var target = new LookAroundMutator();
 
-            var expectedResults = new List<string>
-            {
-                "(?!foo)",
-                "(?<=foo)"
-            };
-
             // Act
-            var mutations = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
+            var result = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
 
             // Assert
-            var index = 0;
-            var originalQuantifier = "(?=foo)";
-            foreach (var mutation in mutations)
-            {
-                mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
-                mutation.ReplacementNode.ToString().ShouldBe(expectedResults[index]);
-                mutation.ReplacementPattern.ShouldBe(expectedResults[index]);
-                mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
-                mutation.Description.ShouldBe($"Quantifier \"{originalQuantifier}\" was replaced with \"{expectedResults[index]}\" at offset 0.");
-                index++;
-            }
-            mutations.Count.ShouldBe(2);
+            var mutation = result.ShouldHaveSingleItem();
+            mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
+            mutation.ReplacementNode.ToString().ShouldBe("(?<!foo)");
+            mutation.ReplacementPattern.ShouldBe("(?<!foo)");
+            mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
+            mutation.Description.ShouldBe("Quantifier \"(?<=foo)\" was replaced with \"(?<!foo)\" at offset 0.");
         }
         
         [Fact]
@@ -62,28 +50,16 @@ namespace Stryker.RegexMutators.UnitTest.Mutators
             var rootNode = new ConcatenationNode(lookaroundGroupNode);
             var target = new LookAroundMutator();
 
-            var expectedResults = new List<string>
-            {
-                "(?=foo)",
-                "(?<!foo)"
-            };
-
             // Act
-            var mutations = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
+            var result = target.ApplyMutations(lookaroundGroupNode, rootNode).ToList();
 
             // Assert
-            var index = 0;
-            var originalQuantifier = "(?!foo)";
-            foreach (var mutation in mutations)
-            {
-                mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
-                mutation.ReplacementNode.ToString().ShouldBe(expectedResults[index]);
-                mutation.ReplacementPattern.ShouldBe(expectedResults[index]);
-                mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
-                mutation.Description.ShouldBe($"Quantifier \"{originalQuantifier}\" was replaced with \"{expectedResults[index]}\" at offset 0.");
-                index++;
-            }
-            mutations.Count.ShouldBe(2);
+            var mutation = result.ShouldHaveSingleItem();
+            mutation.OriginalNode.ShouldBe(lookaroundGroupNode);
+            mutation.ReplacementNode.ToString().ShouldBe("(?=foo)");
+            mutation.ReplacementPattern.ShouldBe("(?=foo)");
+            mutation.DisplayName.ShouldBe("Regex greedy quantifier quantity mutation");
+            mutation.Description.ShouldBe("Quantifier \"(?!foo)\" was replaced with \"(?=foo)\" at offset 0.");
         }
     }
 }

--- a/src/Stryker.RegexMutators/Stryker.RegexMutators/Mutators/LookAroundMutator.cs
+++ b/src/Stryker.RegexMutators/Stryker.RegexMutators/Mutators/LookAroundMutator.cs
@@ -1,0 +1,29 @@
+﻿using RegexParser.Nodes;
+using System.Collections.Generic;
+using RegexParser.Nodes.GroupNodes;
+
+namespace Stryker.RegexMutators.Mutators
+{
+    public class LookAroundMutator : RegexMutatorBase<LookaroundGroupNode>, IRegexMutator
+    {
+        public override IEnumerable<RegexMutation> ApplyMutations(LookaroundGroupNode node, RegexNode root)
+        {
+            yield return FlipLookAround(node, root, node.Lookahead, ! node.Possitive);
+            yield return FlipLookAround(node, root, ! node.Lookahead, node.Possitive);
+        }
+
+        private RegexMutation FlipLookAround(LookaroundGroupNode node, RegexNode root, bool lookAhead, bool positive)
+        {
+            var replacementNode = new LookaroundGroupNode(lookAhead, positive, node.ChildNodes);
+
+            return new RegexMutation
+            {
+                OriginalNode = node,
+                ReplacementNode = replacementNode,
+                DisplayName = "Regex greedy quantifier quantity mutation",
+                Description = $"Quantifier \"{node}\" was replaced with \"{replacementNode}\" at offset {node.GetSpan().Start}.",
+                ReplacementPattern = root.ReplaceNode(node, replacementNode).ToString()
+            };
+        }
+    }
+}

--- a/src/Stryker.RegexMutators/Stryker.RegexMutators/Mutators/LookAroundMutator.cs
+++ b/src/Stryker.RegexMutators/Stryker.RegexMutators/Mutators/LookAroundMutator.cs
@@ -8,15 +8,9 @@ namespace Stryker.RegexMutators.Mutators
     {
         public override IEnumerable<RegexMutation> ApplyMutations(LookaroundGroupNode node, RegexNode root)
         {
-            yield return FlipLookAround(node, root, node.Lookahead, ! node.Possitive);
-            yield return FlipLookAround(node, root, ! node.Lookahead, node.Possitive);
-        }
+            var replacementNode = new LookaroundGroupNode(node.Lookahead, !node.Possitive, node.ChildNodes);
 
-        private RegexMutation FlipLookAround(LookaroundGroupNode node, RegexNode root, bool lookAhead, bool positive)
-        {
-            var replacementNode = new LookaroundGroupNode(lookAhead, positive, node.ChildNodes);
-
-            return new RegexMutation
+            yield return new RegexMutation
             {
                 OriginalNode = node,
                 ReplacementNode = replacementNode,

--- a/src/Stryker.RegexMutators/Stryker.RegexMutators/RegexMutantOrchestrator.cs
+++ b/src/Stryker.RegexMutators/Stryker.RegexMutators/RegexMutantOrchestrator.cs
@@ -8,6 +8,7 @@ using Stryker.RegexMutators.Mutators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using RegexParser.Nodes.GroupNodes;
 
 namespace Stryker.RegexMutators
 {
@@ -28,6 +29,7 @@ namespace Stryker.RegexMutators
                 { typeof(CharacterClassShorthandNode), new List<IRegexMutator> { new CharacterClassShorthandNegationMutator() } },
                 { typeof(QuantifierNOrMoreNode), new List<IRegexMutator> { new QuantifierUnlimitedQuantityMutator() } },
                 { typeof(QuantifierNMNode), new List<IRegexMutator> { new QuantifierQuantityMutator() } },
+                { typeof(LookaroundGroupNode), new List<IRegexMutator> { new LookAroundMutator() } },
             };
         }
 


### PR DESCRIPTION
## Description
In regex there is a way to match something, only if it is preceded or proceded by a group.
For example: (?<=foo)bar will match the word bar in foobar, but won't match bar in minibar.

This mutator flips these regexes to check at the end instead of beginning, and to ensure
that it does NOT start with the group. It flips the check.

## Issue
Closes #1278