### PR TITLE
Redundant csproj settings

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -3,15 +3,11 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
 
   <PropertyGroup>
     <xunit>2.4.1</xunit>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Compile Remove="TestResources\ExampleSourceFile.cs" />
   </ItemGroup>


### PR DESCRIPTION
VS often adds these settings when u change certain settings in the project properties. but they are the default and not required