### PR TITLE
fix(rollback): rollback mutation in expressions that cause build error(s)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/RollbackProcessTests.cs
@@ -7,8 +7,18 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
+using System.Reflection;
+using System.Text;
+using Buildalyzer;
 using Stryker.Core.Exceptions;
+using Stryker.Core.Initialisation;
+using Stryker.Core.InjectedHelpers;
+using Stryker.Core.Mutants;
+using Stryker.Core.MutationTest;
+using Stryker.Core.Mutators;
+using Stryker.Core.Options;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.Compiling
@@ -75,178 +85,248 @@ if(Environment.GetEnvironmentVariable(""ActiveMutation"") == ""1"") {
             }
         }
 
-        [Fact]
-        public void RollbackProcess_ShouldRollbackAllCompileErrors()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
-
-namespace ExampleProject
-{
-    public class Calculator
+    [Fact]
+    public void ShouldRollbackIssueInExpression()
     {
-        public string Subtract(string first, string second)
+               var syntaxTree = CSharpSyntaxTree.ParseText(@"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    namespace ExampleProject
+    {
+       public class Test
+       {
+           public void SomeLinq()
+           {
+               var list = new List<List<double>>();
+               int[] listProjected = list.Select(l => l.Count()).ToArray();
+           }   
+       }
+    }");
+       var mutator = new CsharpMutantOrchestrator(options: new StrykerOptions(mutationLevel: MutationLevel.Complete.ToString(), devMode:true));
+       var helpers = new List<SyntaxTree>();
+       foreach (var (name, code) in CodeInjection.MutantHelpers)
+       {
+           helpers.Add(CSharpSyntaxTree.ParseText(code, path: name, encoding: Encoding.UTF32));
+       }
+
+       var mutant = mutator.Mutate(syntaxTree.GetRoot());
+       helpers.Add(mutant.SyntaxTree);
+       var references = new List<PortableExecutableReference>() {
+               MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+               MetadataReference.CreateFromFile(typeof(List<string>).Assembly.Location),
+               MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+               MetadataReference.CreateFromFile(typeof(PipeStream).Assembly.Location),
+           };
+
+       Assembly.GetEntryAssembly().GetReferencedAssemblies().ToList().ForEach(a => references.Add(MetadataReference.CreateFromFile(Assembly.Load(a).Location)));
+
+       var input = new MutationTestInput()
+       {
+           ProjectInfo = new ProjectInfo()
+           {
+               ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(properties: new Dictionary<string, string>()
+                   {
+                       { "TargetDir", "" },
+                       { "AssemblyName", "AssemblyName"},
+                       { "TargetFileName", "TargetFileName.dll"},
+                       { "SignAssembly", "true" },
+                       { "AssemblyOriginatorKeyFile", Path.GetFullPath(Path.Combine("TestResources", "StrongNameKeyFile.snk")) }
+                   },
+                  projectFilePath: "TestResources").Object,
+               TestProjectAnalyzerResults = new List<IAnalyzerResult> { TestHelper.SetupProjectAnalyzerResult(properties: new Dictionary<string, string>()
+                   {
+                       { "AssemblyName", "AssemblyName"},
+                   }).Object
+               }
+           },
+           AssemblyReferences = references
+       };
+
+       var rollbackProcess = new RollbackProcess();
+
+       var target = new CompilingProcess(input, rollbackProcess);
+
+       using (var ms = new MemoryStream())
+       {
+           var result = target.Compile(helpers,  ms, null, true);
+           result.RollbackResult.RollbackedIds.Count().ShouldBe(1);
+       }
+    }
+
+    [Fact]
+    public void RollbackProcess_ShouldRollbackAllCompileErrors()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
+
+    namespace ExampleProject
+    {
+        public class Calculator
         {
-            if(Environment.GetEnvironmentVariable(""ActiveMutation"") == ""6"") {
-                while (first.Length > 2)
-                {
-                    return first - second;
-                } 
-                while (first.Length < 2)
-                {
-                    return second + first;
+            public string Subtract(string first, string second)
+            {
+                if(Environment.GetEnvironmentVariable(""ActiveMutation"") == ""6"") {
+                    while (first.Length > 2)
+                    {
+                        return first - second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return second + first;
+                    }
+                    return null;
+                } else {
+                    while (first.Length > 2)
+                    {
+                        return first + second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return (System.Environment.GetEnvironmentVariable(""ActiveMutation"") == ""7"" ? second - first : second + first);
+                    }
+                    return null;
                 }
-                return null;
-            } else {
-                while (first.Length > 2)
-                {
-                    return first + second;
-                } 
-                while (first.Length < 2)
-                {
-                    return (System.Environment.GetEnvironmentVariable(""ActiveMutation"") == ""7"" ? second - first : second + first);
-                }
-                return null;
             }
+        }
+    }");
+        var root = syntaxTree.GetRoot();
+
+        var mutantIf = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(
+            mutantIf,
+            mutantIf.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
+        );
+        var mutantCondition = root.DescendantNodes().First(x => x is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression is ConditionalExpressionSyntax);
+        root = root.ReplaceNode(
+            mutantCondition,
+            mutantCondition.WithAdditionalAnnotations(GetMutationMarker(7), _conditionalEngineMarker)
+        );
+
+        var annotatedSyntaxTree = root.SyntaxTree;
+
+        var compiler = CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: new List<PortableExecutableReference>() {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+            });
+
+        var target = new RollbackProcess();
+
+        using (var ms = new MemoryStream())
+        {
+            var compileResult = compiler.Emit(ms);
+
+            var fixedCompilation = target.Start(compiler, compileResult.Diagnostics,false, false);
+
+            var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+
+            rollbackedResult.Success.ShouldBeTrue();
+            fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 6, 7 });
         }
     }
-}");
-            var root = syntaxTree.GetRoot();
 
-            var mutantIf = root.DescendantNodes().OfType<IfStatementSyntax>().First();
-            root = root.ReplaceNode(
-                mutantIf,
-                mutantIf.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
-            );
-            var mutantCondition = root.DescendantNodes().First(x => x is ParenthesizedExpressionSyntax parenthesized && parenthesized.Expression is ConditionalExpressionSyntax);
-            root = root.ReplaceNode(
-                mutantCondition,
-                mutantCondition.WithAdditionalAnnotations(GetMutationMarker(7), _conditionalEngineMarker)
-            );
-
-            var annotatedSyntaxTree = root.SyntaxTree;
-
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
-                });
-
-            var target = new RollbackProcess();
-
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
-
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics,false, false);
-
-                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
-
-                rollbackedResult.Success.ShouldBeTrue();
-                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 6, 7 });
-            }
-        }
-
-        [Fact]
-        public void RollbackProcess_ShouldRollbackErrorsAndKeepTheRest()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
-
-namespace ExampleProject
-{
-    public class StringMagic
+    [Fact]
+    public void RollbackProcess_ShouldRollbackErrorsAndKeepTheRest()
     {
-        public string AddTwoStrings(string first, string second)
+        var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
+
+    namespace ExampleProject
+    {
+        public class StringMagic
         {
-            if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""8""){            
-                while (first.Length > 2)
-                {
-                    return first - second;
-                } 
-                while (first.Length < 2)
-                {
-                    return second + first;
-                }
-                return null;
-            }else{if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""7""){            
-                while (first.Length > 2)
-                {
-                    return first + second;
-                } 
-                while (first.Length < 2)
-                {
-                    return second - first;
-                }
-                return null;
-            }else{if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""6""){            
-                while (first.Length == 2)
-                {
-                    return first + second;
-                } 
-                while (first.Length < 2)
-                {
-                    return second + first;
-                }
-                return null;
-            }else{
-                while (first.Length == 2)
-                {
-                    return first + second;
-                } 
-                while (first.Length < 2)
-                {
-                    return second + first;
-                }
-                return null;
-            }}}
-        }
-    }
-}");
-            var root = syntaxTree.GetRoot();
-
-            var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
-            root = root.ReplaceNode(
-                mutantIf1,
-                mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
-            );
-            var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
-            root = root.ReplaceNode(
-                mutantIf2,
-                mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
-            );
-
-            var annotatedSyntaxTree = root.SyntaxTree;
-
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
-                });
-
-            var target = new RollbackProcess();
-
-            using (var ms = new MemoryStream())
+            public string AddTwoStrings(string first, string second)
             {
-                var compileResult = compiler.Emit(ms);
-
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
-
-                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
-
-                rollbackedResult.Success.ShouldBeTrue();
-                // validate that only mutation 8 and 7 were rollbacked
-                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+                if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""8""){            
+                    while (first.Length > 2)
+                    {
+                        return first - second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return second + first;
+                    }
+                    return null;
+                }else{if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""7""){            
+                    while (first.Length > 2)
+                    {
+                        return first + second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return second - first;
+                    }
+                    return null;
+                }else{if(System.Environment.GetEnvironmentVariable(""ActiveMutation"")==""6""){            
+                    while (first.Length == 2)
+                    {
+                        return first + second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return second + first;
+                    }
+                    return null;
+                }else{
+                    while (first.Length == 2)
+                    {
+                        return first + second;
+                    } 
+                    while (first.Length < 2)
+                    {
+                        return second + first;
+                    }
+                    return null;
+                }}}
             }
         }
+    }");
+    var root = syntaxTree.GetRoot();
+
+    var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+    root = root.ReplaceNode(
+        mutantIf1,
+        mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
+    );
+    var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+    root = root.ReplaceNode(
+        mutantIf2,
+        mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
+    );
+
+    var annotatedSyntaxTree = root.SyntaxTree;
+
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+        });
+
+    var target = new RollbackProcess();
+
+    using (var ms = new MemoryStream())
+    {
+        var compileResult = compiler.Emit(ms);
+
+        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
+
+        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+
+        rollbackedResult.Success.ShouldBeTrue();
+        // validate that only mutation 8 and 7 were rollbacked
+        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+    }
+}
 
 
-        [Fact]
-        public void RollbackProcess_ShouldRollbackMethodWhenLocalRollbackFails()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
+[Fact]
+public void RollbackProcess_ShouldRollbackMethodWhenLocalRollbackFails()
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
 
 namespace ExampleProject
 {
@@ -297,58 +377,58 @@ namespace ExampleProject
         }
     }
 }");
-            var root = syntaxTree.GetRoot();
+    var root = syntaxTree.GetRoot();
 
-            var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
-            root = root.ReplaceNode(
-                mutantIf1,
-                mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
-            );
-            var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
-            root = root.ReplaceNode(
-                mutantIf2,
-                mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
-            );
-            var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
-            root = root.ReplaceNode(
-                mutantIf3,
-                mutantIf3.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
-            );
-            var annotatedSyntaxTree = root.SyntaxTree;
+    var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+    root = root.ReplaceNode(
+        mutantIf1,
+        mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
+    );
+    var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+    root = root.ReplaceNode(
+        mutantIf2,
+        mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
+    );
+    var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
+    root = root.ReplaceNode(
+        mutantIf3,
+        mutantIf3.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
+    );
+    var annotatedSyntaxTree = root.SyntaxTree;
 
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
-                });
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+        });
 
-            var target = new RollbackProcess();
+    var target = new RollbackProcess();
 
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
+    using (var ms = new MemoryStream())
+    {
+        var compileResult = compiler.Emit(ms);
 
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
+        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
 
-                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
 
-                rollbackedResult.Success.ShouldBeFalse();
-                rollbackedResult.Diagnostics.ShouldHaveSingleItem();
+        rollbackedResult.Success.ShouldBeFalse();
+        rollbackedResult.Diagnostics.ShouldHaveSingleItem();
 
-                fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,false);
-                rollbackedResult = fixedCompilation.Compilation.Emit(ms);
-                rollbackedResult.Success.ShouldBeTrue();
-                // validate that only mutation 8 and 7 were rollbacked
-                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 ,6});
-            }
-        }
+        fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,false);
+        rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        rollbackedResult.Success.ShouldBeTrue();
+        // validate that only mutation 8 and 7 were rollbacked
+        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 ,6});
+    }
+}
 
-        [Fact]
-        public void RollbackProcess_ShouldRollbackAcessorWhenLocalRollbackFails()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
+[Fact]
+public void RollbackProcess_ShouldRollbackAcessorWhenLocalRollbackFails()
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
 
 namespace ExampleProject
 {
@@ -405,59 +485,59 @@ namespace ExampleProject
         }
     }
 }");
-            var root = syntaxTree.GetRoot();
+    var root = syntaxTree.GetRoot();
 
-            var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
-            root = root.ReplaceNode(
-                mutantIf1,
-                mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
-            );
-            var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
-            root = root.ReplaceNode(
-                mutantIf2,
-                mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
-            );
-            var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
-            root = root.ReplaceNode(
-                mutantIf3,
-                mutantIf3.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
-            );
-            var annotatedSyntaxTree = root.SyntaxTree;
+    var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+    root = root.ReplaceNode(
+        mutantIf1,
+        mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
+    );
+    var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+    root = root.ReplaceNode(
+        mutantIf2,
+        mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
+    );
+    var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
+    root = root.ReplaceNode(
+        mutantIf3,
+        mutantIf3.WithAdditionalAnnotations(GetMutationMarker(6), _ifEngineMarker)
+    );
+    var annotatedSyntaxTree = root.SyntaxTree;
 
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
-                });
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+        });
 
-            var target = new RollbackProcess();
+    var target = new RollbackProcess();
 
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
+    using (var ms = new MemoryStream())
+    {
+        var compileResult = compiler.Emit(ms);
 
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
+        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
 
-                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
                 
-                rollbackedResult.Success.ShouldBeFalse();
-                rollbackedResult.Diagnostics.ShouldHaveSingleItem();
+        rollbackedResult.Success.ShouldBeFalse();
+        rollbackedResult.Diagnostics.ShouldHaveSingleItem();
 
-                fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,false);
-                rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,false);
+        rollbackedResult = fixedCompilation.Compilation.Emit(ms);
 
-                rollbackedResult.Success.ShouldBeTrue();
-                // validate that only mutation 8 and 7 were rollbacked
-                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 ,6});
-            }
-        }
+        rollbackedResult.Success.ShouldBeTrue();
+        // validate that only mutation 8 and 7 were rollbacked
+        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 ,6});
+    }
+}
 
-        [Fact]
-        public void RollbackProcess_ShouldFailWhenLocalRollbackFailsAndInDevMode()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
+[Fact]
+public void RollbackProcess_ShouldFailWhenLocalRollbackFailsAndInDevMode()
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
 
 namespace ExampleProject
 {
@@ -508,52 +588,52 @@ namespace ExampleProject
         }
     }
 }");
-            var root = syntaxTree.GetRoot();
+    var root = syntaxTree.GetRoot();
 
-            var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
-            root = root.ReplaceNode(
-                mutantIf1,
-                mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
-            );
-            var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
-            root = root.ReplaceNode(
-                mutantIf2,
-                mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
-            );
-            var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
-            root = root.ReplaceNode(
-                mutantIf3,
-                mutantIf3.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
-            );
-            var annotatedSyntaxTree = root.SyntaxTree;
+    var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+    root = root.ReplaceNode(
+        mutantIf1,
+        mutantIf1.WithAdditionalAnnotations(GetMutationMarker(8), _ifEngineMarker)
+    );
+    var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+    root = root.ReplaceNode(
+        mutantIf2,
+        mutantIf2.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
+    );
+    var mutantIf3 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[2];
+    root = root.ReplaceNode(
+        mutantIf3,
+        mutantIf3.WithAdditionalAnnotations(GetMutationMarker(7), _ifEngineMarker)
+    );
+    var annotatedSyntaxTree = root.SyntaxTree;
 
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
-                });
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+        });
 
-            var target = new RollbackProcess();
+    var target = new RollbackProcess();
 
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
+    using (var ms = new MemoryStream())
+    {
+        var compileResult = compiler.Emit(ms);
+        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
 
-                var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
                 
-                rollbackedResult.Success.ShouldBeFalse();
-                rollbackedResult.Diagnostics.ShouldHaveSingleItem();
-                Should.Throw<StrykerCompilationException>(() => {target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,true);});
-            }
-        }
+        rollbackedResult.Success.ShouldBeFalse();
+        rollbackedResult.Diagnostics.ShouldHaveSingleItem();
+        Should.Throw<StrykerCompilationException>(() => {target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, false,true);});
+    }
+}
 
-        [Fact]
-        public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhenUriIsEmpty()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"
+[Fact]
+public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompileWhenUriIsEmpty()
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(@"
 using System;
 
 namespace ExampleProject
@@ -575,46 +655,46 @@ namespace ExampleProject
         }
     }
 }");
-            var ifStatement = syntaxTree
-                .GetRoot()
-                .DescendantNodes()
-                .First(x => x is IfStatementSyntax);
-            var annotatedSyntaxTree = syntaxTree.GetRoot()
-                .ReplaceNode(
-                    ifStatement, 
-                    ifStatement.WithAdditionalAnnotations(GetMutationMarker(1), _ifEngineMarker)
-                ).SyntaxTree;
+    var ifStatement = syntaxTree
+        .GetRoot()
+        .DescendantNodes()
+        .First(x => x is IfStatementSyntax);
+    var annotatedSyntaxTree = syntaxTree.GetRoot()
+        .ReplaceNode(
+            ifStatement, 
+            ifStatement.WithAdditionalAnnotations(GetMutationMarker(1), _ifEngineMarker)
+        ).SyntaxTree;
 
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location),
-                });
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location),
+        });
 
-            var target = new RollbackProcess();
+    var target = new RollbackProcess();
 
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
+    using (var ms = new MemoryStream())
+    {
+        var fixedCompilation = target.Start(compiler, compiler.Emit(ms).Diagnostics, false,false);
 
-                var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, false,false);
+        fixedCompilation.Compilation.Emit(ms).Success.ShouldBeTrue();
                 
                 var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
 
                 rollbackedResult.Success.ShouldBeTrue();
                 
-                // validate that only one of the compile errors marked the mutation as rollbacked.
-                fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 1 });
-            }
-        }
+        // validate that only one of the compile errors marked the mutation as rollbacked.
+        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 1 });
+    }
+}
 
-        [Fact]
-        public void RollbackProcess_ShouldOnlyRaiseExceptionOnFinalAttempt()
-        {
-            var syntaxTree = CSharpSyntaxTree.ParseText(@"
+[Fact]
+public void RollbackProcess_ShouldOnlyRaiseExceptionOnFinalAttempt()
+{
+    var syntaxTree = CSharpSyntaxTree.ParseText(@"
 using System;
 
 namespace ExampleProject
@@ -627,24 +707,24 @@ namespace ExampleProject
     }
 }");
 
-            var compiler = CSharpCompilation.Create("TestCompilation",
-                syntaxTrees: new Collection<SyntaxTree>() { syntaxTree },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                references: new List<PortableExecutableReference>() {
-                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location),
-                    MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location),
-                });
+    var compiler = CSharpCompilation.Create("TestCompilation",
+        syntaxTrees: new Collection<SyntaxTree>() { syntaxTree },
+        options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+        references: new List<PortableExecutableReference>() {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Uri).Assembly.Location),
+        });
 
-            var target = new RollbackProcess();
+    var target = new RollbackProcess();
 
-            using (var ms = new MemoryStream())
-            {
-                var compileResult = compiler.Emit(ms);
+    using (var ms = new MemoryStream())
+    {
+        var compileResult = compiler.Emit(ms);
 
-                Should.NotThrow(() => target.Start(compiler, compileResult.Diagnostics, false, false));
-                Should.Throw<StrykerCompilationException>(() => target.Start(compiler, compileResult.Diagnostics, true, false));
-            }
-        }
+        Should.NotThrow(() => target.Start(compiler, compileResult.Diagnostics, false, false));
+        Should.Throw<StrykerCompilationException>(() => target.Start(compiler, compileResult.Diagnostics, true, false));
+    }
+}
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTests.cs
@@ -930,6 +930,19 @@ static TestClass(){using(new StrykerNamespace.MutantContext()){}}}";
         }
 
         [Fact]
+        public void ShouldMarkStaticMutationStarticInPropertiesInitializer()
+        {
+            var source = @"class Test {
+static string Value {get;} = """";}";
+
+            var expected = @"class Test {
+static string Value {get;} = (StrykerNamespace.MutantControl.IsActive(0)?""Stryker was here!"":"""");}";
+            ShouldMutateSourceToExpected(source, expected);
+            _target.Mutants.Count.ShouldBe(1);
+            _target.Mutants.First().IsStaticValue.ShouldBeTrue();
+        }
+
+        [Fact]
         public void ShouldMutatePropertiesAsArrowExpression()
         {
             var source = @"class Test {

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -35,6 +35,8 @@ namespace Stryker.Core.Helpers
             };
         }
 
+        public static bool IsStatic(this MemberDeclarationSyntax node) => node.Modifiers.Any(x => x.Kind() == SyntaxKind.StaticKeyword);
+
         public static bool NeedsReturn(this AccessorDeclarationSyntax baseMethod)
         {
             return baseMethod.Keyword.Text switch

--- a/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/PropertyDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/NodeOrchestrators/PropertyDeclarationOrchestrator.cs
@@ -13,6 +13,17 @@ namespace Stryker.Core.Mutants.NodeOrchestrators
         {
         }
 
+        protected override BasePropertyDeclarationSyntax OrchestrateChildrenMutation(PropertyDeclarationSyntax node, MutationContext context)
+        {
+            if (!node.IsStatic())
+            {
+                return base.OrchestrateChildrenMutation(node, context);
+            }
+
+            return node.ReplaceNodes(node.ChildNodes(), (original, _) =>
+                MutantOrchestrator.Mutate(original, original == node.Initializer ? context.EnterStatic() : context));
+        }
+
         protected override BasePropertyDeclarationSyntax InjectMutations(PropertyDeclarationSyntax sourceNode,
             BasePropertyDeclarationSyntax targetNode, MutationContext context)
         {


### PR DESCRIPTION
Stryker now search for mutation within an expression that triggers an error whenever the original search method fails (mutation encompassing the faulty code).
Fixes #1533 and other SAFE mode errors.