### PR TITLE
Fix flaky tests by not running them in parallel

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -42,6 +42,9 @@
     <ProjectReference Include="..\Stryker.Core\Stryker.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/Stryker.Core/Stryker.Core.UnitTest/xunit.runner.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
I observed that one of the issues was related to the static `JsonReport._report` field. It would be better to get rid of this static caching, by passing the state around explicitly instead, but for now, fixing the flaky tests is probably still a good idea.

I've had the test running with `while dotnet test --no-build; do :; done` for several minutes now without failure.