### PR TITLE
feat(testrunner): Filter which unit tests are used during mutation test

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,15 @@ Config file: `"test-projects": ['../MyProject.UnitTests/MyProject.UnitTests.cspr
 
 When you have multiple test projects covering one project under test you may specify all relevant test projects in the config file. You must run stryker from the project under test instead of the test project directory when using multiple test projects.
 
-### `mutate` <`glob[]`]
+### `test-case-filter` <`string`>
+
+Default: `""`  
+Command line: `N/A`  
+Config file: `"test-case-filter": "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"`
+
+Filter expression to run selective tests. Uses `dotnet test --filter` option syntax, [detailed here](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests). Use this option if you wish to run stryker only on a selective subset of tests from your test suite.
+
+### `mutate` <`glob[]`>
 
 Default: `*`  
 Command line: `[-m|--mutate] "**/*Services.cs" -m "!**/*.Generated.cs"`  

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
@@ -79,6 +79,7 @@ namespace Stryker.CLI.UnitTest
             actualInputs.CoverageAnalysisInput.SuppliedInput.ShouldBe("perTest");
             actualInputs.DisableBailInput.SuppliedInput.ShouldBe(true);
             actualInputs.ExcludedMutationsInput.SuppliedInput.ShouldContain("linq.FirstOrDefault");
+            actualInputs.TestCaseFilterInput.SuppliedInput.ShouldBe("(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1");
         }
     }
 }

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.json
@@ -6,7 +6,7 @@
     "verbosity": "trace",
     "coverage-analysis": "perTest",
     "disable-bail": true,
-    "disable-mix-mutants":  true,
+    "disable-mix-mutants": true,
     "additional-timeout": 9999,
     "project": "ExampleProject.csproj",
     "concurrency": 1,
@@ -25,7 +25,7 @@
       ""
     ],
     "ignore-mutations": [
-      "linq.FirstOrDefault",
+      "linq.FirstOrDefault"
     ],
     "ignore-methods": [
       ""
@@ -44,10 +44,11 @@
       "module": "cli"
     },
     "baseline": {
-      "enabled":  false,
+      "enabled": false,
       "fallback-version": "master",
       "azure-fileshare-url": "",
       "provider": ""
-    }
+    },
+    "test-case-filter": "(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1"
   }
 }

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
@@ -126,8 +126,6 @@ namespace Stryker.CLI
             AddCliInput(inputs.ProjectUnderTestNameInput, "project", "p", argumentHint: "project-name.csproj");
             AddCliInput(inputs.MutationLevelInput, "mutation-level", "l");
 
-            AddCliInput(inputs.TestCaseFilterInput, "filter", "");
-
             AddCliInput(inputs.LogToFileInput, "log-to-file", "L", optionType: CommandOptionType.NoValue);
             AddCliInput(inputs.VerbosityInput, "verbosity", "V");
 

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
@@ -40,7 +40,7 @@ namespace Stryker.CLI
             {
                 var strykerInput = GetStrykerInput(cliInput);
 
-                switch(cliInput.OptionType)
+                switch (cliInput.OptionType)
                 {
                     case CommandOptionType.NoValue:
                         HandleNoValue((IInput<bool?>)strykerInput);
@@ -53,7 +53,7 @@ namespace Stryker.CLI
                         break;
                 }
 
-                switch(strykerInput)
+                switch (strykerInput)
                 {
                     case IInput<string> stringInput:
                         HandleSingleStringValue(cliInput, stringInput);
@@ -83,7 +83,8 @@ namespace Stryker.CLI
             if (int.TryParse(cliInput.Value(), out var value))
             {
                 strykerInput.SuppliedInput = value;
-            } else
+            }
+            else
             {
                 throw new InputException($"Unexpected value for argument {cliInput.LongName}:{cliInput.Value()}. Expected type to be integer");
             }
@@ -124,6 +125,8 @@ namespace Stryker.CLI
 
             AddCliInput(inputs.ProjectUnderTestNameInput, "project", "p", argumentHint: "project-name.csproj");
             AddCliInput(inputs.MutationLevelInput, "mutation-level", "l");
+
+            AddCliInput(inputs.TestCaseFilterInput, "filter", "f");
 
             AddCliInput(inputs.LogToFileInput, "log-to-file", "L", optionType: CommandOptionType.NoValue);
             AddCliInput(inputs.VerbosityInput, "verbosity", "V");

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfigHandler.cs
@@ -126,7 +126,7 @@ namespace Stryker.CLI
             AddCliInput(inputs.ProjectUnderTestNameInput, "project", "p", argumentHint: "project-name.csproj");
             AddCliInput(inputs.MutationLevelInput, "mutation-level", "l");
 
-            AddCliInput(inputs.TestCaseFilterInput, "filter", "f");
+            AddCliInput(inputs.TestCaseFilterInput, "filter", "");
 
             AddCliInput(inputs.LogToFileInput, "log-to-file", "L", optionType: CommandOptionType.NoValue);
             AddCliInput(inputs.VerbosityInput, "verbosity", "V");

--- a/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
@@ -55,10 +55,13 @@ namespace Stryker.CLI
 
         [JsonProperty(PropertyName = "test-projects")]
         public string[] TestProjects { get; set; }
-        
+
+        [JsonProperty(PropertyName = "test-case-filter")]
+        public string TestCaseFilter { get; set; }
+
         [JsonProperty(PropertyName = "ignore-mutations")]
         public string[] IgnoreMutations { get; set; }
-        
+
         [JsonProperty(PropertyName = "ignore-methods")]
         public string[] IgnoreMethods { get; set; }
     }

--- a/src/Stryker.CLI/Stryker.CLI/JsonConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/JsonConfigHandler.cs
@@ -36,7 +36,7 @@ namespace Stryker.CLI
             inputs.ModuleNameInput.SuppliedInput = jsonConfig.ProjectInfo?.Module;
             inputs.ProjectVersionInput.SuppliedInput = jsonConfig.ProjectInfo?.Version;
             inputs.ReportersInput.SuppliedInput = jsonConfig.Reporters;
-            
+
             inputs.SinceTargetInput.SuppliedInput = jsonConfig.Since?.Target;
             inputs.SolutionInput.SuppliedInput = jsonConfig.Solution;
             inputs.ProjectUnderTestNameInput.SuppliedInput = jsonConfig.Project;
@@ -46,6 +46,7 @@ namespace Stryker.CLI
             inputs.VerbosityInput.SuppliedInput = jsonConfig.Verbosity;
             inputs.LanguageVersionInput.SuppliedInput = jsonConfig.LanguageVersion;
             inputs.TestProjectsInput.SuppliedInput = jsonConfig.TestProjects;
+            inputs.TestCaseFilterInput.SuppliedInput = jsonConfig.TestCaseFilter;
             inputs.ExcludedMutationsInput.SuppliedInput = jsonConfig.IgnoreMutations;
         }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/TestCaseFilterInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/TestCaseFilterInputTests.cs
@@ -1,0 +1,46 @@
+using Shouldly;
+using Stryker.Core.Options.Inputs;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Options.Inputs
+{
+    public class TestCaseFilterInputTests : TestBase
+    {
+        [Fact]
+        public void ShouldHaveHelpText()
+        {
+            var input = new TestCaseFilterInput();
+            input.HelpText.ShouldBe(@"Filters out tests in the project using the given expression.
+Uses the syntax for dotnet test --filter option and vstest.console.exe --testcasefilter option.
+For more information on running selective tests, see https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests. | default: ''");
+        }
+
+        [Fact]
+        public void DefaultShouldBeEmpty()
+        {
+            var input = new TestCaseFilterInput();
+            input.Default.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldReturnSuppliedInputWhenNotNullOrWhiteSpace()
+        {
+            var input = new TestCaseFilterInput { SuppliedInput = "Category=Unit" };
+            input.Validate().ShouldBe("Category=Unit");
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultWhenSuppliedInputNull()
+        {
+            var input = new TestCaseFilterInput { SuppliedInput = null };
+            input.Validate().ShouldBe("");
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultWhenSuppliedInputWhiteSpace()
+        {
+            var input = new TestCaseFilterInput { SuppliedInput = "    " };
+            input.Validate().ShouldBe("");
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
@@ -210,9 +210,10 @@ namespace Stryker.Core.UnitTest.TestRunners
                 x.RunTestsWithCustomTestHost(
                     It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),
                     It.Is<string>(settings => settings.Contains("<Coverage")),
+                    It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                     It.IsAny<ITestRunEventsHandler>(),
                     It.IsAny<ITestHostLauncher>())).Callback(
-                (IEnumerable<string> _, string _, ITestRunEventsHandler testRunEvents,
+                (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
                     ITestHostLauncher _) =>
                 {
                     // generate test results
@@ -245,9 +246,10 @@ namespace Stryker.Core.UnitTest.TestRunners
                 x.RunTestsWithCustomTestHost(
                     It.IsAny<IEnumerable<TestCase>>(),
                     It.Is<string>(s => !s.Contains("<Coverage")),
+                    It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                     It.IsAny<ITestRunEventsHandler>(),
                     It.IsAny<ITestHostLauncher>())).Callback(
-                (IEnumerable<TestCase> sources, string settings, ITestRunEventsHandler testRunEvents,
+                (IEnumerable<TestCase> sources, string settings, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
                     ITestHostLauncher _) =>
                 {
                     var collector = new CoverageCollector();
@@ -299,9 +301,10 @@ namespace Stryker.Core.UnitTest.TestRunners
                 x.RunTestsWithCustomTestHost(
                     It.IsAny<IEnumerable<TestCase>>(),
                     It.IsAny<string>(),
+                    It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                     It.IsAny<ITestRunEventsHandler>(),
                     It.IsAny<ITestHostLauncher>())).Callback(
-                (IEnumerable<TestCase> sources, string settings, ITestRunEventsHandler testRunEvents,
+                (IEnumerable<TestCase> sources, string settings, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
                     ITestHostLauncher _) =>
                 {
                     var collector = new CoverageCollector();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
@@ -1,3 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Buildalyzer;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer.Interfaces;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -14,19 +23,10 @@ using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.Reporters;
+using Stryker.Core.TestRunners;
 using Stryker.Core.TestRunners.VsTest;
 using Stryker.Core.ToolHelpers;
 using Stryker.DataCollector;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using Stryker.Core.TestRunners;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.TestRunners
@@ -123,7 +123,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                 ContinueWith((_, u) => discoveryEventsHandler.HandleDiscoveryComplete((int)u, null, aborted), tests.Count);
         }
 
-        private TestCase BuildCase(string name) => new TestCase(name, _executorUri, _testAssemblyPath){Id = new Guid()};
+        private TestCase BuildCase(string name) => new TestCase(name, _executorUri, _testAssemblyPath) { Id = new Guid() };
 
         private TestCase FindOrBuildCase(string testResultId) => _testCases.FirstOrDefault(@t => t.FullyQualifiedName == testResultId) ?? BuildCase(testResultId);
 
@@ -172,7 +172,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             }
             SetupMockTestRun(mockVsTest, results, synchroObject);
         }
-        
+
         private void SetupMockTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, IEnumerable<(string id, bool success)> testResults,
             EventWaitHandle synchroObject)
         {
@@ -191,9 +191,10 @@ namespace Stryker.Core.UnitTest.TestRunners
                 x.RunTestsWithCustomTestHost(
                     It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),
                     It.Is<string>(settings => !settings.Contains("<Coverage")),
+                    It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                     It.IsAny<ITestRunEventsHandler>(),
                     It.IsAny<ITestHostLauncher>())).Callback(
-                (IEnumerable<string> _, string _, ITestRunEventsHandler testRunEvents,
+                (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
                     ITestHostLauncher _) =>
                 {
                     // generate test results
@@ -390,7 +391,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         {
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(new StrykerOptions(), endProcess, out var runner);
-            SetupMockTestRun(mockVsTest, new[] {("T0", false),("T1", true) }, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", false), ("T1", true) }, endProcess);
             var result = runner.InitialTest();
             // tests are successful => run should be successful
             result.FailingTests.Count.ShouldBe(1);
@@ -591,9 +592,12 @@ namespace Stryker.Core.UnitTest.TestRunners
                 _testCases.Add(new TestCase("T2", _executorUri, _testAssemblyPath));
                 _testCases.Add(new TestCase("T3", _executorUri, _testAssemblyPath));
 
-                var input = new MutationTestInput { ProjectInfo = _targetProject,
+                var input = new MutationTestInput
+                {
+                    ProjectInfo = _targetProject,
                     TestRunner = runner,
-                    InitialTestRun = new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(500))};
+                    InitialTestRun = new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(500))
+                };
                 foreach (var mutant in _targetProject.ProjectContents.Mutants)
                 {
                     mutant.ResetCoverage();
@@ -642,12 +646,12 @@ namespace Stryker.Core.UnitTest.TestRunners
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
             // assume 2 results for T0
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true), ("T0", true) }, endProcess);
             var result = runner.InitialTest();
             // initial test is fine
             result.FailingTests.IsEmpty.ShouldBeTrue();
             // test session will fail
-            SetupMockTestRun(mockVsTest, new[]{("T0", true),  ("T0", true), ("T1", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T0", true), ("T1", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.FailingTests.IsEmpty.ShouldBeTrue();
             result.RanTests.IsEveryTest.ShouldBeTrue();
@@ -660,18 +664,18 @@ namespace Stryker.Core.UnitTest.TestRunners
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
             // assume 2 results for T0
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true), ("T0", true) }, endProcess);
             var result = runner.InitialTest();
             // initial test is fine
             result.FailingTests.IsEmpty.ShouldBeTrue();
             // test session will fail on test 1
-            SetupMockTestRun(mockVsTest, new[]{("T0", false),  ("T0", true), ("T1", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", false), ("T0", true), ("T1", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.RanTests.IsEveryTest.ShouldBeTrue();
             result.FailingTests.IsEmpty.ShouldBeFalse();
             result.FailingTests.GetGuids().ShouldContain(_testCases[0].Id);
             // test session will fail on the other test result
-            SetupMockTestRun(mockVsTest, new[]{("T0", true),  ("T0", false), ("T1", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T0", false), ("T1", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.RanTests.IsEveryTest.ShouldBeTrue();
             result.FailingTests.IsEmpty.ShouldBeFalse();
@@ -685,12 +689,12 @@ namespace Stryker.Core.UnitTest.TestRunners
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
             // assume 2 results for T0
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true), ("T0", true) }, endProcess);
             var result = runner.InitialTest();
             // initial test is fine
             result.FailingTests.IsEmpty.ShouldBeTrue();
             // test session will fail
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.FailingTests.IsEmpty.ShouldBeTrue();
             result.TimedOutTests.Count.ShouldBe(1);
@@ -705,12 +709,12 @@ namespace Stryker.Core.UnitTest.TestRunners
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
             // assume 2 results for T0
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true), ("T0", true) }, endProcess);
             var result = runner.InitialTest();
             // initial test is fine
             result.FailingTests.IsEmpty.ShouldBeTrue();
             // test session will fail
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T0", true), ("T0", false), ("T1", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T0", true), ("T0", false), ("T1", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.RanTests.IsEveryTest.ShouldBeTrue();
             result.FailingTests.IsEmpty.ShouldBeFalse();
@@ -724,12 +728,12 @@ namespace Stryker.Core.UnitTest.TestRunners
             using var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset);
             var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
             // assume 2 results for T0
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T1", true), ("T0", true) }, endProcess);
             var result = runner.InitialTest();
             // initial test is fine
             result.FailingTests.IsEmpty.ShouldBeTrue();
             // test session will fail
-            SetupMockTestRun(mockVsTest, new[]{("T0", true), ("T2", true), ("T1", true), ("T0", true)}, endProcess);
+            SetupMockTestRun(mockVsTest, new[] { ("T0", true), ("T2", true), ("T1", true), ("T0", true) }, endProcess);
             result = runner.RunAll(null, _mutant, null);
             result.RanTests.IsEveryTest.ShouldBeTrue();
             result.FailingTests.IsEmpty.ShouldBeTrue();

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/TestCaseFilterInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/TestCaseFilterInput.cs
@@ -1,0 +1,14 @@
+namespace Stryker.Core.Options.Inputs
+{
+    public class TestCaseFilterInput : Input<string>
+    {
+        public override string Default => string.Empty;
+
+        protected override string Description => @"Filters out tests in the project using the given expression.
+Uses the syntax for dotnet test --filter option and vstest.console.exe --testcasefilter option.
+For more information on running selective tests, see https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests.";
+
+        public string Validate()
+            => string.IsNullOrWhiteSpace(SuppliedInput) ? Default : SuppliedInput;
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
@@ -35,6 +35,7 @@ namespace Stryker.Core.Options
         SinceTargetInput SinceTargetInput { get; init; }
         SolutionInput SolutionInput { get; init; }
         TestProjectsInput TestProjectsInput { get; init; }
+        TestCaseFilterInput TestCaseFilterInput { get; init; }
         ThresholdBreakInput ThresholdBreakInput { get; init; }
         ThresholdHighInput ThresholdHighInput { get; init; }
         ThresholdLowInput ThresholdLowInput { get; init; }
@@ -69,6 +70,7 @@ namespace Stryker.Core.Options
         public ConcurrencyInput ConcurrencyInput { get; init; } = new();
         public ProjectUnderTestNameInput ProjectUnderTestNameInput { get; init; } = new();
         public TestProjectsInput TestProjectsInput { get; init; } = new();
+        public TestCaseFilterInput TestCaseFilterInput { get; init; } = new();
         public WithBaselineInput WithBaselineInput { get; init; } = new();
         public ReportersInput ReportersInput { get; init; } = new();
         public BaselineProviderInput BaselineProviderInput { get; init; } = new();
@@ -127,6 +129,7 @@ namespace Stryker.Core.Options
                 LanguageVersion = LanguageVersionInput.Validate(),
                 OptimizationMode = CoverageAnalysisInput.Validate() | DisableBailInput.Validate() | DisableMixMutantsInput.Validate(),
                 TestProjects = TestProjectsInput.Validate(),
+                TestCaseFilter = TestCaseFilterInput.Validate(),
                 DashboardUrl = DashboardUrlInput.Validate(),
                 DashboardApiKey = DashboardApiKeyInput.Validate(WithBaselineInput.SuppliedInput),
                 ProjectName = ProjectNameInput.Validate(reporters),

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -87,6 +87,7 @@ namespace Stryker.Core.Options
                 SinceTarget = SinceTarget,
                 SolutionPath = SolutionPath,
                 TestProjects = testProjects,
+                TestCaseFilter = TestCaseFilter,
                 Thresholds = Thresholds,
                 WithBaseline = WithBaseline
             };

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.Baseline.Providers;
-using Stryker.Core.Logging;
 using Stryker.Core.Mutators;
 using Stryker.Core.Reporters;
 
@@ -27,6 +26,7 @@ namespace Stryker.Core.Options
         public int Concurrency { get; init; }
         public string ProjectUnderTestName { get; init; }
         public IEnumerable<string> TestProjects { get; init; } = Enumerable.Empty<string>();
+        public string TestCaseFilter { get; init; }
 
         public bool WithBaseline { get; init; }
         public IEnumerable<Reporter> Reporters { get; init; } = Enumerable.Empty<Reporter>();


### PR DESCRIPTION
Replaces #1557 and fixes #420.

- Added the option `--filter` to specify a [TestCaseFilter](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests).
- Passed the option to VsTestRunner in two forms: one with the XML RunSettings and one as `TestPlatformOptions` parameter when calling `_vsTestConsole.RunTestsWithCustomTestHost()`. Previous work in #1557 had shown that both were required, since one is used during test discovery and the other is used during test execution.
- Tested the option with a very basic test of two xUnit tests. One test is attributed `[Trait("Category", "unit")]` and the other one `[Trait("Category", "integration")]`. When running Stryker.CLI without `--filter` option, the console outputs `Total number of tests found: 2.` with a correct HTML report. When using either `--filter "Category=unit"` or `--filter "Category=integration"`, then Stryker only analyses the targetted test `Total number of tests found: 1.`

I'm not sure what to do next to go forward with this. Would you require unit or integration tests on this new option? Any chance you might help on that?