### PR TITLE
Improved debug message.

### DIFF
--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -165,7 +165,6 @@ namespace Stryker.Core.MutationTest
 
         private IEnumerable<List<Mutant>> BuildMutantGroupsForTest(IReadOnlyCollection<Mutant> mutantsNotRun)
         {
-
             if (_options.Optimizations.HasFlag(OptimizationFlags.DisableTestMix) || !_options.Optimizations.HasFlag(OptimizationFlags.CoverageBasedTest))
             {
                 return mutantsNotRun.Select(x => new List<Mutant> { x });
@@ -198,7 +197,10 @@ namespace Stryker.Core.MutationTest
                 blocks.Add(nextBlock);
             }
 
-            _logger.LogDebug($"Mutations will be tested in {blocks.Count} test runs, instead of {mutantsNotRun.Count}.");
+            _logger.LogDebug(
+                $"Mutations will be tested in {blocks.Count} test runs" +
+                (mutantsNotRun.Count > blocks.Count ? $", instead of {mutantsNotRun.Count}." : "."));
+
             return blocks;
         }
 


### PR DESCRIPTION
Suggesting this after I noticed a message `Mutations will be tested in 10 test runs instead of 10.` :)

Discard if this actually represents a more serious problem.