### PR TITLE
Allow ignoring mutants of qualified method names

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -293,8 +293,8 @@ dotnet stryker -m "['MyFolder/MyService.cs{10..100}']"
 If you would like to ignore some mutations that are passed as method parameters, you can do so by specifying which methods to ignore:
 
 ```
-dotnet stryker --ignore-methods "['ToString', 'ConfigureAwait', '*Exception.ctor']"
-dotnet stryker -im "['ToString', 'ConfigureAwait', '*Exception.ctor']"
+dotnet stryker --ignore-methods "['ToString', 'ConfigureAwait', '*Exception.ctor', 'Console.Write*']"
+dotnet stryker -im "['ToString', 'ConfigureAwait', '*Exception.ctor', 'Console.Write*']"
 ```
 
 Ignore methods will only affect mutations in directly passed parameters.
@@ -318,6 +318,10 @@ Both, method names and constructor names, support wildcards.
 dotnet stryker -im "['*Log']" // Ignores all methods ending with Log
 dotnet stryker -im "['*Exception.ctor']" // Ignores all exception constructors
 ```
+
+You can also qualify method names.
+
+`dotnet stryker -im "['Console.Write']" // Ignores Console.Write, but not Stream.Write`
 
 Default: `[]`
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -102,7 +102,7 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
 {
     private void TestMethod()
     {
-        var t = Enumerable.Range(0, 9)?.Select(x => x)?.Where(x => x < 5).ToList();
+        var t = Enumerable.Range(0, 9)?.Where(x => x < 5).ToList();
     }
 }";
             var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
@@ -207,7 +207,7 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
     }
 }";
             var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
-            var originalNode = baseSyntaxTree.FindNode(new TextSpan(source.IndexOf('D'), 1));
+            var originalNode = baseSyntaxTree.FindNode(new TextSpan(source.IndexOf("Dispose"), 1));
 
             var mutant = new Mutant
             {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
@@ -296,5 +296,19 @@ namespace Stryker.Core.UnitTest.Options
 
             target.DiffEnabled.ShouldBeTrue();
         }
+
+        [Theory]
+        [InlineData("Foo", @"^(?:[^.]*\.)*Foo$")]
+        [InlineData("Foo*", @"^(?:[^.]*\.)*Foo[^.]*$")]
+        [InlineData("Bar.Foo", @"^(?:[^.]*\.)*Bar\.Foo$")]
+        [InlineData("B*r.Foo", @"^(?:[^.]*\.)*B[^.]*r\.Foo$")]
+        [InlineData("*.Foo", @"^(?:[^.]*\.)*[^.]*\.Foo$")]
+        [InlineData("Bar.*", @"^(?:[^.]*\.)*Bar\.[^.]*$")]
+        [InlineData("Quux.Bar.Foo", @"^(?:[^.]*\.)*Quux\.Bar\.Foo$")]
+        public void Should_Validate_Ignored_Methods(string methodPattern, string regex)
+        {
+            var target = new StrykerOptions(ignoredMethods: new[] { methodPattern });
+            target.IgnoredMethods.Single().ToString().ShouldBe(regex);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
@@ -12,9 +13,10 @@ namespace Stryker.Core.MutantFilters
     /// Checks if the mutants are part of ignored method calls.
     /// </summary>
     /// <seealso cref="IMutantFilter" />
-    public class IgnoredMethodMutantFilter : IMutantFilter
+    public sealed class IgnoredMethodMutantFilter : IMutantFilter
     {
         public string DisplayName => "method filter";
+        private readonly SyntaxTriviaRemover _triviaRemover = new SyntaxTriviaRemover();
 
         public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, ReadOnlyFileLeaf file, IStrykerOptions options)
         {
@@ -26,35 +28,22 @@ namespace Stryker.Core.MutantFilters
             return mutants.Where(m => !IsPartOfIgnoredMethodCall(m.Mutation.OriginalNode, options));
         }
 
-        private bool IsPartOfIgnoredMethodCall(SyntaxNode syntaxNode, IStrykerOptions options)
-        {
-            switch (syntaxNode)
+        private bool IsPartOfIgnoredMethodCall(SyntaxNode syntaxNode, IStrykerOptions options) =>
+            syntaxNode switch
             {
-                // Check if the current node is an invocation and the expression is a member
+                // Check if the current node is an invocation
                 // This will also ignore invokable properties like `Func<bool> MyProp { get;}`
-                case InvocationExpressionSyntax invocation when invocation.Expression is MemberAccessExpressionSyntax member:
-                    return options.IgnoredMethods.Any(r => r.IsMatch(member.Name.ToString()));
-                // Check when conditional access
-                case InvocationExpressionSyntax invocation when invocation.Expression is MemberBindingExpressionSyntax member:
-                    return options.IgnoredMethods.Any(r => r.IsMatch(member.Name.ToString()));
-                // Check when direct identifier
-                case InvocationExpressionSyntax invocation when invocation.Expression is IdentifierNameSyntax member:
-                    return options.IgnoredMethods.Any(r => r.IsMatch(member.ToString()));
-                // Check if the current node is an object creation syntax (constructor invocation).
-                case ObjectCreationExpressionSyntax creation:
-                {
-                    var methodName = creation.Type + ".ctor";
-                    return options.IgnoredMethods.Any(r => r.IsMatch(methodName));
-                }
-            }
+                InvocationExpressionSyntax invocation => MatchesAnIgnoredMethod(_triviaRemover.Visit(invocation.Expression).ToString(), options),
+                ObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(_triviaRemover.Visit(creation.Type) + ".ctor", options),
+                SyntaxNode node when node.Parent != null => IsPartOfIgnoredMethodCall(syntaxNode.Parent, options),
+                _ => false,
+            };
 
-            // Traverse the tree upwards
-            if (syntaxNode.Parent != null)
-            {
-                return IsPartOfIgnoredMethodCall(syntaxNode.Parent, options);
-            }
+        private static bool MatchesAnIgnoredMethod(string expressionString, IStrykerOptions options) => options.IgnoredMethods.Any(r => r.IsMatch(expressionString));
 
-            return false;
+        private sealed class SyntaxTriviaRemover : CSharpSyntaxRewriter
+        {
+            public override SyntaxTrivia VisitTrivia(SyntaxTrivia trivia) => default;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
@@ -18,29 +18,30 @@ namespace Stryker.Core.MutantFilters
         public string DisplayName => "method filter";
         private readonly SyntaxTriviaRemover _triviaRemover = new SyntaxTriviaRemover();
 
-        public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, ReadOnlyFileLeaf file, IStrykerOptions options)
-        {
-            if (!options.IgnoredMethods.Any())
-            {
-                return mutants;
-            }
-
-            return mutants.Where(m => !IsPartOfIgnoredMethodCall(m.Mutation.OriginalNode, options));
-        }
+        public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, ReadOnlyFileLeaf file, IStrykerOptions options) =>
+            options.IgnoredMethods.Any() ?
+                    mutants.Where(m => !IsPartOfIgnoredMethodCall(m.Mutation.OriginalNode, options)) :
+                    mutants;
 
         private bool IsPartOfIgnoredMethodCall(SyntaxNode syntaxNode, IStrykerOptions options) =>
             syntaxNode switch
             {
-                // Check if the current node is an invocation
-                // This will also ignore invokable properties like `Func<bool> MyProp { get;}`
+                // Check if the current node is an invocation. This will also ignore invokable properties like `Func<bool> MyProp { get;}`
                 InvocationExpressionSyntax invocation => MatchesAnIgnoredMethod(_triviaRemover.Visit(invocation.Expression).ToString(), options),
+
+                // Check if the current node is an object creation syntax (constructor invocation).
                 ObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(_triviaRemover.Visit(creation.Type) + ".ctor", options),
+
+                // Traverse the tree upwards.
                 SyntaxNode node when node.Parent != null => IsPartOfIgnoredMethodCall(syntaxNode.Parent, options),
                 _ => false,
             };
 
         private static bool MatchesAnIgnoredMethod(string expressionString, IStrykerOptions options) => options.IgnoredMethods.Any(r => r.IsMatch(expressionString));
 
+        /// <summary>
+        /// Removes comments, whitespace, and other junk from a syntax tree.
+        /// </summary>
         private sealed class SyntaxTriviaRemover : CSharpSyntaxRewriter
         {
             public override SyntaxTrivia VisitTrivia(SyntaxTrivia trivia) => default;

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -388,6 +388,11 @@ namespace Stryker.Core.Options
             return mappedDiffIgnoreFiles;
         }
 
+        /// <summary>
+        /// This method returns regexes that are equivalent to the provided method patterns.
+        /// In a method pattern the wildcard ('*') matches zero-or-more characters that are not periods ('.').
+        /// The regexes check from either the beginning of a method name or immediately after a period ('.'), whether the rest of the method name matches the method pattern.
+        /// </summary>
         private static IEnumerable<Regex> ValidateIgnoredMethods(IEnumerable<string> methodPatterns) =>
             methodPatterns
                 .Where(x => !string.IsNullOrEmpty(x))

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -388,13 +388,11 @@ namespace Stryker.Core.Options
             return mappedDiffIgnoreFiles;
         }
 
-        private static IEnumerable<Regex> ValidateIgnoredMethods(IEnumerable<string> methodPatterns)
-        {
-            foreach (var methodPattern in methodPatterns.Where(x => !string.IsNullOrEmpty(x)))
-            {
-                yield return new Regex("^" + Regex.Escape(methodPattern).Replace("\\*", ".*") + "$", RegexOptions.IgnoreCase);
-            }
-        }
+        private static IEnumerable<Regex> ValidateIgnoredMethods(IEnumerable<string> methodPatterns) =>
+            methodPatterns
+                .Where(x => !string.IsNullOrEmpty(x))
+                .Select(methodPattern => new Regex("^([^.]*\\.)*" + Regex.Escape(methodPattern).Replace("\\*", "[^.]*") + "$", RegexOptions.IgnoreCase))
+                .ToList();
 
         private OptimizationFlags ValidateMode(string mode)
         {

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -391,7 +391,7 @@ namespace Stryker.Core.Options
         private static IEnumerable<Regex> ValidateIgnoredMethods(IEnumerable<string> methodPatterns) =>
             methodPatterns
                 .Where(x => !string.IsNullOrEmpty(x))
-                .Select(methodPattern => new Regex("^([^.]*\\.)*" + Regex.Escape(methodPattern).Replace("\\*", "[^.]*") + "$", RegexOptions.IgnoreCase))
+                .Select(methodPattern => new Regex("^(?:[^.]*\\.)*" + Regex.Escape(methodPattern).Replace("\\*", "[^.]*") + "$", RegexOptions.IgnoreCase))
                 .ToList();
 
         private OptimizationFlags ValidateMode(string mode)


### PR DESCRIPTION
Existing filters work as before: they only match against the method name. For example, the filter `Foo*` does not match the expression `Foo.Bar()`. However, a filter like `Foo.*`, `Bar`, or `Foo.Bar` will match that expression. Ignores comments and whitespace inside of the expression. Works for constructors too!

Resolves #1630
