### PR TITLE
docs(sidebar): add custom sidebar

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -1,0 +1,9 @@
+[
+  "stryker-net/Introduction",
+  "stryker-net/Configuration",
+  "stryker-net/Mutators",
+  "stryker-net/ProjectComponents",
+  "stryker-net/RegexMutators",
+  "stryker-net/Reporters",
+  "stryker-net/Stryker-in-pipeline"
+]


### PR DESCRIPTION
As discussed, this will be used to render the sidebar on the website.

The `sidebar.json` (or `sidebar.js` if you prefer a node module) should contain a valid [sidebar object](https://v2.docusaurus.io/docs/docs-introduction#sidebar-object). The document root is `stryker-net`, so [document ids](https://v2.docusaurus.io/docs/docs-introduction#document-id) should be prefixed with that.