### PR TITLE
Update documentation to include wrapping quotes

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -387,8 +387,8 @@ This feature is only recommended when you are sure these files will not affect r
 Use [globbing syntax](https://en.wikipedia.org/wiki/Glob_(programming)) for wildcards. Example: ['**/*Assets.json','**/favicon.ico']
 
 ```
-dotnet stryker --diff-ignore-files ['**/*.ts']
-dotnet stryker -diff-ignore-files ['**/*.ts']
+dotnet stryker --diff-ignore-files "['**/*.ts']"
+dotnet stryker -diff-ignore-files "['**/*.ts']"
 ```
 
 Default: `[]`


### PR DESCRIPTION
I was going through the docs and couldn't run the command as is, so I updated it to match some of the other commands that pass in an array and thought I'd propose the change.

Thanks again for stryker!