### PR TITLE
fix(mutating): Place yield return instead of yield return default(type) for yield break

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -729,19 +729,27 @@ const string text = ""a""+""b""+""c"";}";
         public void ShouldNotAddReturnDefaultToEnumerationMethods()
         {
             string source = @"public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable, string propertyName)
-        {
+      {
         foreach (var o in enumerable)
         {
             yield return value;
         }
-    }";
+      }
+public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable)
+      {
+        yield break;
+      }";
             string expected = @"public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable, string propertyName)
-        {
+      {
         foreach (var o in enumerable)
         {
             yield return value;
         }
-    }";
+      } 
+public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable)
+      {
+        yield break;
+      }";
             ShouldMutateSourceToExpected(source, expected);
         }
 

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -25,7 +25,7 @@ namespace Stryker.Core.Instrumentation
             }
 
             // we can also skip iterator methods, as they don't need to end with return
-            if (method.Body.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement), false))
+            if (method.Body.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement) || x.IsKind(SyntaxKind.YieldBreakStatement), false))
             {
                 // not need to add yield return at the end of an enumeration method
                 return method;
@@ -58,7 +58,7 @@ namespace Stryker.Core.Instrumentation
 
         protected override SyntaxNode Revert(BaseMethodDeclarationSyntax node)
         {
-            if (node.Body?.Statements.Last()?.IsKind(SyntaxKind.ReturnStatement) != true)
+            if (node.Body?.Statements.Last().IsKind(SyntaxKind.ReturnStatement) != true)
             {
                 throw new InvalidOperationException($"No return at the end of: {node.Body}");
             }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -69,9 +69,11 @@ namespace Stryker.Core.Mutants
                 .WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
 
         public static PropertyDeclarationSyntax ConvertPropertyExpressionToBodyAccessor(PropertyDeclarationSyntax property) =>
-            propertyExpressionToBodyEngine.ConvertExpressionToBody(property);
+            propertyExpressionToBodyEngine.ConvertExpressionToBody(property).
+                WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
 
-        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax node) => endingReturnEngine.InjectReturn(node);
+        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax node) => endingReturnEngine.InjectReturn(node).
+            WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
 
         public static BlockSyntax PlaceStaticContextMarker(BlockSyntax block) => 
             StaticEngine.PlaceStaticContextMarker(block).


### PR DESCRIPTION
Bring 2 fixes:
1 : successfully rollback process can now rollback added `return default(x)`, as well as accessor expression to body form (no unit test)
2: add `yield return default(x)` to iteration method having only `yield break`(but no `yield return`) (unit test)