### PR TITLE
feat(InputFileResolver) : Validate Project File Option Value

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -1173,5 +1173,27 @@ Please specify a test project name filter that results in one project.
             ex.Message.ShouldBe("Project reference issue.");
             ex.Details.ShouldContain("no project", Case.Insensitive);
         }
+
+        [Theory]
+        [InlineData("../../Sources/ExampleProject.csproj")]
+        [InlineData("../ExampleProject.csproj")]
+        [InlineData("../../")]
+        [InlineData("..\\..\\")]
+        public void ShouldThrowWhenUsingRelativePath(string shouldMatchNone)
+        {
+            var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                    projectReferences: new List<string> {
+                        "../ExampleProject/ExampleProject.csproj",
+                        "../AnotherProject/AnotherProject.csproj"
+                    }).Object;
+
+            var ex = Assert.Throws<StrykerInputException>(() =>
+            {
+                new InputFileResolver().FindProjectUnderTest(new List<IAnalyzerResult> { analyzerResult }, shouldMatchNone);
+            });
+
+            ex.Message.ShouldBe("Project reference issue.");
+            ex.Details.ShouldContain("Use the project name instead of an absolute or relative path", Case.Insensitive);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -166,12 +166,34 @@ namespace Stryker.Core.Initialisation
             }
             else
             {
+                ValidateProjectUnderTestNameFilter(projectUnderTestNameFilter);
                 projectUnderTestPath = DetermineProjectUnderTestWithNameFilter(projectUnderTestNameFilter, projectReferences);
             }
 
             _logger.LogDebug("Using {0} as project under test", projectUnderTestPath);
 
             return projectUnderTestPath;
+        }
+
+        private void ValidateProjectUnderTestNameFilter(string projectUnderTestNameFilter)
+        {
+            var pathIndicators = new[] {
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar,
+                };
+
+            if (pathIndicators.Any(i => projectUnderTestNameFilter.Contains(i)))
+            {
+                var fileName = Path.GetFileName(projectUnderTestNameFilter) ?? "MyProject.csproj";
+                var stringBuilder = new StringBuilder();
+                stringBuilder.Append("Use the project name instead of an absolute or relative path, ");
+                stringBuilder.AppendLine("i.e. --project-file=");
+                stringBuilder.Append(fileName);
+                stringBuilder.Append(" instead of --project-file=");
+                stringBuilder.Append(projectUnderTestNameFilter);
+
+                throw new StrykerInputException(ErrorMessage, stringBuilder.ToString());
+            }
         }
 
         private void ValidateTestProjectsCanBeExecuted(ProjectInfo projectInfo, IStrykerOptions options)


### PR DESCRIPTION
ValidateProjectUnderTestNameFilter checks if the filter looks
like a path to a project rather than just a project name (with or without file extension), the exception message will instruct the user in how to properly use the --project-file option.

Unit test added to verify that the exception is thrown when a path is discovered.

This hopefully "fixes" #520 by providing a more helpful exception message.