### PR TITLE
feat(dashboard reporter): Retrieve the project name and version from the project under test using source link

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -61,7 +61,7 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var options = new StrykerOptions();
 
-            var result = target.Initialize(options);
+            var result = target.Initialize(options, dashboardReporter: null);
 
             inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);
         }
@@ -106,7 +106,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 assemblyReferenceResolverMock.Object);
             var options = new StrykerOptions();
 
-            target.Initialize(options);
+            target.Initialize(options, dashboardReporter: null);
             Assert.Throws<InputException>(() => target.InitialTest(options));
 
             inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -51,7 +51,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var options = new StrykerOptions();
             var target = new ProjectMutator(_initialisationProcessProviderMock.Object, _mutationTestProcessProviderMock.Object);
 
-            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>())).Returns(_mutationTestInput);
+            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>(), It.IsAny<DashboardReporter>())).Returns(_mutationTestInput);
             _initialisationProcessMock.Setup(x => x.InitialTest(options))
                 .Returns(new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(500)));
             // act

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
@@ -63,7 +63,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
             var target = new ProjectOrchestrator(_buildalyzerProviderMock.Object, _projectMutatorMock.Object);
 
-            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>())).Returns(_mutationTestInput);
+            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>(), It.IsAny<DashboardReporter>())).Returns(_mutationTestInput);
             _initialisationProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>())).Returns(new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(5)));
             _buildalyzerProviderMock.Setup(x => x.Provide(It.IsAny<string>(), It.IsAny<AnalyzerManagerOptions>())).Returns(buildalyzerAnalyzerManagerMock.Object);
             // The analyzer finds two projects

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ProjectNameInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ProjectNameInputTests.cs
@@ -21,32 +21,17 @@ For example: Your project might be called 'consumer-loans' and it might contains
         {
             var input = new ProjectNameInput { SuppliedInput = "name" };
 
-            var result = input.Validate(new[] { Reporter.Dashboard });
+            var result = input.Validate();
 
             result.ShouldBe("name");
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void ShouldThrowOnEmptyValue(string value)
-        {
-            var input = new ProjectNameInput { SuppliedInput = value };
-
-            var exception = Should.Throw<InputException>(() =>
-            {
-                input.Validate(new[] { Reporter.Dashboard });
-            });
-
-            exception.Message.ShouldBe("When the stryker dashboard is enabled the project name is required.");
         }
 
         [Fact]
         public void ShouldHaveDefault()
         {
             var input = new ProjectNameInput { SuppliedInput = null };
-            
-            var result = input.Validate(new Reporter[] { });
+
+            var result = input.Validate();
 
             result.ShouldBe(string.Empty);
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ProjectVersionInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ProjectVersionInputTests.cs
@@ -16,21 +16,6 @@ namespace Stryker.Core.UnitTest.Options.Inputs
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void ProjectVersionCannotBeEmpty(string value)
-        {
-            var input = new ProjectVersionInput { };
-            input.SuppliedInput = value;
-
-            var exception = Should.Throw<InputException>(() => {
-                input.Validate(null, reporters: new[] { Reporter.Dashboard }, true);
-            });
-
-            exception.Message.ShouldBe("When the stryker dashboard is enabled the project version is required. Please provide a project version.");
-        }
-
-        [Theory]
         [InlineData("test")]
         [InlineData("myversion")]
         public void ProjectVersionCannotBeFallbackVersion(string value)

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -12,6 +12,7 @@ namespace Stryker.Core.Clients
 {
     public interface IDashboardClient
     {
+        string ProjectName { get; set; }
         Task<string> PublishReport(string json, string version);
         Task<JsonReport> PullReport(string version);
     }
@@ -27,11 +28,14 @@ namespace Stryker.Core.Clients
             _options = options;
             _logger = logger ?? ApplicationLogging.LoggerFactory.CreateLogger<DashboardClient>();
             _httpClient = httpClient ?? new HttpClient();
+            ProjectName = _options.ProjectName;
         }
+
+        public string ProjectName { get; set; }
 
         public async Task<string> PublishReport(string json, string version)
         {
-            var url = new Uri($"{_options.DashboardUrl}/api/reports/{_options.ProjectName}/{version}");
+            var url = new Uri($"{_options.DashboardUrl}/api/reports/{ProjectName}/{version}");
 
             if (_options.ModuleName != null)
             {
@@ -65,7 +69,7 @@ namespace Stryker.Core.Clients
 
         public async Task<JsonReport> PullReport(string version)
         {
-            var url = new Uri($"{_options.DashboardUrl}/api/reports/{_options.ProjectName}/{version}");
+            var url = new Uri($"{_options.DashboardUrl}/api/reports/{ProjectName}/{version}");
 
             if (_options.ModuleName != null)
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -120,7 +120,7 @@ namespace Stryker.Core.Initialisation
 
                 if (!projectInfo.ProjectUnderTestAnalyzerResult.Properties.TryGetValue("TargetPath", out var targetPath))
                 {
-                    throw new StrykerInputException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
+                    throw new InputException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
                 }
 
                 _logger.LogTrace("{Subject} missing for the dashboard reporter, reading it from {TargetPath}. " +
@@ -144,9 +144,9 @@ namespace Stryker.Core.Initialisation
                         _logger.LogDebug("Using {ProjectVersion} as project version for the dashboard reporter. (Read from the AssemblyInformationalVersion assembly attribute of {TargetName})", dashboardReporter.ProjectVersion, targetName);
                     }
                 }
-                catch (Exception e) when (e is not StrykerInputException)
+                catch (Exception e) when (e is not InputException)
                 {
-                    throw new StrykerInputException($"Failed to read {subject.ToLowerInvariant()} from {targetPath}", e);
+                    throw new InputException($"Failed to read {subject.ToLowerInvariant()} from {targetPath} because of error {e.Message}");
                 }
             }
         }
@@ -160,14 +160,14 @@ namespace Stryker.Core.Initialisation
 
             if (repositoryUrl == null)
             {
-                throw new StrykerInputException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
+                throw new InputException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
             }
 
             const string schemeSeparator = "://";
             var indexOfScheme = repositoryUrl.IndexOf(schemeSeparator, StringComparison.Ordinal);
             if (indexOfScheme < 0)
             {
-                throw new StrykerInputException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
+                throw new InputException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
             }
 
             return repositoryUrl.Substring(indexOfScheme + schemeSeparator.Length);
@@ -181,7 +181,7 @@ namespace Stryker.Core.Initialisation
 
             if (assemblyInformationalVersion == null)
             {
-                throw new StrykerInputException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
+                throw new InputException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
             }
 
             return assemblyInformationalVersion;

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -120,7 +120,7 @@ namespace Stryker.Core.Initialisation
 
                 if (!projectInfo.ProjectUnderTestAnalyzerResult.Properties.TryGetValue("TargetPath", out var targetPath))
                 {
-                    throw new GeneralStrykerException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
+                    throw new StrykerInputException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
                 }
 
                 _logger.LogTrace("{Subject} missing for the dashboard reporter, reading it from {TargetPath}. " +
@@ -144,9 +144,9 @@ namespace Stryker.Core.Initialisation
                         _logger.LogDebug("Using {ProjectVersion} as project version for the dashboard reporter. (Read from the AssemblyInformationalVersion assembly attribute of {TargetName})", dashboardReporter.ProjectVersion, targetName);
                     }
                 }
-                catch (Exception e) when (e is not GeneralStrykerException)
+                catch (Exception e) when (e is not StrykerInputException)
                 {
-                    throw new GeneralStrykerException($"Failed to read {subject.ToLowerInvariant()} from {targetPath}", e);
+                    throw new StrykerInputException($"Failed to read {subject.ToLowerInvariant()} from {targetPath}", e);
                 }
             }
         }
@@ -160,14 +160,14 @@ namespace Stryker.Core.Initialisation
 
             if (repositoryUrl == null)
             {
-                throw new GeneralStrykerException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
+                throw new StrykerInputException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
             }
 
             const string schemeSeparator = "://";
             var indexOfScheme = repositoryUrl.IndexOf(schemeSeparator, StringComparison.Ordinal);
             if (indexOfScheme < 0)
             {
-                throw new GeneralStrykerException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
+                throw new StrykerInputException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
             }
 
             return repositoryUrl.Substring(indexOfScheme + schemeSeparator.Length);
@@ -181,7 +181,7 @@ namespace Stryker.Core.Initialisation
 
             if (assemblyInformationalVersion == null)
             {
-                throw new GeneralStrykerException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
+                throw new StrykerInputException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
             }
 
             return assemblyInformationalVersion;

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -1,10 +1,15 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Mono.Cecil;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation.Buildalyzer;
 using Stryker.Core.Logging;
 using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
+using Stryker.Core.Reporters;
 using Stryker.Core.TestRunners;
 using Stryker.Core.TestRunners.VsTest;
 
@@ -24,7 +29,7 @@ namespace Stryker.Core.Initialisation
 
     public interface IInitialisationProcess
     {
-        MutationTestInput Initialize(StrykerOptions options);
+        MutationTestInput Initialize(StrykerOptions options, DashboardReporter dashboardReporter);
         InitialTestRun InitialTest(StrykerOptions options);
     }
 
@@ -52,7 +57,7 @@ namespace Stryker.Core.Initialisation
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<InitialisationProcess>();
         }
 
-        public MutationTestInput Initialize(StrykerOptions options)
+        public MutationTestInput Initialize(StrykerOptions options, DashboardReporter dashboardReporter)
         {
             // resolve project info
             var projectInfo = _inputFileResolver.ResolveInput(options);
@@ -72,6 +77,8 @@ namespace Stryker.Core.Initialisation
                     options.SolutionPath);
             }
 
+            InitializeDashboardReporter(dashboardReporter, projectInfo);
+
             if (_testRunner == null)
             {
                 _testRunner = new VsTestRunnerPool(options, projectInfo);
@@ -90,5 +97,94 @@ namespace Stryker.Core.Initialisation
         public InitialTestRun InitialTest(StrykerOptions options) =>
             // initial test
             _initialTestProcess.InitialTest(options, _testRunner);
+
+        private void InitializeDashboardReporter(DashboardReporter dashboardReporter, ProjectInfo projectInfo)
+        {
+            if (dashboardReporter == null)
+            {
+                return;
+            }
+
+            // try to read the repository URL + version for the dashboard report
+            var missingProjectName = string.IsNullOrEmpty(dashboardReporter.ProjectName);
+            var missingProjectVersion = string.IsNullOrEmpty(dashboardReporter.ProjectVersion);
+            if (missingProjectName || missingProjectVersion)
+            {
+                var subject = missingProjectName switch
+                {
+                    true when missingProjectVersion => "Project name and project version",
+                    true => "Project name",
+                    _ => "Project version"
+                };
+                var projectFilePath = projectInfo.ProjectUnderTestAnalyzerResult.ProjectFilePath;
+
+                if (!projectInfo.ProjectUnderTestAnalyzerResult.Properties.TryGetValue("TargetPath", out var targetPath))
+                {
+                    throw new GeneralStrykerException($"Can't read {subject.ToLowerInvariant()} because the TargetPath property was not found in {projectFilePath}");
+                }
+
+                _logger.LogTrace("{Subject} missing for the dashboard reporter, reading it from {TargetPath}. " +
+                                 "Note that this requires SourceLink to be properly configured in {ProjectPath}", subject, targetPath, projectFilePath);
+
+                try
+                {
+                    var targetName = Path.GetFileName(targetPath);
+                    using var module = ModuleDefinition.ReadModule(targetPath);
+
+                    var details = $"To solve this issue, either specify the {subject.ToLowerInvariant()} in the stryker configuration or configure [SourceLink](https://github.com/dotnet/sourcelink#readme) in {projectFilePath}";
+                    if (missingProjectName)
+                    {
+                        dashboardReporter.ProjectName = ReadProjectName(module, details);
+                        _logger.LogDebug("Using {ProjectName} as project name for the dashboard reporter. (Read from the AssemblyMetadata/RepositoryUrl assembly attribute of {TargetName})", dashboardReporter.ProjectName, targetName);
+                    }
+
+                    if (missingProjectVersion)
+                    {
+                        dashboardReporter.ProjectVersion = ReadProjectVersion(module, details);
+                        _logger.LogDebug("Using {ProjectVersion} as project version for the dashboard reporter. (Read from the AssemblyInformationalVersion assembly attribute of {TargetName})", dashboardReporter.ProjectVersion, targetName);
+                    }
+                }
+                catch (Exception e) when (e is not GeneralStrykerException)
+                {
+                    throw new GeneralStrykerException($"Failed to read {subject.ToLowerInvariant()} from {targetPath}", e);
+                }
+            }
+        }
+
+        private static string ReadProjectName(ModuleDefinition module, string details)
+        {
+            var repositoryUrl = module.Assembly.CustomAttributes
+                .FirstOrDefault(e => e.AttributeType.Name == "AssemblyMetadataAttribute"
+                                     && e.ConstructorArguments.Count == 2
+                                     && e.ConstructorArguments[0].Value.Equals("RepositoryUrl"))?.ConstructorArguments[1].Value as string;
+
+            if (repositoryUrl == null)
+            {
+                throw new GeneralStrykerException($"Failed to retrieve the RepositoryUrl from the AssemblyMetadataAttribute of {module.FileName}", details);
+            }
+
+            const string schemeSeparator = "://";
+            var indexOfScheme = repositoryUrl.IndexOf(schemeSeparator, StringComparison.Ordinal);
+            if (indexOfScheme < 0)
+            {
+                throw new GeneralStrykerException($"Failed to compute the project name from the repository URL ({repositoryUrl}) because it doesn't contain a scheme ({schemeSeparator})", details);
+            }
+
+            return repositoryUrl.Substring(indexOfScheme + schemeSeparator.Length);
+        }
+
+        private static string ReadProjectVersion(ModuleDefinition module, string details)
+        {
+            var assemblyInformationalVersion = module.Assembly.CustomAttributes
+                .FirstOrDefault(e => e.AttributeType.Name == "AssemblyInformationalVersionAttribute"
+                                     && e.ConstructorArguments.Count == 1)?.ConstructorArguments[0].Value as string;
+
+            if (assemblyInformationalVersion == null)
+            {
+                throw new GeneralStrykerException($"Failed to retrieve the AssemblyInformationalVersionAttribute of {module.FileName}", details);
+            }
+
+            return assemblyInformationalVersion;
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
 using Stryker.Core.Reporters;
@@ -26,7 +27,8 @@ namespace Stryker.Core.Initialisation
             // get a new instance of InitialisationProcess for each project
             var initialisationProcess = _initialisationProcessProvider.Provide();
             // initialize
-            var input = initialisationProcess.Initialize(options);
+            var dashboardReporter = GetDashboardReporter(reporters);
+            var input = initialisationProcess.Initialize(options, dashboardReporter);
 
             var process = _mutationTestProcessProvider.Provide(
                 mutationTestInput: input,
@@ -41,6 +43,16 @@ namespace Stryker.Core.Initialisation
             process.Mutate();
 
             return process;
+        }
+
+        private static DashboardReporter GetDashboardReporter(IReporter reporters)
+        {
+            if (reporters is BroadcastReporter broadcastReporter)
+            {
+                return broadcastReporter.Reporters.OfType<DashboardReporter>().FirstOrDefault();
+            }
+
+            return reporters as DashboardReporter;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectNameInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectNameInput.cs
@@ -1,29 +1,12 @@
-using System.Collections.Generic;
-using System.Linq;
-using Stryker.Core.Exceptions;
-using Stryker.Core.Reporters;
-
 namespace Stryker.Core.Options.Inputs
 {
     public class ProjectNameInput : Input<string>
     {
-
         protected override string Description => @"The organizational name for your project. Required when dashboard reporter is turned on.
 For example: Your project might be called 'consumer-loans' and it might contains sub-modules 'consumer-loans-frontend' and 'consumer-loans-backend'.";
 
         public override string Default => string.Empty;
 
-        public string Validate(IEnumerable<Reporter> reporters)
-        {
-            if (reporters is { } && reporters.Contains(Reporter.Dashboard))
-            {
-                if (string.IsNullOrWhiteSpace(SuppliedInput))
-                {
-                    throw new InputException("When the stryker dashboard is enabled the project name is required.");
-                }
-            }
-
-            return SuppliedInput ?? Default;
-        }
+        public string Validate() => SuppliedInput ?? Default;
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectVersionInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectVersionInput.cs
@@ -15,11 +15,6 @@ namespace Stryker.Core.Options.Inputs
         {
             if (reporters.Contains(Reporter.Dashboard))
             {
-                if (string.IsNullOrWhiteSpace(SuppliedInput))
-                {
-                    throw new InputException("When the stryker dashboard is enabled the project version is required. Please provide a project version.");
-                }
-
                 if (dashboardCompareEnabled.IsNotNullAndTrue() && fallbackVersion == SuppliedInput)
                 {
                     throw new InputException("Project version cannot be the same as the fallback version. Please provide a different version for one of them.");

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
@@ -128,7 +128,7 @@ namespace Stryker.Core.Options
                 TestProjects = TestProjectsInput.Validate(),
                 DashboardUrl = DashboardUrlInput.Validate(),
                 DashboardApiKey = DashboardApiKeyInput.Validate(WithBaselineInput.SuppliedInput),
-                ProjectName = ProjectNameInput.Validate(reporters),
+                ProjectName = ProjectNameInput.Validate(),
                 ModuleName = ModuleNameInput.Validate(),
                 ProjectVersion = ProjectVersionInput.Validate(FallbackVersionInput.SuppliedInput, reporters, WithBaselineInput.SuppliedInput),
                 DiffIgnoreChanges = DiffIgnoreChangesInput.Validate(),

--- a/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
@@ -25,13 +25,22 @@ namespace Stryker.Core.Reporters
             _dashboardClient = dashboardClient ?? new DashboardClient(options);
             _logger = logger ?? ApplicationLogging.LoggerFactory.CreateLogger<DashboardReporter>();
             _consoleWriter = consoleWriter ?? Console.Out;
+            ProjectVersion = _options.ProjectVersion;
         }
+
+        public string ProjectName
+        {
+            get => _dashboardClient.ProjectName;
+            set => _dashboardClient.ProjectName = value;
+        }
+
+        public string ProjectVersion { get; set; }
 
         public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent)
         {
             var mutationReport = JsonReport.Build(_options, reportComponent);
 
-            var reportUrl = _dashboardClient.PublishReport(mutationReport.ToJson(), _options.ProjectVersion).Result;
+            var reportUrl = _dashboardClient.PublishReport(mutationReport.ToJson(), ProjectVersion).Result;
 
             if (reportUrl != null)
             {


### PR DESCRIPTION
Thanks to [SourceLink][1], the repository URL and the full version (including the git SHA1) of a project can be included in the produced assembly.

This commit uses the information computed by SourceLink to automatically retrieve the project name (github.com/organization/project) and project version which are required for the dashboard reporter.

With this technique, the table on the [Stryker dashboard documentation][2] can be updated with ✅ everywhere for the Stryker.NET column since it doesn't depend on a specific CI provider to provide the repository URL and version.

Note that I have run `Stryker.CLI --reporter progress --reporter html --reporter dashboard` on my local checkout of https://github.com/0xced/serilog-formatting-log4net/tree/20e86d55b4bd9e3682c3608530398e794df12481 and it automatically retrieved the project name (`github.com/0xced/serilog-formatting-log4net`) and project version (`1.0.0-rc.2+20e86d55b4bd9e3682c3608530398e794df12481`). The report was successfully uploaded to the [Stryker dashboard][3]

[1]: https://github.com/dotnet/sourcelink#readme
[2]: https://stryker-mutator.io/docs/General/dashboard/#retrieved-from-environment
[3]: https://dashboard.stryker-mutator.io/reports/github.com/0xced/serilog-formatting-log4net/1.0.0-rc.2%2B20e86d55b4bd9e3682c3608530398e794df12481