### PR TITLE
Fix rollback of helpers and injections of array initializers in the following method

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -118,8 +118,47 @@ else{
 }
 private bool Out(out string test)
 {
-    return (StrykerNamespace.MutantControl.IsActive(14)?false:true);
+    {test= default(string);}    return (StrykerNamespace.MutantControl.IsActive(14)?false:true);
 }}";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
+        public void ShouldNotFail()
+        {
+            string source = @"public static class ExampleExtension
+    {
+        private static string[] tabs = { ""tab1"", ""tab2""};
+
+        private List<string> _collection;
+
+        public List<string> Collection
+        {
+            get => _collection;
+
+            set
+            {
+                _collection = value;
+            }
+        }
+    }";
+            string expected = @"public static class ExampleExtension
+    {
+        private static string[] tabs = { (StrykerNamespace.MutantControl.IsActive(1)?"""":""tab1""), (StrykerNamespace.MutantControl.IsActive(2)?"""":""tab2"")};
+
+        private List<string> _collection;
+
+        public List<string> Collection
+        {
+            get => _collection;
+
+            set
+            {
+                _collection = value;
+            }
+        }
+    }";
 
             ShouldMutateSourceToExpected(source, expected);
         }
@@ -134,7 +173,7 @@ private bool Out(out string test)
 }
 private bool Out(out string test)
 {
-    return true;
+       return true;
 }";
             string expected = @"void TestMethod()
 {if(StrykerNamespace.MutantControl.IsActive(0)){
@@ -147,7 +186,7 @@ else{
 }
 }private bool Out(out string test)
 {
-    return (StrykerNamespace.MutantControl.IsActive(2)?false:true);
+{test= default(string);}     return (StrykerNamespace.MutantControl.IsActive(2)?false:true);
 }";
 
             ShouldMutateSourceToExpected(source, expected);
@@ -625,6 +664,15 @@ static Mutator_Flag_MutatedStatics()
         }
 
         [Fact]
+        public void ShouldInitializeOutVars()
+        {
+            string source = @"public void SomeMethod(out int x, out string text) { x = 1; text = ""hello"";}";
+            string expected = @"public void SomeMethod(out int x, out string text) { {x= default(int);text= default(string);}x = 1; text = (StrykerNamespace.MutantControl.IsActive(0)?"""":""hello"");)}";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
         public void ShouldMutateInsideLambda()
         {
             string source = @"private async Task GoodLuck()
@@ -751,14 +799,14 @@ public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable)
       {
         foreach (var o in enumerable)
         {
-            if(StrykerNamespace.MutantControl.IsActive(0)){;}else{
-                yield return value;
+            if(StrykerNamespace.MutantControl.IsActive(0)){;}else{ yield return value;
             }
         }
       } 
 public static IEnumerable<object> Extracting<T>(this IEnumerable<T> enumerable)
       {
-        yield break;
+if(StrykerNamespace.MutantControl.IsActive(1)){;}else{        yield break;
+}
       }";
             ShouldMutateSourceToExpected(source, expected);
         }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -94,21 +94,16 @@ namespace Stryker.Core.Compiling
 
         private int? ExtractMutationIfAndId(SyntaxNode node)
         {
-            var first = node.GetAnnotations(MutantPlacer.MutationMarkers).FirstOrDefault();
-            if (first == null)
+            var (engine, id) = MutantPlacer.FindEngine(node);
+
+            if (engine == null)
             {
                 return null;
             }
 
-            if (first.Data == null)
-            {
-                Logger.LogDebug("Remove a mutation helper.");
-                return _dummyId;
-            }
-            var mutantId = int.Parse(first.Data);
-            Logger.LogDebug("Found id {0} in MutantIf annotation", mutantId);
-            return mutantId;
+            Logger.LogDebug(id == -1 ? $"Found a helper: {engine}." : $"Found id {id} in {engine} annotation.");
 
+            return id;
         }
 
         private static SyntaxNode FindEnclosingMember(SyntaxNode node)
@@ -208,7 +203,7 @@ namespace Stryker.Core.Compiling
                         if (!brokenMutations.Contains(key))
                         {
                             brokenMutations.Add(key);
-                            if (value != _dummyId)
+                            if (value != -1)
                             {
                                 RolledBackIds.Add(value);
                             }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -24,7 +24,6 @@ namespace Stryker.Core.Compiling
     {
         private List<int> RolledBackIds { get; }
         private ILogger Logger { get; }
-        private const int _dummyId = int.MinValue;
 
         public RollbackProcess()
         {
@@ -89,7 +88,7 @@ namespace Stryker.Core.Compiling
                 }
             }
 
-            return (null, 0);
+            return (null, -1);
         }
 
         private int? ExtractMutationIfAndId(SyntaxNode node)

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -56,5 +56,7 @@ namespace Stryker.Core.Helpers
 
         public static AccessorDeclarationSyntax GetAccessor(this PropertyDeclarationSyntax propertyDeclaration)
             => propertyDeclaration?.AccessorList?.Accessors.FirstOrDefault(a => a.Keyword.Text == "get");
+
+        public static ExpressionSyntax BuildDefaultExpression(this TypeSyntax type) => SyntaxFactory.DefaultExpression(type.WithoutTrailingTrivia()).WithLeadingTrivia(SyntaxFactory.Space);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/AccessorExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/AccessorExpressionToBodyEngine.cs
@@ -5,12 +5,21 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Helper that converts a property accessor from expression body to statement body form (or arrow to curly braces).
+    /// </summary>
     internal class AccessorExpressionToBodyEngine : BaseEngine<AccessorDeclarationSyntax>
     {
         public AccessorExpressionToBodyEngine(string markerId) : base(markerId)
         {
         }
 
+        /// <summary>
+        /// Convert an expression accessor to the body form.
+        /// </summary>
+        /// <param name="accessor">Accessor to be converted</param>
+        /// <returns>Accessor in body form</returns>
+        /// <remarks>No conversion happens it is already in body form or if it is virtual.</remarks>
         public AccessorDeclarationSyntax ConvertExpressionToBody(AccessorDeclarationSyntax accessor)
         {
             if (accessor.Body != null || accessor.ExpressionBody == null)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/BaseEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/BaseEngine.cs
@@ -22,7 +22,7 @@ namespace Stryker.Core.Instrumentation
             {
                 return Revert(tNode);
             }
-            throw new InvalidOperationException($"Expected a block containing a conditional expression, found:\n{node.ToFullString()}.");
+            throw new InvalidOperationException($"Expected a {typeof(T).Name}, found:\n{node.ToFullString()}.");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/BaseEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/BaseEngine.cs
@@ -3,6 +3,12 @@ using Microsoft.CodeAnalysis;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Base logic for all instrumentation helpers. It takes of generating a specific annotation
+    /// </summary>
+    /// <typeparam name="T">SyntaxNode type handled by this helper.</typeparam>
+    /// <remarks>There is no standard helper injection method as each injector may require specific arguments.</remarks>
+    /// <remarks>Multiple helpers can work on the same type of constructs.</remarks>
     internal abstract class BaseEngine<T>: IInstrumentCode where T: SyntaxNode
     {
         protected BaseEngine(string markerId)
@@ -10,12 +16,29 @@ namespace Stryker.Core.Instrumentation
             Marker = new SyntaxAnnotation(markerId, InstrumentEngineID);
         }
 
+        /// <summary>
+        /// Annotation to be added to the the instrumented node
+        /// </summary>
         protected SyntaxAnnotation Marker { get; }
 
+        /// <summary>
+        /// Engine name. Used by roll back logic to forward rollback to the proper engine.
+        /// </summary>
         public string InstrumentEngineID => GetType().Name;
 
+        /// <summary>
+        /// Removes the instrumentation.
+        /// </summary>
+        /// <param name="node">node to be cleaned</param>
+        /// <returns></returns>
         protected abstract SyntaxNode Revert(T node);
 
+        /// <summary>
+        /// Removes the helper from the code. Ensure that the node is of the proper type
+        /// and forwards to specific implementation.
+        /// </summary>
+        /// <param name="node">Syntax node where the helper is located.</param>
+        /// <returns>The non instrumented node.</returns>
         public SyntaxNode RemoveInstrumentation(SyntaxNode node)
         {
             if (node is T tNode)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/ConditionalInstrumentationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/ConditionalInstrumentationEngine.cs
@@ -5,6 +5,9 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Injects a mutation controlled by a conditional operator.
+    /// </summary>
     internal class ConditionalInstrumentationEngine : BaseEngine<ParenthesizedExpressionSyntax>
     {
 
@@ -12,6 +15,13 @@ namespace Stryker.Core.Instrumentation
         {
         }
 
+        /// <summary>
+        /// Injects a conditional operator with the original code or the mutated one, depending on condition's result.
+        /// </summary>
+        /// <param name="condition">Expression for the condition.</param>
+        /// <param name="original">Original code</param>
+        /// <param name="mutated">Mutated code</param>
+        /// <returns>A new expression containing the expected construct.</returns>
         public  ParenthesizedExpressionSyntax PlaceWithConditionalExpression(ExpressionSyntax condition, ExpressionSyntax original, ExpressionSyntax mutated) =>
             SyntaxFactory.ParenthesizedExpression(
                     SyntaxFactory.ConditionalExpression(

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Stryker.Core.Helpers;
+
+namespace Stryker.Core.Instrumentation
+{
+    internal class DefaultInitializationEngine : BaseEngine<BaseMethodDeclarationSyntax>
+    {
+        private static SyntaxAnnotation blockMarker = new SyntaxAnnotation("InitializationBlock");
+        public DefaultInitializationEngine(string injector): base(injector)
+        {
+        }
+
+        protected override SyntaxNode Revert(BaseMethodDeclarationSyntax node)
+        {
+            if (node.Body == null || node.Body.Statements.Count == 0 || node.Body.Statements[0].Kind() != SyntaxKind.Block)
+            {
+                throw new InvalidOperationException(
+                    "Can't find initializer block at the beginning of method.");
+            }
+
+            return node.WithBody(
+                    node.Body.WithStatements(new SyntaxList<StatementSyntax>(node.Body.Statements.Skip(1))))
+                .WithoutAnnotations(Marker);
+        }
+
+        public BaseMethodDeclarationSyntax AddDefaultInitializer(BaseMethodDeclarationSyntax node, SyntaxToken outParameterParameterName, TypeSyntax outParameterParameterType)
+        {
+            if (node.Body == null)
+            {
+                throw new InvalidOperationException(
+                    "Cant' add default initializer(s) to expression bodied or virtual method.");
+            }
+
+            IEnumerable<StatementSyntax> initializers = null;
+            IEnumerable<StatementSyntax> originalStatements = null;
+            if (node.Body.Statements.Count > 0 && node.Body.Statements[0].HasAnnotation(blockMarker))
+            {
+                // we add a new initializer, we need to get the existing ones
+                initializers = (node.Body.Statements[0] as BlockSyntax).Statements;
+                // we can skip the initializer helper block
+                originalStatements = node.Body.Statements.Skip(1);
+            }
+            else
+            {
+                // this is the first initializer helper, no pre existing ones
+                initializers = Array.Empty<StatementSyntax>();
+                // keep all statements
+                originalStatements = node.Body.Statements;
+            }
+
+            var initializer = SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(
+                SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(outParameterParameterName),
+                outParameterParameterType.BuildDefaultExpression()));
+            var initializersBlock = SyntaxFactory.Block(initializers.Append(initializer))
+                .WithAdditionalAnnotations(blockMarker);
+
+            return node.WithBody(node.Body.WithStatements(new SyntaxList<StatementSyntax>(originalStatements.Prepend(initializersBlock)))).WithAdditionalAnnotations(Marker);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
@@ -8,6 +8,12 @@ using Stryker.Core.Helpers;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Injects initialization to default value for a parameter or a variable at the beginning of a method.
+    /// <remarks>No check is made on the visibility of the variable.</remarks>
+    /// <exception cref="InvalidOperationException">If the method has no body (virtual or expression form).</exception>
+    /// </summary>
+    /// <remarks>Parameters/variables are added on a one by one basis but they are all removed simultaneously.</remarks>
     internal class DefaultInitializationEngine : BaseEngine<BaseMethodDeclarationSyntax>
     {
         private static SyntaxAnnotation blockMarker = new SyntaxAnnotation("InitializationBlock");
@@ -15,6 +21,52 @@ namespace Stryker.Core.Instrumentation
         {
         }
 
+        /// <summary>
+        /// Add an assignment to default value for the given parameter/variable
+        /// </summary>
+        /// <param name="methodDeclarationSyntax">method/accessor where to inject the assignment</param>
+        /// <param name="outParameterParameterName">parameter/variable name</param>
+        /// <param name="outParameterParameterType">parameter/variable type</param>
+        /// <returns>the method with a block containing an initialization to default for the given variables/parameters</returns>
+        public BaseMethodDeclarationSyntax AddDefaultInitializer(BaseMethodDeclarationSyntax methodDeclarationSyntax, SyntaxToken outParameterParameterName, TypeSyntax outParameterParameterType)
+        {
+            if (methodDeclarationSyntax.Body == null)
+            {
+                throw new InvalidOperationException(
+                    "Cant' add default initializer(s) to expression bodied or virtual method.");
+            }
+
+            IEnumerable<StatementSyntax> initializers;
+            IEnumerable<StatementSyntax> originalStatements;
+            if (methodDeclarationSyntax.Body.Statements.Count > 0 && methodDeclarationSyntax.Body.Statements[0].HasAnnotation(blockMarker))
+            {
+                // we add a new initializer, we need to get the existing ones
+                initializers = (methodDeclarationSyntax.Body.Statements[0] as BlockSyntax).Statements;
+                // we can skip the initializer helper block
+                originalStatements = methodDeclarationSyntax.Body.Statements.Skip(1);
+            }
+            else
+            {
+                // this is the first initializer helper, no pre existing ones
+                initializers = Array.Empty<StatementSyntax>();
+                // keep all statements
+                originalStatements = methodDeclarationSyntax.Body.Statements;
+            }
+
+            var initializer = SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(
+                SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(outParameterParameterName),
+                outParameterParameterType.BuildDefaultExpression()));
+            var initializersBlock = SyntaxFactory.Block(initializers.Append(initializer))
+                .WithAdditionalAnnotations(blockMarker);
+
+            return methodDeclarationSyntax.WithBody(methodDeclarationSyntax.Body.WithStatements(new SyntaxList<StatementSyntax>(originalStatements.Prepend(initializersBlock)))).WithAdditionalAnnotations(Marker);
+        }
+
+        /// <summary>
+        /// Removes all initializer from the given method.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns>the method with the initialization block removed.</returns>
         protected override SyntaxNode Revert(BaseMethodDeclarationSyntax node)
         {
             if (node.Body == null || node.Body.Statements.Count == 0 || node.Body.Statements[0].Kind() != SyntaxKind.Block)
@@ -26,40 +78,6 @@ namespace Stryker.Core.Instrumentation
             return node.WithBody(
                     node.Body.WithStatements(new SyntaxList<StatementSyntax>(node.Body.Statements.Skip(1))))
                 .WithoutAnnotations(Marker);
-        }
-
-        public BaseMethodDeclarationSyntax AddDefaultInitializer(BaseMethodDeclarationSyntax node, SyntaxToken outParameterParameterName, TypeSyntax outParameterParameterType)
-        {
-            if (node.Body == null)
-            {
-                throw new InvalidOperationException(
-                    "Cant' add default initializer(s) to expression bodied or virtual method.");
-            }
-
-            IEnumerable<StatementSyntax> initializers = null;
-            IEnumerable<StatementSyntax> originalStatements = null;
-            if (node.Body.Statements.Count > 0 && node.Body.Statements[0].HasAnnotation(blockMarker))
-            {
-                // we add a new initializer, we need to get the existing ones
-                initializers = (node.Body.Statements[0] as BlockSyntax).Statements;
-                // we can skip the initializer helper block
-                originalStatements = node.Body.Statements.Skip(1);
-            }
-            else
-            {
-                // this is the first initializer helper, no pre existing ones
-                initializers = Array.Empty<StatementSyntax>();
-                // keep all statements
-                originalStatements = node.Body.Statements;
-            }
-
-            var initializer = SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(
-                SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(outParameterParameterName),
-                outParameterParameterType.BuildDefaultExpression()));
-            var initializersBlock = SyntaxFactory.Block(initializers.Append(initializer))
-                .WithAdditionalAnnotations(blockMarker);
-
-            return node.WithBody(node.Body.WithStatements(new SyntaxList<StatementSyntax>(originalStatements.Prepend(initializersBlock)))).WithAdditionalAnnotations(Marker);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -49,9 +49,8 @@ namespace Stryker.Core.Instrumentation
                 }
             }
 
-            method = method.ReplaceNode(method.Body!, method.Body!.AddStatements(
-                    SyntaxFactory.ReturnStatement(SyntaxFactory.DefaultExpression(returnType.WithoutTrailingTrivia()).
-                        WithLeadingTrivia(SyntaxFactory.Space)))).WithAdditionalAnnotations(Marker);
+            method = method.WithBody(method.Body!.AddStatements(
+                    SyntaxFactory.ReturnStatement(returnType.BuildDefaultExpression()))).WithAdditionalAnnotations(Marker);
 
             return method;
         }
@@ -63,7 +62,7 @@ namespace Stryker.Core.Instrumentation
                 throw new InvalidOperationException($"No return at the end of: {node.Body}");
             }
 
-            return node.ReplaceNode(node.Body, node.Body.WithStatements(node.Body.Statements.Remove(node.Body.Statements.Last())));
+            return node.WithBody(node.Body.WithStatements(node.Body.Statements.Remove(node.Body.Statements.Last()))).WithoutAnnotations(Marker);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -8,7 +8,7 @@ using Stryker.Core.Helpers;
 namespace Stryker.Core.Instrumentation
 {
     /// <summary>
-    /// Injects 'return' statement at the end of a method
+    /// Injects 'return default(...)' statement at the end of a method
     /// </summary>
     internal class EndingReturnEngine: BaseEngine<BaseMethodDeclarationSyntax>
     {

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/ExpressionMethodToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/ExpressionMethodToBodyEngine.cs
@@ -6,12 +6,22 @@ using Stryker.Core.Helpers;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Helper that converts a method (including operators) from expression body to statement body form (or arrow to curly braces).
+    /// </summary>
     internal class ExpressionMethodToBodyEngine : BaseEngine<BaseMethodDeclarationSyntax>
     {
         public ExpressionMethodToBodyEngine(string markerId) : base(markerId)
         {
         }
 
+        /// <summary>
+        /// Converts the given method (or operator) from expression to body form.
+        /// </summary>
+        /// <typeparam name="T">Specific node type</typeparam>
+        /// <param name="method">Method/operator to be converted.</param>
+        /// <returns>the converted method/operator</returns>
+        /// <remarks>returns the original node if no conversion is needed/possible</remarks>
         public T ConvertToBody<T>(T method) where T: BaseMethodDeclarationSyntax
         {
             if (method.ExpressionBody == null || method.Body != null)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/IfInstrumentationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/IfInstrumentationEngine.cs
@@ -4,13 +4,23 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core.Instrumentation
-{
+{    /// <summary>
+    /// Injects a mutation controlled by an if Statement.
+    /// </summary>
     internal class IfInstrumentationEngine: BaseEngine<IfStatementSyntax>
     {
         public IfInstrumentationEngine(string annotation) : base(annotation)
         {
         }
 
+        /// <summary>
+        /// Injects an if statement with the original code or the mutated one, depending on condition's result.
+        /// </summary>
+        /// <param name="condition">Expression for the condition.</param>
+        /// <param name="original">Original code</param>
+        /// <param name="mutated">Mutated code</param>
+        /// <returns>A statement containing the expected construct.</returns>
+        /// <remarks>This method works with statement and block.</remarks>
         public IfStatementSyntax InjectIf(ExpressionSyntax condition, StatementSyntax originalNode, StatementSyntax mutatedNode)
         {
             return SyntaxFactory.IfStatement(condition, 
@@ -23,6 +33,12 @@ namespace Stryker.Core.Instrumentation
             return (code as BlockSyntax) ?? SyntaxFactory.Block(code);
         }
 
+        /// <summary>
+        /// Returns the original code.
+        /// </summary>
+        /// <param name="ifNode">if statement to be 'removed'</param>
+        /// <returns>the original node.</returns>
+        /// <remarks>this method returns either a single statement or a syntax block.</remarks>
         protected override SyntaxNode Revert(IfStatementSyntax ifNode)
         {
             if (ifNode.Else?.Statement is BlockSyntax block)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/PropertyExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/PropertyExpressionToBodyEngine.cs
@@ -6,12 +6,21 @@ using Stryker.Core.Helpers;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Helper that converts a property from expression body to statement body form (or arrow to curly braces).
+    /// </summary>
     internal class PropertyExpressionToBodyEngine : BaseEngine<PropertyDeclarationSyntax>
     {
         public PropertyExpressionToBodyEngine(string markerId) : base(markerId)
         {
         }
 
+        /// <summary>
+        /// Convert a property from arrow form to the body form.
+        /// </summary>
+        /// <param name="accessor">Accessor to be converted</param>
+        /// <returns>a property with a getter in body form</returns>
+        /// <remarks>No conversion happens it is already in body form or if it is virtual.</remarks>
         public PropertyDeclarationSyntax ConvertExpressionToBody(PropertyDeclarationSyntax propertyDeclaration)
         {
             if (propertyDeclaration.ExpressionBody == null)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/StaticInstrumentationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/StaticInstrumentationEngine.cs
@@ -5,6 +5,9 @@ using Stryker.Core.InjectedHelpers;
 
 namespace Stryker.Core.Instrumentation
 {
+    /// <summary>
+    /// Injects a static marker, to help identification of mutations executed through a static constructor/method/property...
+    /// </summary>
     internal class StaticInstrumentationEngine : BaseEngine<BlockSyntax>
     {
         private readonly ExpressionSyntax _cachedMarker = SyntaxFactory.ParseExpression(CodeInjection.StaticMarker);
@@ -12,6 +15,15 @@ namespace Stryker.Core.Instrumentation
         public StaticInstrumentationEngine(string annotation) : base(annotation)
         {
         }
+
+        /// <summary>
+        /// injects a 'using' block with static marker class used by coverage logic.
+        /// </summary>
+        /// <param name="block"></param>
+        /// <returns></returns>
+        public BlockSyntax PlaceStaticContextMarker(BlockSyntax block) =>
+            SyntaxFactory.Block( 
+                SyntaxFactory.UsingStatement(null, _cachedMarker, block)).WithAdditionalAnnotations(Marker);
 
         protected override SyntaxNode Revert(BlockSyntax node)
         {
@@ -23,9 +35,6 @@ namespace Stryker.Core.Instrumentation
             return node;
         }
 
-        public BlockSyntax PlaceStaticContextMarker(BlockSyntax block) =>
-            SyntaxFactory.Block( 
-                SyntaxFactory.UsingStatement(null, _cachedMarker, block)).WithAdditionalAnnotations(Marker);
 
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -57,10 +57,11 @@ namespace Stryker.Core.Mutants
                 new ForStatementOrchestrator(this),
                 new AssignmentStatementOrchestrator(this),
                 new PostfixUnaryExpressionOrchestrator(this),
-                new StaticFieldDeclarationOrchestrator(this),
+                new StaticFieldDeclarationDeclarationOrchestrator(this),
                 new StaticConstructorOrchestrator(this),
                 new PropertyDeclarationOrchestrator(this),
                 new ArrayInitializerOrchestrator(this),
+                new MemberDeclarationOrchestrator<MemberDeclarationSyntax, MemberDeclarationSyntax>(this),
                 new BaseMethodDeclarationOrchestrator<BaseMethodDeclarationSyntax>(this),
                 new AccessorSyntaxOrchestrator(this),
                 new LocalDeclarationOrchestrator(this),
@@ -80,17 +81,6 @@ namespace Stryker.Core.Mutants
         {
             var mutationContext = new MutationContext(this);
             var mutation = Mutate(input, mutationContext);
-            if (mutationContext.HasStatementLevelMutant && _options?.DevMode == true)
-            {
-                // some mutants where not injected for some reason, they should be reviewed to understand why.
-                Logger.LogError($"Several mutants were not injected in the project : {mutationContext.BlockLevelControlledMutations.Count + mutationContext.StatementLevelControlledMutations.Count}");
-            }
-            // mark remaining mutants as CompileError
-            foreach (var mutant in mutationContext.StatementLevelControlledMutations.Union(mutationContext.BlockLevelControlledMutations))
-            {
-                mutant.ResultStatus = MutantStatus.CompileError;
-                mutant.ResultStatusReason = "Stryker was not able to inject mutation in code.";
-            }
             return mutation;
         }
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -57,7 +57,7 @@ namespace Stryker.Core.Mutants
                 new ForStatementOrchestrator(this),
                 new AssignmentStatementOrchestrator(this),
                 new PostfixUnaryExpressionOrchestrator(this),
-                new StaticFieldDeclarationDeclarationOrchestrator(this),
+                new StaticFieldDeclarationOrchestrator(this),
                 new StaticConstructorOrchestrator(this),
                 new PropertyDeclarationOrchestrator(this),
                 new ArrayInitializerOrchestrator(this),

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -16,7 +16,6 @@ namespace Stryker.Core.Mutants
     public static class MutantPlacer
     {
         private const string MutationMarker = "Mutation";
-        private const string MutationHelper = "Helper";
         private const string Injector = "Injector";
 
         private static readonly StaticInstrumentationEngine StaticEngine;
@@ -26,12 +25,13 @@ namespace Stryker.Core.Mutants
         private static readonly AccessorExpressionToBodyEngine accessorExpressionToBodyEngine;
         private static readonly PropertyExpressionToBodyEngine propertyExpressionToBodyEngine;
         private static readonly EndingReturnEngine endingReturnEngine;
+        private static readonly DefaultInitializationEngine defaultInitializationEngine;
         private static ExpressionSyntax _binaryExpression;
         private static SyntaxNode _placeHolderNode;
         
         private static readonly IDictionary<string, IInstrumentCode> InstrumentEngines = new Dictionary<string, IInstrumentCode>();
 
-        public static IEnumerable<string> MutationMarkers => new[] { MutationMarker, MutationHelper};
+        public static IEnumerable<string> MutationMarkers => new[] { MutationMarker, Injector};
 
         static MutantPlacer()
         {
@@ -49,6 +49,8 @@ namespace Stryker.Core.Mutants
             RegisterEngine(propertyExpressionToBodyEngine);
             endingReturnEngine = new EndingReturnEngine(Injector);
             RegisterEngine(endingReturnEngine);
+            defaultInitializationEngine = new DefaultInitializationEngine(Injector);
+            RegisterEngine(defaultInitializationEngine);
         }
 
         /// <summary>
@@ -61,23 +63,24 @@ namespace Stryker.Core.Mutants
         }
 
         public static T ConvertExpressionToBody<T>(T method) where T: BaseMethodDeclarationSyntax =>
-            expressionMethodEngine.ConvertToBody(method)
-                .WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
+            expressionMethodEngine.ConvertToBody(method);
 
         public static AccessorDeclarationSyntax ConvertExpressionToBody(AccessorDeclarationSyntax method) =>
-            accessorExpressionToBodyEngine.ConvertExpressionToBody(method)
-                .WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
+            accessorExpressionToBodyEngine.ConvertExpressionToBody(method);
 
         public static PropertyDeclarationSyntax ConvertPropertyExpressionToBodyAccessor(PropertyDeclarationSyntax property) =>
-            propertyExpressionToBodyEngine.ConvertExpressionToBody(property).
-                WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
+            propertyExpressionToBodyEngine.ConvertExpressionToBody(property);
 
-        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax node) => endingReturnEngine.InjectReturn(node).
-            WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
+        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax node) => endingReturnEngine.InjectReturn(node);
 
         public static BlockSyntax PlaceStaticContextMarker(BlockSyntax block) => 
-            StaticEngine.PlaceStaticContextMarker(block).
-            WithAdditionalAnnotations(new SyntaxAnnotation(MutationHelper));
+            StaticEngine.PlaceStaticContextMarker(block);
+
+        public static BaseMethodDeclarationSyntax AddDefaultInitialization(BaseMethodDeclarationSyntax node, SyntaxToken outParameterParameterName, TypeSyntax outParameterParameterType)
+        {
+            return defaultInitializationEngine.AddDefaultInitializer(node, outParameterParameterName,
+                outParameterParameterType);
+        }
 
         public static StatementSyntax PlaceStatementControlledMutations(StatementSyntax original,
             IEnumerable<(int mutantId, StatementSyntax mutated)> mutations)
@@ -109,6 +112,26 @@ namespace Stryker.Core.Mutants
             throw new InvalidOperationException($"Unable to find an engine to remove injection from this node: '{nodeToRemove}' ");
         }
 
+        public static (string engine, int id) FindEngine(SyntaxNode node)
+        {
+            string engine = null;
+            var id = -1;
+            var first = node.GetAnnotations(MutantPlacer.MutationMarkers);
+            foreach (var annotation in first)
+            {
+                if (annotation.Kind == MutationMarker)
+                {
+                    id = int.Parse(annotation.Data);
+                }
+                else if (annotation.Kind == Injector)
+                {
+                    engine = annotation.Data;
+                }
+            }
+
+            return (engine, id);
+        }
+
         /// <summary>
         /// Builds a syntax for the expression to check if a mutation is active
         /// Example for mutationId 1: Stryker.Helper.ActiveMutation == 1
@@ -126,5 +149,6 @@ namespace Stryker.Core.Mutants
             return _binaryExpression.ReplaceNode(_placeHolderNode,
                 SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(mutantId)));
         }
+
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Stryker.Core.Logging;
 
 namespace Stryker.Core.Mutants
 {
@@ -8,11 +11,17 @@ namespace Stryker.Core.Mutants
     /// </summary>
     public class MutationContext: IDisposable
     {
+        private static readonly ILogger Logger;
         private readonly CsharpMutantOrchestrator _mainOrchestrator;
         private readonly MutationContext _ancestor;
         public readonly List<Mutant> ExpressionLevelMutations = new List<Mutant>();
         public readonly List<Mutant> BlockLevelControlledMutations = new List<Mutant>();
         public readonly List<Mutant> StatementLevelControlledMutations = new List<Mutant>();
+
+        static MutationContext()
+        {
+            Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationContext>();
+        }
 
         public MutationContext(CsharpMutantOrchestrator mutantOrchestrator)
         {
@@ -47,10 +56,28 @@ namespace Stryker.Core.Mutants
             return new MutationContext(this);
         }
 
+        public void Discard()
+        {
+            if (HasStatementLevelMutant)
+            {
+                // some mutants 
+                Logger.LogInformation($"{BlockLevelControlledMutations.Count+StatementLevelControlledMutations.Count} mutations were not injected.");
+                foreach (var mutant in BlockLevelControlledMutations.Union(StatementLevelControlledMutations))
+                {
+                    mutant.ResultStatus = MutantStatus.CompileError;
+                    mutant.ResultStatusReason = "Stryker was not able to inject mutation in code.";
+                }
+                BlockLevelControlledMutations.Clear();
+                StatementLevelControlledMutations.Clear();
+            }
+
+        }
+
         public void Dispose()
         {
             if (_ancestor == null)
             {
+                Discard();
                 return;
             }
             // copy the pending mutation to the enclosing context

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
@@ -61,7 +61,7 @@ namespace Stryker.Core.Mutants
             if (HasStatementLevelMutant)
             {
                 // some mutants 
-                Logger.LogInformation($"{BlockLevelControlledMutations.Count+StatementLevelControlledMutations.Count} mutations were not injected.");
+                Logger.LogDebug($"{BlockLevelControlledMutations.Count+StatementLevelControlledMutations.Count} mutations were not injected.");
                 foreach (var mutant in BlockLevelControlledMutations.Union(StatementLevelControlledMutations))
                 {
                     mutant.ResultStatus = MutantStatus.CompileError;

--- a/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/MemberDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/MemberDeclarationOrchestrator.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Stryker.Core.Mutants.NodeOrchestrators
+{
+    internal class MemberDeclarationOrchestrator<T, TBase> : NodeSpecificOrchestrator<T, TBase> where T : TBase where TBase : MemberDeclarationSyntax
+    {
+        public MemberDeclarationOrchestrator(CsharpMutantOrchestrator mutantOrchestrator) : base(mutantOrchestrator)
+        {
+        }
+
+        protected override TBase OrchestrateChildrenMutation(T node, MutationContext context)
+        {
+            var result = base.OrchestrateChildrenMutation(node, context);
+            context.Discard();
+            return result;
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/MemberDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/MemberDeclarationOrchestrator.cs
@@ -11,7 +11,12 @@ namespace Stryker.Core.Mutants.NodeOrchestrators
         protected override TBase OrchestrateChildrenMutation(T node, MutationContext context)
         {
             var result = base.OrchestrateChildrenMutation(node, context);
-            context.Discard();
+            // discard any mutations that has not been injected in the code yet
+            // otherwise they will end up in some other method/properties.
+            // Note:
+            // 1 - this is sure sign that current design needs to be improved
+            // 2 - this logic needs to be updated if we can control mutations at some higher level
+            context.Discard(); 
             return result;
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/StaticFieldDeclarationDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/StaticFieldDeclarationDeclarationOrchestrator.cs
@@ -1,10 +1,10 @@
-﻿using System.Linq;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core.Mutants.NodeOrchestrators
 {
-    internal class StaticFieldDeclarationOrchestrator: NodeSpecificOrchestrator<FieldDeclarationSyntax, BaseFieldDeclarationSyntax>
+    internal class StaticFieldDeclarationDeclarationOrchestrator: MemberDeclarationOrchestrator<FieldDeclarationSyntax, BaseFieldDeclarationSyntax>
     {
         protected override bool CanHandle(FieldDeclarationSyntax t)
         {
@@ -18,7 +18,7 @@ namespace Stryker.Core.Mutants.NodeOrchestrators
             return base.OrchestrateChildrenMutation(node, newContext);
         }
 
-        public StaticFieldDeclarationOrchestrator(CsharpMutantOrchestrator mutantOrchestrator) : base(mutantOrchestrator)
+        public StaticFieldDeclarationDeclarationOrchestrator(CsharpMutantOrchestrator mutantOrchestrator) : base(mutantOrchestrator)
         {
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/StaticFieldDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/StaticFieldDeclarationOrchestrator.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Stryker.Core.Mutants.NodeOrchestrators
 {
-    internal class StaticFieldDeclarationDeclarationOrchestrator: MemberDeclarationOrchestrator<FieldDeclarationSyntax, BaseFieldDeclarationSyntax>
+    internal class StaticFieldDeclarationOrchestrator: MemberDeclarationOrchestrator<FieldDeclarationSyntax, BaseFieldDeclarationSyntax>
     {
         protected override bool CanHandle(FieldDeclarationSyntax t)
         {
@@ -18,7 +18,7 @@ namespace Stryker.Core.Mutants.NodeOrchestrators
             return base.OrchestrateChildrenMutation(node, newContext);
         }
 
-        public StaticFieldDeclarationDeclarationOrchestrator(CsharpMutantOrchestrator mutantOrchestrator) : base(mutantOrchestrator)
+        public StaticFieldDeclarationOrchestrator(CsharpMutantOrchestrator mutantOrchestrator) : base(mutantOrchestrator)
         {
         }
     }


### PR DESCRIPTION
Include several fixes and one improvement:

1. Ensure helpers are properly rollbacked and add unit test to prevent regression (issues #1511, #1512).
1. Stryker drops any pending mutants during mutation orchestrating when moving to the next member definition (issue #1527)
1. Stryker injects initialization to default value for all out parameters (at the beginning of methods). This should reduce compile error mutants (should improve #1511 and #1512)

Also refactored injection engine testing, fixed some error messages and improved some naming.
Fixes issues: #1511, #1512, #1527