### PR TITLE
fix(filtered mutants reporter): OnMutantsCreated was executed before filtering mutants

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
@@ -48,15 +48,19 @@ namespace Stryker.Core.UnitTest
 
             reporterFactoryMock.Setup(x => x.Create(It.IsAny<StrykerOptions>(), It.IsAny<IGitInfoProvider>())).Returns(reporterMock.Object);
 
-            reporterMock.Setup(x => x.OnMutantsCreated(It.IsAny<IReadOnlyProjectComponent>()));
             reporterMock.Setup(x => x.OnStartMutantTestRun(It.IsAny<IEnumerable<IReadOnlyMutant>>()));
             reporterMock.Setup(x => x.OnAllMutantsTested(It.IsAny<IReadOnlyProjectComponent>()));
 
             mutationTestProcessMock.SetupGet(x => x.Input).Returns(mutationTestInput);
             mutationTestProcessMock.Setup(x => x.GetCoverage());
-            mutationTestProcessMock.Setup(x => x.FilterMutants());
             mutationTestProcessMock.Setup(x => x.Test(It.IsAny<IEnumerable<Mutant>>()))
                 .Returns(new StrykerRunResult(It.IsAny<StrykerOptions>(), It.IsAny<double>()));
+
+            // Set up sequence-critical methods:
+            // * FilterMutants must be called before OnMutantsCreated to get valid reports
+            var seq = new MockSequence();
+            mutationTestProcessMock.InSequence(seq).Setup(x => x.FilterMutants());
+            reporterMock.InSequence(seq).Setup(x => x.OnMutantsCreated(It.IsAny<IReadOnlyProjectComponent>()));
 
             var target = new StrykerRunner(projectOrchestratorMock.Object, reporterFactory: reporterFactoryMock.Object);
 

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -65,17 +65,16 @@ namespace Stryker.Core
                 AnalyseCoverage(options);
                 var readOnlyInputComponent = rootComponent.ToReadOnlyInputComponent();
 
-                // Report
-                reporters.OnMutantsCreated(readOnlyInputComponent);
-
-                var allMutants = rootComponent.Mutants.ToList();
-
                 // Filter
                 foreach (var project in _mutationTestProcesses)
                 {
                     project.FilterMutants();
                 }
 
+                // Report
+                reporters.OnMutantsCreated(readOnlyInputComponent);
+
+                var allMutants = rootComponent.Mutants.ToList();
                 var mutantsNotRun = allMutants.Where(x => x.ResultStatus == MutantStatus.NotRun).ToList();
 
                 if (!mutantsNotRun.Any())


### PR DESCRIPTION
Filters were run after reports, which caused the report to not include information about ignored mutants.
Running filters before reports fixes the issue.

### Example output

Before:
```
[13:23:18 INF] 1     mutants got status CompileError. Reason: Mutant caused compile errors
[13:23:18 INF] 7     mutants got status NoCoverage.   Reason: Mutant has no test coverage
[13:23:18 INF] 8     total mutants are skipped for the above mentioned reasons
[13:23:18 INF] 97    total mutants will be tested
███████████████████████████████████████████████████████████████████████████████████████████████████████████
100.00% │ Testing mutant 95 / 95 │ K 88 │ S 0 │ T 7 │ ~0m 00s │
```

After:
```
[14:09:51 INF] 1     mutants got status CompileError. Reason: Mutant caused compile errors
[14:09:51 INF] 7     mutants got status Ignored.      Reason: Removed by exclude from code coverage filter
[14:09:51 INF] 2     mutants got status Ignored.      Reason: Removed by file filter
[14:09:51 INF] 10    total mutants are skipped for the above mentioned reasons
[14:09:51 INF] 95    total mutants will be tested
███████████████████████████████████████████████████████████████████████████████████████████████████████████
100.00% │ Testing mutant 95 / 95 │ K 88 │ S 0 │ T 7 │ ~0m 00s │  
```
