### PR TITLE
Potential fix for assembly resolving issues

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    ".NETCoreApp,Version=v5.0": {
       "Microsoft.CodeCoverage": {
         "type": "Direct",
         "requested": "[16.9.4, )",
@@ -297,8 +297,7 @@
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "5.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
-          "System.Text.Json": "5.0.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -357,8 +356,7 @@
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
-          "Microsoft.Extensions.Options": "5.0.0",
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
+          "Microsoft.Extensions.Options": "5.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1028,8 +1026,15 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
+        "resolved": "4.3.0",
+        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1198,7 +1203,7 @@
         "resolved": "13.2.28",
         "contentHash": "Q+CtHEI1gcIqz2XOScfprBBR3YM4HZS4S5dSrOzuid/kijaapSyoYMhn19g3menbDT1QGLErLas7ELrOW3HV/w==",
         "dependencies": {
-          "System.IO.FileSystem.AccessControl": "4.7.0"
+          "System.IO.FileSystem.AccessControl": "5.0.0"
         }
       },
       "System.IO.Compression": {
@@ -1265,7 +1270,6 @@
         "resolved": "5.0.0",
         "contentHash": "P0FIsXSFNL1AXlHO9zpJ9atRUzVyoPZCkcbkYGZfXXMx9xlGA2H3HOGBwIhpKhB+h0eL3hry/z0UcfJZ+yb2kQ==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "5.0.0",
           "System.Security.AccessControl": "5.0.0",
           "System.Security.Principal.Windows": "5.0.0"
         }
@@ -1464,10 +1468,7 @@
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ==",
-        "dependencies": {
-          "System.Collections.Immutable": "5.0.0"
-        }
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",
@@ -1865,8 +1866,7 @@
         "resolved": "5.0.0",
         "contentHash": "NyscU59xX6Uo91qvhOs2Ccho3AR2TnZPomo1Z0K6YpyztBPM/A5VbkzOO19sy3A3i1TtEnTxA7bCe3Us+r5MWg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+          "Microsoft.NETCore.Platforms": "5.0.0"
         }
       },
       "System.Text.Encoding.Extensions": {
@@ -1879,11 +1879,6 @@
           "System.Runtime": "4.3.0",
           "System.Text.Encoding": "4.3.0"
         }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -2073,8 +2068,8 @@
           "Serilog.Extensions.Logging.File": "2.0.0",
           "Serilog.Sinks.Console": "3.1.1",
           "ShellProgressBar": "5.1.0",
-          "Stryker.DataCollector": "0.22.1",
-          "Stryker.RegexMutators": "0.22.1",
+          "Stryker.DataCollector": "0.16.1",
+          "Stryker.RegexMutators": "1.0.0",
           "System.IO.Abstractions": "13.2.28"
         }
       },

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    ".NETCoreApp,Version=v5.0": {
       "McMaster.Extensions.CommandLineUtils": {
         "type": "Direct",
         "requested": "[3.1.0, )",
@@ -211,8 +211,7 @@
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "5.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
-          "System.Text.Json": "5.0.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -271,8 +270,7 @@
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
-          "Microsoft.Extensions.Options": "5.0.0",
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
+          "Microsoft.Extensions.Options": "5.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -296,8 +294,8 @@
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "3.1.0",
-        "contentHash": "z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w=="
+        "resolved": "5.0.0",
+        "contentHash": "VyPlqzH2wavqquTcYpkIIAQ6WdenuKoFN0BdYBbCWsclXacSOHNQn66Gt4z5NBqEYW0FAPm5rlvki9ZiCij5xQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
@@ -687,8 +685,15 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
+        "resolved": "4.3.0",
+        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
       },
       "System.Diagnostics.TraceSource": {
         "type": "Transitive",
@@ -789,7 +794,7 @@
         "resolved": "13.2.28",
         "contentHash": "Q+CtHEI1gcIqz2XOScfprBBR3YM4HZS4S5dSrOzuid/kijaapSyoYMhn19g3menbDT1QGLErLas7ELrOW3HV/w==",
         "dependencies": {
-          "System.IO.FileSystem.AccessControl": "4.7.0"
+          "System.IO.FileSystem.AccessControl": "5.0.0"
         }
       },
       "System.IO.Compression": {
@@ -831,11 +836,11 @@
       },
       "System.IO.FileSystem.AccessControl": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw==",
+        "resolved": "5.0.0",
+        "contentHash": "SxHB3nuNrpptVk+vZ/F+7OHEpoHUIKKMl02bUmYHQr1r+glbZQxs7pRtsf4ENO29TVm2TH3AEeep2fJcy92oYw==",
         "dependencies": {
-          "System.Security.AccessControl": "4.7.0",
-          "System.Security.Principal.Windows": "4.7.0"
+          "System.Security.AccessControl": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.IO.FileSystem.Primitives": {
@@ -1019,10 +1024,7 @@
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ==",
-        "dependencies": {
-          "System.Collections.Immutable": "5.0.0"
-        }
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",
@@ -1162,11 +1164,11 @@
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "JECvTt5aFF3WT3gHpfofL2MNNP6v84sxtXxpqhLBCcDRzqsPBmHhQ6shv4DwwN2tRlzsUxtb3G9M3763rbXKDg==",
+        "resolved": "5.0.0",
+        "contentHash": "dagJ1mHZO3Ani8GH0PHpPEe/oYO+rVdbQjvjJkBRNQkX4t0r1iaeGn8+/ybkSLEan3/slM0t59SVdHzuHf2jmw==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "3.1.0",
-          "System.Security.Principal.Windows": "4.7.0"
+          "Microsoft.NETCore.Platforms": "5.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.Security.Cryptography.Algorithms": {
@@ -1315,8 +1317,8 @@
       },
       "System.Security.Principal.Windows": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
+        "resolved": "5.0.0",
+        "contentHash": "t0MGLukB5WAVU9bO3MGzvlGnyJPgUlcwerXn1kzBRjwLKixT96XV0Uza41W49gVd8zEMFu9vQEFlv0IOrytICA=="
       },
       "System.Text.Encoding": {
         "type": "Transitive",
@@ -1347,11 +1349,6 @@
           "System.Runtime": "4.1.0",
           "System.Text.Encoding": "4.0.11"
         }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       },
       "System.Threading": {
         "type": "Transitive",
@@ -1423,8 +1420,8 @@
           "Serilog.Extensions.Logging.File": "2.0.0",
           "Serilog.Sinks.Console": "3.1.1",
           "ShellProgressBar": "5.1.0",
-          "Stryker.DataCollector": "0.22.1",
-          "Stryker.RegexMutators": "0.22.1",
+          "Stryker.DataCollector": "0.16.1",
+          "Stryker.RegexMutators": "1.0.0",
           "System.IO.Abstractions": "13.2.28"
         }
       },

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.1": {
+    ".NETCoreApp,Version=v5.0": {
       "Microsoft.CodeCoverage": {
         "type": "Direct",
         "requested": "[16.9.4, )",
@@ -308,8 +308,7 @@
           "Microsoft.Extensions.Configuration": "5.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "5.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "5.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0",
-          "System.Text.Json": "5.0.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "5.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -368,8 +367,7 @@
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
-          "Microsoft.Extensions.Options": "5.0.0",
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
+          "Microsoft.Extensions.Options": "5.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1029,8 +1027,15 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
+        "resolved": "4.3.0",
+        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -1199,7 +1204,7 @@
         "resolved": "13.2.28",
         "contentHash": "Q+CtHEI1gcIqz2XOScfprBBR3YM4HZS4S5dSrOzuid/kijaapSyoYMhn19g3menbDT1QGLErLas7ELrOW3HV/w==",
         "dependencies": {
-          "System.IO.FileSystem.AccessControl": "4.7.0"
+          "System.IO.FileSystem.AccessControl": "5.0.0"
         }
       },
       "System.IO.Compression": {
@@ -1266,7 +1271,6 @@
         "resolved": "5.0.0",
         "contentHash": "P0FIsXSFNL1AXlHO9zpJ9atRUzVyoPZCkcbkYGZfXXMx9xlGA2H3HOGBwIhpKhB+h0eL3hry/z0UcfJZ+yb2kQ==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "5.0.0",
           "System.Security.AccessControl": "5.0.0",
           "System.Security.Principal.Windows": "5.0.0"
         }
@@ -1465,10 +1469,7 @@
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ==",
-        "dependencies": {
-          "System.Collections.Immutable": "5.0.0"
-        }
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",
@@ -1866,8 +1867,7 @@
         "resolved": "5.0.0",
         "contentHash": "NyscU59xX6Uo91qvhOs2Ccho3AR2TnZPomo1Z0K6YpyztBPM/A5VbkzOO19sy3A3i1TtEnTxA7bCe3Us+r5MWg==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+          "Microsoft.NETCore.Platforms": "5.0.0"
         }
       },
       "System.Text.Encoding.Extensions": {
@@ -1880,11 +1880,6 @@
           "System.Runtime": "4.3.0",
           "System.Text.Encoding": "4.3.0"
         }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -2070,8 +2065,8 @@
           "Serilog.Extensions.Logging.File": "2.0.0",
           "Serilog.Sinks.Console": "3.1.1",
           "ShellProgressBar": "5.1.0",
-          "Stryker.DataCollector": "0.22.1",
-          "Stryker.RegexMutators": "0.22.1",
+          "Stryker.DataCollector": "0.16.1",
+          "Stryker.RegexMutators": "1.0.0",
           "System.IO.Abstractions": "13.2.28"
         }
       },

--- a/src/Stryker.Core/Stryker.Core/Initialisation/CustomAssemblyResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/CustomAssemblyResolver.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Mono.Cecil;
+
+namespace Stryker.Core.Initialisation
+{
+    // This (CustomAssemblyResolver) is a copy of Mono.Cecil's BaseAssemblyResolver with all the conditional compilation removed and changes made to "Resolve"
+    // Author:
+    //   Jb Evain (jbevain@gmail.com)
+    //
+    // Copyright (c) 2008 - 2015 Jb Evain
+    // Copyright (c) 2008 - 2011 Novell, Inc.
+    //
+    // Licensed under the MIT/X11 license.
+    //
+    public class CustomAssemblyResolver : IAssemblyResolver
+    {
+        public CustomAssemblyResolver()
+        {
+            directories = new List<string>(2) { ".", "bin" };
+        }
+
+        static readonly bool on_mono = Type.GetType("Mono.Runtime") != null;
+
+        readonly List<string> directories;
+
+        // Maps file names of available trusted platform assemblies to their full paths.
+        // Internal for testing.
+        internal static readonly Lazy<Dictionary<string, string>> TrustedPlatformAssemblies =
+            new Lazy<Dictionary<string, string>>(CreateTrustedPlatformAssemblyMap);
+
+        List<string> gac_paths;
+
+        public void AddSearchDirectory(string directory)
+        {
+            directories.Add(directory);
+        }
+
+        public void RemoveSearchDirectory(string directory)
+        {
+            directories.Remove(directory);
+        }
+
+        public string[] GetSearchDirectories()
+        {
+            var directories = new string[this.directories.Count];
+            Array.Copy(this.directories.ToArray(), directories, directories.Length);
+            return directories;
+        }
+
+        public event AssemblyResolveEventHandler ResolveFailure;
+
+
+
+        AssemblyDefinition GetAssembly(string file, ReaderParameters parameters)
+        {
+            if (parameters.AssemblyResolver == null)
+                parameters.AssemblyResolver = this;
+
+            return ModuleDefinition.ReadModule(file, parameters).Assembly;
+        }
+
+        public virtual AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            return Resolve(name, new ReaderParameters());
+        }
+
+        public virtual AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (name.Name == "System.Data.Entity")
+            {
+                //TODOF: remove if statement
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            var assembly = SearchDirectory(name, directories, parameters);
+            if (assembly != null)
+                return assembly;
+
+            if (name.IsRetargetable)
+            {
+                // if the reference is retargetable, zero it
+                name = new AssemblyNameReference(name.Name, new Version(0, 0, 0, 0))
+                {
+                    PublicKeyToken = new byte[0],
+                };
+            }
+
+            //Try resolve as .NET core first (since stryker runs as .NET core, this is still the default)
+            assembly = SearchTrustedPlatformAssemblies(name, parameters);
+            if (assembly != null)
+            {
+                return assembly;
+            }
+            //If that fails, try as .NET framework
+            else
+            {
+                var framework_dir = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName);
+                var framework_dirs = on_mono
+                    ? new[] { framework_dir, Path.Combine(framework_dir, "Facades") }
+                    : new[] { framework_dir };
+
+                if (IsZero(name.Version))
+                {
+                    assembly = SearchDirectory(name, framework_dirs, parameters);
+                    if (assembly != null)
+                        return assembly;
+                }
+
+                if (name.Name == "mscorlib")
+                {
+                    assembly = GetCorlib(name, parameters);
+                    if (assembly != null)
+                        return assembly;
+                }
+
+                assembly = GetAssemblyInGac(name, parameters);
+                if (assembly != null)
+                    return assembly;
+
+                assembly = SearchDirectory(name, framework_dirs, parameters);
+                if (assembly != null)
+                    return assembly;
+            }
+
+
+            if (ResolveFailure != null)
+            {
+                assembly = ResolveFailure(this, name);
+                if (assembly != null)
+                    return assembly;
+            }
+
+            throw new AssemblyResolutionException(name);
+        }
+
+
+        AssemblyDefinition SearchTrustedPlatformAssemblies(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (name.IsWindowsRuntime)
+                return null;
+
+            if (TrustedPlatformAssemblies.Value.TryGetValue(name.Name, out string path))
+                return GetAssembly(path, parameters);
+
+            return null;
+        }
+
+        static Dictionary<string, string> CreateTrustedPlatformAssemblyMap()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            string paths;
+
+            try
+            {
+                paths = (string)AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            }
+            catch
+            {
+                paths = null;
+            }
+
+            if (paths == null)
+                return result;
+
+            foreach (var path in paths.Split(Path.PathSeparator))
+                if (string.Equals(Path.GetExtension(path), ".dll", StringComparison.OrdinalIgnoreCase))
+                    result[Path.GetFileNameWithoutExtension(path)] = path;
+
+            return result;
+        }
+
+        protected virtual AssemblyDefinition SearchDirectory(AssemblyNameReference name,
+            IEnumerable<string> directories, ReaderParameters parameters)
+        {
+            var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll" } : new[] { ".exe", ".dll" };
+            foreach (var directory in directories)
+            {
+                foreach (var extension in extensions)
+                {
+                    string file = Path.Combine(directory, name.Name + extension);
+                    if (!File.Exists(file))
+                        continue;
+                    try
+                    {
+                        return GetAssembly(file, parameters);
+                    }
+                    catch (System.BadImageFormatException)
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        static bool IsZero(Version version)
+        {
+            return version.Major == 0 && version.Minor == 0 && version.Build == 0 && version.Revision == 0;
+        }
+
+
+        AssemblyDefinition GetCorlib(AssemblyNameReference reference, ReaderParameters parameters)
+        {
+            var version = reference.Version;
+            var corlib = typeof(object).Assembly.GetName();
+            if (corlib.Version == version || IsZero(version))
+                return GetAssembly(typeof(object).Module.FullyQualifiedName, parameters);
+
+            var path = Directory.GetParent(
+                Directory.GetParent(
+                    typeof(object).Module.FullyQualifiedName).FullName
+            ).FullName;
+
+            if (on_mono)
+            {
+                if (version.Major == 1)
+                    path = Path.Combine(path, "1.0");
+                else if (version.Major == 2)
+                {
+                    if (version.MajorRevision == 5)
+                        path = Path.Combine(path, "2.1");
+                    else
+                        path = Path.Combine(path, "2.0");
+                }
+                else if (version.Major == 4)
+                    path = Path.Combine(path, "4.0");
+                else
+                    throw new NotSupportedException("Version not supported: " + version);
+            }
+            else
+            {
+                switch (version.Major)
+                {
+                    case 1:
+                        if (version.MajorRevision == 3300)
+                            path = Path.Combine(path, "v1.0.3705");
+                        else
+                            path = Path.Combine(path, "v1.1.4322");
+                        break;
+                    case 2:
+                        path = Path.Combine(path, "v2.0.50727");
+                        break;
+                    case 4:
+                        path = Path.Combine(path, "v4.0.30319");
+                        break;
+                    default:
+                        throw new NotSupportedException("Version not supported: " + version);
+                }
+            }
+
+            var file = Path.Combine(path, "mscorlib.dll");
+            if (File.Exists(file))
+                return GetAssembly(file, parameters);
+
+            if (on_mono && Directory.Exists(path + "-api"))
+            {
+                file = Path.Combine(path + "-api", "mscorlib.dll");
+                if (File.Exists(file))
+                    return GetAssembly(file, parameters);
+            }
+
+            return null;
+        }
+
+        static List<string> GetGacPaths()
+        {
+            if (on_mono)
+                return GetDefaultMonoGacPaths();
+
+            var paths = new List<string>(2);
+            var windir = Environment.GetEnvironmentVariable("WINDIR");
+            if (windir == null)
+                return paths;
+
+            paths.Add(Path.Combine(windir, "assembly"));
+            paths.Add(Path.Combine(windir, Path.Combine("Microsoft.NET", "assembly")));
+            return paths;
+        }
+
+        static List<string> GetDefaultMonoGacPaths()
+        {
+            var paths = new List<string>(1);
+            var gac = GetCurrentMonoGac();
+            if (gac != null)
+                paths.Add(gac);
+
+            var gac_paths_env = Environment.GetEnvironmentVariable("MONO_GAC_PREFIX");
+            if (string.IsNullOrEmpty(gac_paths_env))
+                return paths;
+
+            var prefixes = gac_paths_env.Split(Path.PathSeparator);
+            foreach (var prefix in prefixes)
+            {
+                if (string.IsNullOrEmpty(prefix))
+                    continue;
+
+                var gac_path = Path.Combine(Path.Combine(Path.Combine(prefix, "lib"), "mono"), "gac");
+                if (Directory.Exists(gac_path) && !paths.Contains(gac))
+                    paths.Add(gac_path);
+            }
+
+            return paths;
+        }
+
+        static string GetCurrentMonoGac()
+        {
+            return Path.Combine(
+                Directory.GetParent(
+                    Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName)).FullName,
+                "gac");
+        }
+
+        AssemblyDefinition GetAssemblyInGac(AssemblyNameReference reference, ReaderParameters parameters)
+        {
+            if (reference.PublicKeyToken == null || reference.PublicKeyToken.Length == 0)
+                return null;
+
+            if (gac_paths == null)
+                gac_paths = GetGacPaths();
+
+            if (on_mono)
+                return GetAssemblyInMonoGac(reference, parameters);
+
+            return GetAssemblyInNetGac(reference, parameters);
+        }
+
+        AssemblyDefinition GetAssemblyInMonoGac(AssemblyNameReference reference, ReaderParameters parameters)
+        {
+            for (int i = 0; i < gac_paths.Count; i++)
+            {
+                var gac_path = gac_paths[i];
+                var file = GetAssemblyFile(reference, string.Empty, gac_path);
+                if (File.Exists(file))
+                    return GetAssembly(file, parameters);
+            }
+
+            return null;
+        }
+
+        AssemblyDefinition GetAssemblyInNetGac(AssemblyNameReference reference, ReaderParameters parameters)
+        {
+            var gacs = new[] { "GAC_MSIL", "GAC_32", "GAC_64", "GAC" };
+            var prefixes = new[] { string.Empty, "v4.0_" };
+
+            for (int i = 0; i < gac_paths.Count; i++)
+            {
+                for (int j = 0; j < gacs.Length; j++)
+                {
+                    var gac = Path.Combine(gac_paths[i], gacs[j]);
+                    var file = GetAssemblyFile(reference, prefixes[i], gac);
+                    if (Directory.Exists(gac) && File.Exists(file))
+                        return GetAssembly(file, parameters);
+                }
+            }
+
+            return null;
+        }
+
+        static string GetAssemblyFile(AssemblyNameReference reference, string prefix, string gac)
+        {
+            var gac_folder = new StringBuilder()
+                .Append(prefix)
+                .Append(reference.Version)
+                .Append("__");
+
+            for (int i = 0; i < reference.PublicKeyToken.Length; i++)
+                gac_folder.Append(reference.PublicKeyToken[i].ToString("x2"));
+
+            return Path.Combine(
+                Path.Combine(
+                    Path.Combine(gac, reference.Name), gac_folder.ToString()),
+                reference.Name + ".dll");
+        }
+
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Initialisation/EmbeddedResourcesGenerator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/EmbeddedResourcesGenerator.cs
@@ -41,7 +41,8 @@ namespace Stryker.Core.Initialisation
                     new ReaderParameters(ReadingMode.Immediate)
                     {
                         InMemory = true,
-                        ReadWrite = false
+                        ReadWrite = false,
+                        AssemblyResolver = new CustomAssemblyResolver()
                     });
             }
             catch (Exception e)


### PR DESCRIPTION
Potential fix for https://github.com/stryker-mutator/stryker-net/issues/1501

Please run the tests for the core project - I was unable to get them running so am unsure if they still pass.


Commit message:
Copied BaseAssemblyResolver from Mono.Cecil into CustomAssemblyResolver.cs, removed conditional compilation. First it tries to resolve the .NET core way, if that doesn't work it proceeds with the .NET framework way.

EmbeddedResourcesGenerator.cs now passes the added CustomAssemblyResolver to LoadModule call to override the default resolving behavior. This object is re-created for each call, maybe it can be instantiated once? Not sure what the lifecycle should be.




