### PR TITLE
fix: Default vstest extensions are no longer required on the filesystem

### DIFF
--- a/integrationtest/TargetProjects/NetFramework/FullFrameworkApp/FullFrameworkApp.csproj
+++ b/integrationtest/TargetProjects/NetFramework/FullFrameworkApp/FullFrameworkApp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -468,11 +468,10 @@ $@"<RunSettings>
                 {
                     throw new GeneralStrykerException($"The test project binaries could not be found at {path}, exiting...");
                 }
+
                 testBinariesLocations.Add(Path.GetDirectoryName(path));
                 _sources.Add(FilePathUtils.NormalizePathSeparators(path));
             }
-
-            testBinariesLocations.Add(_vsTestHelper.GetDefaultVsTestExtensionsPath(_vsTestHelper.GetCurrentPlatformVsTestToolPath()));
 
             try
             {

--- a/src/Stryker.Core/Stryker.Core/ToolHelpers/VsTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/ToolHelpers/VsTestHelper.cs
@@ -1,6 +1,3 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
-using Stryker.Core.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9,13 +6,15 @@ using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
+using Stryker.Core.Logging;
 
 namespace Stryker.Core.ToolHelpers
 {
     public interface IVsTestHelper
     {
         string GetCurrentPlatformVsTestToolPath();
-        string GetDefaultVsTestExtensionsPath(string vstestToolPath);
         void Cleanup(int tries = 5);
     }
 
@@ -58,16 +57,6 @@ namespace Stryker.Core.ToolHelpers
             }
 
             return _platformVsTestToolPath;
-        }
-
-        public string GetDefaultVsTestExtensionsPath(string vstestToolPath)
-        {
-            var extensionPath = Path.Combine(Path.GetDirectoryName(vstestToolPath), "Extensions");
-            if (_fileSystem.Directory.Exists(extensionPath))
-            {
-                return extensionPath;
-            }
-            throw new ApplicationException($"VsTest extensions not found in: {extensionPath}");
         }
 
         private Dictionary<OSPlatform, string> GetVsTestToolPaths()


### PR DESCRIPTION
Fix #1493 