### PR TITLE
feat: Cache and restore unmutated assembly so rebuild is not needed after mutation test

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
@@ -31,12 +31,12 @@ namespace Stryker.Core.UnitTest
                 Mutants = new List<Mutant> { new Mutant { Id = 1 } }
             });
 
+            var projectInfo = Mock.Of<ProjectInfo>();
+            projectInfo.ProjectContents = folder;
+            Mock.Get(projectInfo).Setup(p => p.RestoreOrginalAssembly());
             var mutationTestInput = new MutationTestInput()
             {
-                ProjectInfo = new ProjectInfo()
-                {
-                    ProjectContents = folder
-                },
+                ProjectInfo = projectInfo
             };
             var options = new StrykerOptions(basePath: "c:/test", fileSystem: fileSystemMock);
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -22,6 +22,16 @@ namespace Stryker.Core.Initialisation
                 Path.GetDirectoryName(analyzerResult.GetAssemblyPath()),
                 Path.GetFileName(ProjectUnderTestAnalyzerResult.GetAssemblyPath()));
         }
+
+        public void RestoreOrginalAssembly()
+        {
+            foreach(var testProject in TestProjectAnalyzerResults)
+            {
+                var injectionPath = GetInjectionFilePath(testProject);
+                File.Delete(injectionPath);
+                File.Move(injectionPath + ".stryker-unchanged", injectionPath);
+            }
+        }
     }
 
     public enum Framework

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -23,7 +23,7 @@ namespace Stryker.Core.Initialisation
                 Path.GetFileName(ProjectUnderTestAnalyzerResult.GetAssemblyPath()));
         }
 
-        public void RestoreOrginalAssembly()
+        public virtual void RestoreOrginalAssembly()
         {
             foreach(var testProject in TestProjectAnalyzerResults)
             {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -82,7 +82,11 @@ namespace Stryker.Core.MutationTest
                 {
                     _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(injectionPath));
                 }
-
+                if (_fileSystem.File.Exists(injectionPath))
+                {
+                    _fileSystem.File.Move(injectionPath, injectionPath + ".stryker-unchanged");
+                }
+                
                 // inject the mutated Assembly into the test project
                 using var fs = _fileSystem.File.Create(injectionPath);
                 ms.Position = 0;

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -102,6 +102,7 @@ namespace Stryker.Core
                 foreach (var project in _mutationTestProcesses)
                 {
                     project.Test(project.Input.ProjectInfo.ProjectContents.Mutants.Where(x => x.ResultStatus == MutantStatus.NotRun).ToList());
+                    project.Input.ProjectInfo.RestoreOrginalAssembly();      
                 }
 
                 reporters.OnAllMutantsTested(readOnlyInputComponent);


### PR DESCRIPTION
Fix #1515 

Unit test MutantOrchestratorTests.ShouldNotAddReturnDefaultToEnumerationMethods is failing for me locally but it looks like just whitespace differences in the result.