### PR TITLE
feat(baseline): Azure fileshare uses projectname as output path if specified

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
@@ -170,6 +170,168 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
                 ItExpr.IsAny<CancellationToken>());
         }
 
+        [Fact]
+        public async Task Save_Calls_CreateDictionaryWithProjectName_And_AllocateFileLocation_When_Baseline_Does_Not_Exists()
+        {
+            // arrange
+            var projectName = "my-project-name";
+            var projectVersion = "my-project-version";
+
+            var options = new StrykerOptions(azureFileStorageUrl: "https://www.filestoragelocation.com", azureSAS: "AZURE_SAS_KEY", baselineStorageLocation: "azurefilestorage", projectName: projectName);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            var readonlyInputComponent = new Mock<IReadOnlyProjectComponent>(MockBehavior.Loose).Object;
+
+            var jsonReport = JsonReport.Build(options, readonlyInputComponent);
+
+            var expectedGetUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
+
+            var expectedCreateProjectOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateBaselinesDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/?restype=directory&sv=AZURE_SAS_KEY");
+
+            var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
+
+            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedGetUri && requestMessage.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(() => new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.NotFound,
+                    Content = new StringContent(jsonReport.ToJson(), Encoding.UTF8, "application/json")
+                })
+                .Verifiable();
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedCreateProjectOutputDirectoryUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created
+                })
+                .Verifiable();
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedCreateBaselinesDirectoryUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created
+                })
+                .Verifiable();
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedCreateVersionDirectoryUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created
+                })
+                .Verifiable();
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedFileAllocationUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created
+                })
+                .Verifiable();
+
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedUploadContentUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created,
+                    Content = new StringContent("File created")
+                })
+                .Verifiable();
+
+            var target = new AzureFileShareBaselineProvider(options, new HttpClient(handlerMock.Object));
+
+            await target.Save(jsonReport, projectVersion);
+
+            // assert
+            handlerMock
+               .Protected()
+               .Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                   req.Method == HttpMethod.Get
+                   && req.RequestUri == expectedGetUri),
+                ItExpr.IsAny<CancellationToken>());
+
+            handlerMock
+               .Protected()
+               .Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                   req.Method == HttpMethod.Put
+                   && req.RequestUri == expectedCreateProjectOutputDirectoryUri),
+                ItExpr.IsAny<CancellationToken>());
+            handlerMock
+               .Protected()
+               .Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                   req.Method == HttpMethod.Put
+                   && req.RequestUri == expectedCreateBaselinesDirectoryUri),
+                ItExpr.IsAny<CancellationToken>());
+            handlerMock
+               .Protected()
+               .Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                   req.Method == HttpMethod.Put
+                   && req.RequestUri == expectedCreateVersionDirectoryUri),
+                ItExpr.IsAny<CancellationToken>());
+
+            handlerMock
+              .Protected()
+              .Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Put
+                  && req.RequestUri == expectedFileAllocationUri
+                  && req.Headers.Contains("x-ms-type")),
+                ItExpr.IsAny<CancellationToken>());
+
+            handlerMock
+              .Protected()
+              .Verify(
+               "SendAsync",
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Put
+                  && req.RequestUri == expectedUploadContentUri),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
         [Theory]
         [InlineData("2.0.0")]
         [InlineData("2.0.0-beta001")]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
@@ -272,64 +272,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             await target.Save(jsonReport, projectVersion);
 
             // assert
-            handlerMock
-               .Protected()
-               .Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                   req.Method == HttpMethod.Get
-                   && req.RequestUri == expectedGetUri),
-                ItExpr.IsAny<CancellationToken>());
-
-            handlerMock
-               .Protected()
-               .Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                   req.Method == HttpMethod.Put
-                   && req.RequestUri == expectedCreateProjectOutputDirectoryUri),
-                ItExpr.IsAny<CancellationToken>());
-            handlerMock
-               .Protected()
-               .Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                   req.Method == HttpMethod.Put
-                   && req.RequestUri == expectedCreateBaselinesDirectoryUri),
-                ItExpr.IsAny<CancellationToken>());
-            handlerMock
-               .Protected()
-               .Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                   req.Method == HttpMethod.Put
-                   && req.RequestUri == expectedCreateVersionDirectoryUri),
-                ItExpr.IsAny<CancellationToken>());
-
-            handlerMock
-              .Protected()
-              .Verify(
-               "SendAsync",
-               Times.Exactly(1),
-               ItExpr.Is<HttpRequestMessage>(req =>
-                  req.Method == HttpMethod.Put
-                  && req.RequestUri == expectedFileAllocationUri
-                  && req.Headers.Contains("x-ms-type")),
-                ItExpr.IsAny<CancellationToken>());
-
-            handlerMock
-              .Protected()
-              .Verify(
-               "SendAsync",
-               Times.Exactly(1),
-               ItExpr.Is<HttpRequestMessage>(req =>
-                  req.Method == HttpMethod.Put
-                  && req.RequestUri == expectedUploadContentUri),
-                ItExpr.IsAny<CancellationToken>());
+            handlerMock.VerifyAll();
         }
 
         [Theory]

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -128,7 +128,7 @@ namespace Stryker.Core.Baseline.Providers
 
             if (response.StatusCode == HttpStatusCode.Created)
             {
-                _logger.LogDebug("Succesfully created directory {0}", fileUrl);
+                _logger.LogDebug("Successfully created directory {0}", fileUrl);
                 return true;
             }
             else if (response.StatusCode == HttpStatusCode.Conflict)
@@ -159,7 +159,7 @@ namespace Stryker.Core.Baseline.Providers
 
             if (response.StatusCode == HttpStatusCode.Created)
             {
-                _logger.LogDebug("Succesfully allocated storage");
+                _logger.LogDebug("Successfully allocated storage");
                 return true;
             }
             else

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -14,16 +14,25 @@ namespace Stryker.Core.Baseline.Providers
 {
     public class AzureFileShareBaselineProvider : IBaselineProvider
     {
+        private const string DefaultOutputDirectoryName = "StrykerOutput";
+        private const string BaselinesDirectoryName = "Baselines";
+
         private readonly IStrykerOptions _options;
         private readonly HttpClient _httpClient;
         private readonly ILogger<AzureFileShareBaselineProvider> _logger;
-        private const string _outputPath = "StrykerOutput/Baselines";
+        private readonly string _outputPath;
 
         public AzureFileShareBaselineProvider(IStrykerOptions options, HttpClient httpClient = null)
         {
             _options = options;
             _httpClient = httpClient ?? new HttpClient();
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<AzureFileShareBaselineProvider>();
+
+            _outputPath = $"{DefaultOutputDirectoryName}/{BaselinesDirectoryName}";
+            if (!string.IsNullOrWhiteSpace(options.ProjectName))
+            {
+                _outputPath = $"{options.ProjectName}/{BaselinesDirectoryName}";
+            }
         }
 
         public async Task<JsonReport> Load(string version)

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -307,7 +307,7 @@ namespace Stryker.Core.Options
         {
             if (!Reporters.Contains(Reporter.Dashboard))
             {
-                return (null, null);
+                return (null, projectName);
             }
 
             var errorStrings = new StringBuilder();


### PR DESCRIPTION
Closes #1525