### PR TITLE
fix: Stryker.CLI fails to start on MacOSX due to missing microsoft.testplatform package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ PublishScripts/
 
 # NuGet Packages
 *.nupkg
+!microsoft.testplatform.portable*.nupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/VsTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/VsTestHelper.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+using Stryker.Core.ToolHelpers;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.ToolHelpers
+{
+    public class VsTestHelperTests
+    {
+        [Fact]
+        public void MicrosoftTestPlatformPortableExistsAsEmbededResourse()
+        {
+            var vsTestPortableBinaryExists = typeof(VsTestHelper).Assembly
+                .GetManifestResourceNames()
+                .Any(x => x.Contains("Microsoft.TestPlatform.Portable", StringComparison.OrdinalIgnoreCase));
+            Assert.True(vsTestPortableBinaryExists);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -32,6 +32,8 @@
     <EmbeddedResource Include="Reporters\HtmlReporter\Files\mutation-report.html" />
 
     <EmbeddedResource Include="ToolHelpers\.vstest\Microsoft.TestPlatform.Portable\*\*.nupkg" />
+
+    <EmbeddedResource Include="microsoft.testplatform.portable.16.8.3.nupkg" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stryker.Core/Stryker.Core/ToolHelpers/VsTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/ToolHelpers/VsTestHelper.cs
@@ -193,7 +193,7 @@ namespace Stryker.Core.ToolHelpers
         {
             var vstestZip = typeof(VsTestHelper).Assembly
                 .GetManifestResourceNames()
-                .Single(r => r.Contains("Microsoft.TestPlatform.Portable"));
+                .Single(r => r.Contains("Microsoft.TestPlatform.Portable", StringComparison.OrdinalIgnoreCase));
 
             var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), ".vstest");
 


### PR DESCRIPTION
Added missed binary, corrected .gitignore, and added tests