### PR TITLE
fix: Allow setting break threshold to 100%

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
@@ -174,6 +174,13 @@ namespace Stryker.Core.UnitTest.Options
         }
 
         [Fact]
+        public void ShouldAllowBreakThresholdAt100()
+        {
+            var options = new StrykerOptions(thresholdHigh: 100, thresholdLow: 100, thresholdBreak: 100);
+            options.Thresholds.Break.ShouldBe(100);
+        }
+
+        [Fact]
         public void ShouldValidateMutationLevel()
         {
             var ex = Assert.Throws<StrykerInputException>(() =>

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -574,8 +574,7 @@ namespace Stryker.Core.Options
                     "The thresholds must be between 0 and 100");
             }
 
-            // ThresholdLow and ThresholdHigh can be the same value
-            if (thresholdBreak >= thresholdLow || thresholdLow > thresholdHigh)
+            if (thresholdBreak > thresholdLow || thresholdLow > thresholdHigh)
             {
                 throw new StrykerInputException(
                     ErrorMessage,


### PR DESCRIPTION
Previously only the low and high thresholds were allowed to be the same, and thus the maximum break threshold you could set was 99%. I don't see any reason why this should be so, and would like to set the break threshold to 100% in my project, which was [fairly easy to reach](https://github.com/sbergen/Responsible/pull/72).