### PR TITLE
fix(Diff mutant filter): prevent NPE for compiler error mutants (#1290)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DiffMutantFilterTests.cs
@@ -257,7 +257,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void GetBaselineCallsFallbackWhenDashboardClientReturnsNull()
         {
-            // Arrange 
+            // Arrange
             var baselineProvider = new Mock<IBaselineProvider>();
             var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
             var gitInfoProvider = new Mock<IGitInfoProvider>();
@@ -293,7 +293,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void GetBaselineDoesNotCallFallbackWhenDashboardClientReturnsReport()
         {
-            // Arrange 
+            // Arrange
             var baselineProvider = new Mock<IBaselineProvider>();
             var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
             var gitInfoProvider = new Mock<IGitInfoProvider>();
@@ -329,7 +329,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void FilterMutantsReturnAllMutantsWhenCompareToDashboardEnabledAndBaselineNotAvailabe()
         {
-            // Arrange 
+            // Arrange
             var baselineProvider = new Mock<IBaselineProvider>();
             var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
             var branchProvider = new Mock<IGitInfoProvider>();
@@ -357,7 +357,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void FilterMutantsWithNoChangedFilesReturnsEmptyList()
         {
-            // Arrange 
+            // Arrange
             var diffProvider = new Mock<IDiffProvider>(MockBehavior.Strict);
 
             var options = new StrykerOptions();
@@ -400,7 +400,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void FilterMutants_MergesResetMutants_WhenDashboardCompareOn()
         {
-            // Arrange 
+            // Arrange
             var options = new StrykerOptions(compareToDashboard: true, projectVersion: "version");
 
             var target = new DiffMutantFilter(options, new Mock<IDiffProvider>().Object, new Mock<IBaselineProvider>().Object, new Mock<IGitInfoProvider>().Object);
@@ -467,7 +467,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
         [Fact]
         public void FilterMutants_FiltersNoMutants_IfTestsChanged()
         {
-            // Arrange 
+            // Arrange
             var baselineProvider = new Mock<IBaselineProvider>();
 
             baselineProvider.Setup(x =>
@@ -485,20 +485,67 @@ namespace Stryker.Core.UnitTest.MutantFilters
             diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult
             {
                 ChangedSourceFiles = new List<string>(),
+                ChangedTestFiles = new List<string> { "C:/testfile1.cs" }
+            });
+
+            var target = new DiffMutantFilter(options, diffProvider.Object, baselineProvider.Object, gitInfoProvider.Object);
+
+            var testFile1 = new TestListDescription(new[] { new TestDescription(Guid.NewGuid().ToString(), "name1", "C:/testfile1.cs") });
+            var testFile2 = new TestListDescription(new[] { new TestDescription(Guid.NewGuid().ToString(), "name2", "C:/testfile2.cs") });
+
+            var expectedToStay1 = new Mutant
+            {
+                CoveringTests = testFile1
+            };
+            var expectedToStay2 = new Mutant
+            {
+                CoveringTests = testFile1
+            };
+            var mutants = new List<Mutant>
+            {
+                expectedToStay1,
+                expectedToStay2,
+                new Mutant
+                {
+                    CoveringTests = testFile2
+                }
+            };
+
+            // Act
+            var results = target.FilterMutants(mutants, new FileLeaf().ToReadOnly(), options);
+
+            // Assert
+            results.ShouldBe(new []{expectedToStay1, expectedToStay2});
+        }
+
+        [Fact]
+        public void Should_IgnoreMutants_WithoutCoveringTestsInfo_When_Tests_Have_Changed()
+        {
+            // Arrange
+            var baselineProvider = new Mock<IBaselineProvider>();
+
+            baselineProvider.Setup(x =>
+                x.Load(It.IsAny<string>())
+            ).Returns(
+                Task.FromResult(
+                    JsonReport.Build(new StrykerOptions(), JsonReportTestHelper.CreateProjectWith().ToReadOnlyInputComponent())
+                ));
+
+            var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
+            var gitInfoProvider = new Mock<IGitInfoProvider>();
+
+            var options = new StrykerOptions(compareToDashboard: false, projectVersion: "version");
+
+            diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult
+            {
+                ChangedSourceFiles = new List<string>(),
                 ChangedTestFiles = new List<string> { "C:/testfile.cs" }
             });
 
             var target = new DiffMutantFilter(options, diffProvider.Object, baselineProvider.Object, gitInfoProvider.Object);
 
-            var testDescriptions = new List<TestDescription> { new TestDescription(Guid.NewGuid().ToString(), "name", "C:/testfile.cs") };
-            var testListDescription = new TestListDescription(testDescriptions);
-
             var mutants = new List<Mutant>
             {
-                new Mutant {
-                    CoveringTests = testListDescription
-                },
-                new Mutant(),
                 new Mutant()
             };
 
@@ -506,7 +553,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             var results = target.FilterMutants(mutants, new FileLeaf().ToReadOnly(), options);
 
             // Assert
-            results.Count().ShouldBe(1);
+            results.ShouldBeEmpty();
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/DiffMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/DiffMutantFilter.cs
@@ -258,21 +258,21 @@ namespace Stryker.Core.MutantFilters
             {
                 var coveringTests = mutant.CoveringTests.Tests;
 
-                if (coveringTests.Any(coveringTest => _diffResult.ChangedTestFiles.Any(changedTestFile => coveringTest.TestfilePath == changedTestFile))
-                    || coveringTests.Any(coveringTest => coveringTest.IsAllTests))
+                if (coveringTests != null
+                    && (coveringTests.Any(coveringTest => _diffResult.ChangedTestFiles.Any(changedTestFile => coveringTest.TestfilePath == changedTestFile))
+                        || coveringTests.Any(coveringTest => coveringTest.IsAllTests)))
                 {
                     mutant.ResultStatus = MutantStatus.NotRun;
                     mutant.ResultStatusReason = "One or more covering tests changed";
 
                     filteredMutants.Add(mutant);
-                    break;
                 }
             }
 
             return filteredMutants;
         }
 
-        /// Takes two lists. Adds the mutants from the updateMutants list to the targetMutants. 
+        /// Takes two lists. Adds the mutants from the updateMutants list to the targetMutants.
         /// If the targetMutants already contain a member with the same Id. The results are updated.
         internal IEnumerable<Mutant> MergeMutantLists(IEnumerable<Mutant> target, IEnumerable<Mutant> source)
         {


### PR DESCRIPTION
Fix #1290:
- check `CoveringTests.Tests` list for null before access - no check is added for `CoveringTests`, since it has a property initializer in `Mutant` class - the check is needed for compiler error mutants, which won't have any coverage info;
- do not `break` on first processed mutant;
- update tests to cover scenarios above;
- some whitespaces changes enforced by `.editorconfig` - can rollback if needed.