### PR TITLE
Feature: Added --filter option to VsTestConsoleWrapper

### DIFF
--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -11,7 +11,6 @@ using Stryker.Core.MutantFilters;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
-using Stryker.Core.Reporters;
 
 namespace Stryker.Core.MutationTest
 {
@@ -84,9 +83,9 @@ namespace Stryker.Core.MutationTest
                 }
                 if (_fileSystem.File.Exists(injectionPath))
                 {
-                    _fileSystem.File.Move(injectionPath, injectionPath + ".stryker-unchanged");
+                    _fileSystem.File.Move(injectionPath, injectionPath + ".stryker-unchanged", overwrite: true);
                 }
-                
+
                 // inject the mutated Assembly into the test project
                 using var fs = _fileSystem.File.Create(injectionPath);
                 ms.Position = 0;

--- a/src/Stryker.Core/Stryker.Core/Options/IStrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/IStrykerOptions.cs
@@ -1,11 +1,11 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.Baseline.Providers;
 using Stryker.Core.Logging;
 using Stryker.Core.Mutators;
 using Stryker.Core.Reporters;
 using Stryker.Core.TestRunners;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace Stryker.Core.Options
 {
@@ -44,5 +44,11 @@ namespace Stryker.Core.Options
         IEnumerable<FilePattern> DiffIgnoreFiles { get; }
         string DashboardUrl { get; }
         string DashboardApiKey { get; }
+
+        /// <summary>
+        /// Filter expression to run selective tests.
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests">See here.</see>
+        /// </summary>
+        string TestCaseFilter { get; }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -63,6 +63,13 @@ namespace Stryker.Core.Options
 
         public string FallbackVersion { get; }
 
+        /// <summary>
+        /// DUMMY IMPLEMENTATION.
+        /// DO NOT MERGE TO MASTER.
+        /// MUST BE REPLACED WITH A PROPER HANDLING OF OPTIONS.
+        /// </summary>
+        public string TestCaseFilter => "Category=unit";
+
         private const string ErrorMessage = "The value for one of your settings is not correct. Try correcting or removing them.";
         private readonly IFileSystem _fileSystem;
         private readonly ILogger _logger;

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -100,8 +100,11 @@ namespace Stryker.Core
                 // Test
                 foreach (var project in _mutationTestProcesses)
                 {
-                    project.Test(project.Input.ProjectInfo.ProjectContents.Mutants.Where(x => x.ResultStatus == MutantStatus.NotRun).ToList());
-                    project.Input.ProjectInfo.RestoreOrginalAssembly();      
+                    var mutantsToTest = project.Input.ProjectInfo.ProjectContents.Mutants
+                        .Where(x => x.ResultStatus == MutantStatus.NotRun)
+                        .ToList();
+                    project.Test(mutantsToTest);
+                    project.Input.ProjectInfo.RestoreOrginalAssembly();
                 }
 
                 reporters.OnAllMutantsTested(readOnlyInputComponent);

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -409,6 +409,9 @@ namespace Stryker.Core.TestRunners.VsTest
                 settingsForCoverage += "<DisableParallelization>true</DisableParallelization>";
             }
             var timeoutSettings = timeout.HasValue ? $"<TestSessionTimeout>{timeout}</TestSessionTimeout>" + Environment.NewLine : string.Empty;
+            var testCaseFilter = string.IsNullOrWhiteSpace(_options.TestCaseFilter) ?
+                string.Empty : $"<TestCaseFilter>{_options.TestCaseFilter}</TestCaseFilter>" + Environment.NewLine;
+
             // we need to block parallel run to capture coverage and when testing multiple mutants in a single run
             var optionsConcurrentTestrunners = (forCoverage || !_options.Optimizations.HasFlag(OptimizationFlags.DisableTestMix)) ? 1 : _options.ConcurrentTestrunners;
             var runSettings =
@@ -420,6 +423,7 @@ $@"<RunSettings>
 {settingsForCoverage}
 <DesignMode>false</DesignMode>
 <BatchSize>1</BatchSize>
+{testCaseFilter}
  </RunConfiguration>
 {dataCollectorSettings}
 </RunSettings>";

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Serilog.Events;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
@@ -118,7 +119,13 @@ namespace Stryker.Core.TestRunners.VsTest
                         mutantTestsMap.Add(mutant.Id, tests);
                     }
 
-                    testCases = needAll ? null : mutants.SelectMany(m => m.CoveringTests.GetList()).Distinct().Select(t => _discoveredTests.First(tc => tc.Id.ToString() == t.Guid)).ToList();
+                    testCases = needAll ?
+                        null :
+                        mutants
+                            .SelectMany(m => m.CoveringTests.GetList())
+                            .Distinct()
+                            .Select(t => _discoveredTests.First(tc => tc.Id.ToString() == t.Guid))
+                            .ToList();
 
                     _logger.LogTrace($"{RunnerId}: Testing [{string.Join(',', mutants.Select(m => m.DisplayName))}] " +
                                       $"against {(testCases == null ? "all tests." : string.Join(", ", testCases.Select(x => x.FullyQualifiedName)))}.");
@@ -345,7 +352,8 @@ namespace Stryker.Core.TestRunners.VsTest
             }
             else
             {
-                _vsTestConsole.RunTestsWithCustomTestHost(_sources, runSettings, eventHandler, strykerVsTestHostLauncher);
+                var options = new TestPlatformOptions { TestCaseFilter = _options.TestCaseFilter };
+                _vsTestConsole.RunTestsWithCustomTestHost(_sources, runSettings, options, eventHandler, strykerVsTestHostLauncher);
             }
 
             // Test host exited signal comes after the run completed


### PR DESCRIPTION
This PR is a work in progress.

Contributes to #420.

This PR depends on #1542 and #1273 which will need both to be merged first. Then this PR should be updated before ready for final review. It replaces #1550 by branching off v1.0 for an easier review of the changes.

### Progress
- [ ] user passes filter to stryker as an option according to new standard: #1273 (wait for the PR to be merged). In the meantime, I hardcoded a dummy test case fitler as `Category=unit` to fit my use case.
- [X] filter gets used to filter the discovered tests in the initial testrun
- [X] filter gets used to filter the executed tests during coverage analysis (all modes), this effectively filters the used tests
- [ ] if coverage analysis is turned off, the filter still needs to be applied because coverage analysis did not perform the filtering for us

### Comments
Your feedback is welcome. I have made other unrelated, opinionated changes that I would gladly reverse if they don't fit here: 
- allowed overwriting `.stryker-unchanged` file when moving it. The file is created when running stryker-cli but not removed if the CLI crashes, preventing the next run of the CLI if overwriting is not allowed.
- line returns on Linq expressions for better readability

VsTestConsole behavior around `TestCaseFilter` option is... strange. Passing in a `new TestPlatformOptions { TestCaseFilter = _options.TestCaseFilter }` argument to vsTestConsole when discovering tests has no effect. We must pass the option as a runsettings XML configuration, as suggested by @rouke-broersma. But the runsettings XML config has no effect when running the tests, we must then use the `TestPlatformOptions`.

Please find attached the logs (trace level) of a run of Stryker in a very small test project (2 tests, with a different category, a single test matches the Category=unit option). 
[logs.zip](https://github.com/stryker-mutator/stryker-net/files/6447293/logs.zip)

### What's Next

Where do you suggest we write tests for that option? Should we wait for #1273 to be complete first?
Are there cases I forgot to cover? I only ran stryker on my limited test project, on xUnit.

Thank you!

