### PR TITLE
Retrieve the project name and version from the project under test

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
@@ -99,7 +99,6 @@ namespace Stryker.Core.UnitTest.Options
                     new StrykerOptions(reporters: new string[] { "Dashboard" });
                 });
                 ex.Message.ShouldContain($"An API key is required when the {Reporter.Dashboard} reporter is turned on! You can get an API key at {options.DashboardUrl}");
-                ex.Message.ShouldContain($"A project name is required when the {Reporter.Dashboard} reporter is turned on!");
             }
             finally
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -1,10 +1,15 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Mono.Cecil;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation.Buildalyzer;
 using Stryker.Core.Logging;
 using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
+using Stryker.Core.Reporters;
 using Stryker.Core.TestRunners;
 
 namespace Stryker.Core.Initialisation
@@ -74,6 +79,8 @@ namespace Stryker.Core.Initialisation
                     options.SolutionPath);
             }
 
+            InitializeDashboardReporterOptions(options, projectInfo);
+
             if (_testRunner == null)
             {
                 _testRunner = new TestRunnerFactory().Create(options, options.Optimizations, projectInfo);
@@ -87,6 +94,91 @@ namespace Stryker.Core.Initialisation
             };
 
             return input;
+        }
+
+        private void InitializeDashboardReporterOptions(IStrykerOptions options, ProjectInfo projectInfo)
+        {
+            // try to read the repository URL + version for the dashboard report
+            var missingProjectName = options.ProjectName == null;
+            var missingProjectVersion = options.ProjectVersion == null;
+            var missingProjectInformation = (missingProjectName || missingProjectVersion) && options.Reporters.Contains(Reporter.Dashboard);
+            if (missingProjectInformation)
+            {
+                var subject = missingProjectName switch
+                {
+                    true when missingProjectVersion => "Project name and project version",
+                    true => "Project name",
+                    _ => "Project version"
+                };
+                var projectFilePath = projectInfo.ProjectUnderTestAnalyzerResult.ProjectFilePath;
+
+                if (!projectInfo.ProjectUnderTestAnalyzerResult.Properties.TryGetValue("TargetPath", out var targetPath))
+                {
+                    throw new GeneralStrykerException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
+                }
+
+                _logger.LogTrace("{Subject} missing for the dashboard reporter, reading it from {TargetPath}. " +
+                                 "Note that this requires SourceLink to be properly configured in {ProjectPath}", subject, targetPath, projectFilePath);
+
+                try
+                {
+                    var targetName = Path.GetFileName(targetPath);
+                    using var module = ModuleDefinition.ReadModule(targetPath);
+
+                    var details = $"To solve this issue, either specify the {subject.ToLowerInvariant()} in the stryker configuration or configure [SourceLink](https://github.com/dotnet/sourcelink#readme) in {projectFilePath}";
+                    if (missingProjectName)
+                    {
+                        options.ProjectName = ReadProjectName(module, details);
+                        _logger.LogDebug("Using {ProjectName} as project name for the dashboard reporter. (Read from the AssemblyMetadata/RepositoryUrl assembly attribute of {TargetName})", options.ProjectName, targetName);
+                    }
+
+                    if (missingProjectVersion)
+                    {
+                        options.ProjectVersion = ReadProjectVersion(module, details);
+                        _logger.LogDebug("Using {ProjectVersion} as project version for the dashboard reporter. (Read from the AssemblyInformationalVersion assembly attribute of {TargetName})", options.ProjectVersion, targetName);
+                    }
+                }
+                catch (Exception e) when (e is not GeneralStrykerException)
+                {
+                    throw new GeneralStrykerException($"Failed to read {subject.ToLowerInvariant()} from {targetPath}", e);
+                }
+            }
+        }
+
+        private static string ReadProjectName(ModuleDefinition module, string details)
+        {
+            var repositoryUrl = module.Assembly.CustomAttributes
+                .FirstOrDefault(e => e.AttributeType.Name == "AssemblyMetadataAttribute"
+                                     && e.ConstructorArguments.Count == 2
+                                     && e.ConstructorArguments[0].Value.Equals("RepositoryUrl"))?.ConstructorArguments[1].Value as string;
+
+            if (repositoryUrl == null)
+            {
+                throw new GeneralStrykerException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
+            }
+
+            const string schemeSeparator = "://";
+            var indexOfScheme = repositoryUrl.IndexOf(schemeSeparator, StringComparison.Ordinal);
+            if (indexOfScheme < 0)
+            {
+                throw new GeneralStrykerException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
+            }
+
+            return repositoryUrl.Substring(indexOfScheme + schemeSeparator.Length);
+        }
+
+        private static string ReadProjectVersion(ModuleDefinition module, string details)
+        {
+            var assemblyInformationalVersion = module.Assembly.CustomAttributes
+                .FirstOrDefault(e => e.AttributeType.Name == "AssemblyInformationalVersionAttribute"
+                                     && e.ConstructorArguments.Count == 1)?.ConstructorArguments[0].Value as string;
+
+            if (assemblyInformationalVersion == null)
+            {
+                throw new GeneralStrykerException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
+            }
+
+            return assemblyInformationalVersion;
         }
 
         public int InitialTest(IStrykerOptions options)

--- a/src/Stryker.Core/Stryker.Core/Options/IStrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/IStrykerOptions.cs
@@ -37,8 +37,8 @@ namespace Stryker.Core.Options
         bool DiffEnabled { get; }
         string GitDiffSource { get; }
         string ModuleName { get; }
-        string ProjectName { get; }
-        string ProjectVersion { get; }
+        string ProjectName { get; set; }
+        string ProjectVersion { get; set; }
         bool CompareToDashboard { get; }
         string FallbackVersion { get; }
         IEnumerable<FilePattern> DiffIgnoreFiles { get; }


### PR DESCRIPTION
Thanks to [SourceLink][1], the repository URL and the full version (including the git SHA1) of a project can be included in the produced assembly.

This commit uses the information computed by SourceLink to automatically retrieve the project name (github.com/organization/project) and project version which are required for the dashboard reporter.

With this technique, the table on the [Stryker dashboard documentation][2] can be updated with ✅ everywhere for the Stryker.NET column since it doesn't depend on a specific CI provider to provide the repository URL and version.

Note that I have run `Stryker.CLI --reporters ["progress","html","dashboard"]` on my local checkout of https://github.com/0xced/serilog-formatting-log4net/tree/20e86d55b4bd9e3682c3608530398e794df12481 and it automatically retrieved the project name (`github.com/0xced/serilog-formatting-log4net`) and project version (`1.0.0-rc.2+20e86d55b4bd9e3682c3608530398e794df12481`). The report was sucessfully uploaded to the [Stryker dashboard][3]

[1]: https://github.com/dotnet/sourcelink#readme
[2]: https://stryker-mutator.io/docs/General/dashboard/#retrieved-from-environment
[3]: https://dashboard.stryker-mutator.io/reports/github.com/0xced/serilog-formatting-log4net/1.0.0-rc.2%2B20e86d55b4bd9e3682c3608530398e794df12481
