### PR TITLE
Refactor v1.0 post merge

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -19,7 +18,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
                 return result;
             }
 
-            if (!context.Store.HasBlockLevel)
+            if (!context.HasStatementLevelMutant)
             {
                 return result;
             }
@@ -29,15 +28,8 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
                 result = MutantPlacer.ConvertExpressionToBody(result);
             }
 
-            var converter = sourceNode.NeedsReturn()
-                ? (Func<Mutation, StatementSyntax>)(toConvert =>
-                    SyntaxFactory.ReturnStatement(sourceNode.ExpressionBody!.Expression.InjectMutation(toConvert)))
-                : (toConvert) =>
-                    SyntaxFactory.ExpressionStatement(sourceNode.ExpressionBody!.Expression.InjectMutation(toConvert));
-
-            var newBody = context.Store.PlaceBlockMutations(result.Body, converter);
+            var newBody = context.InjectBlockLevelExpressionMutation(result.Body, sourceNode.ExpressionBody!.Expression, sourceNode.NeedsReturn());
             return result.WithBody(SyntaxFactory.Block(newBody));
-
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BlockOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BlockOrchestrator.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Stryker.Core.Helpers;
 
 namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
 {
@@ -14,7 +13,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
         /// <remarks>Ensure we returns a block after mutants are injected.</remarks>
         protected override StatementSyntax InjectMutations(BlockSyntax sourceNode, StatementSyntax targetNode, MutationContext context)
         {
-            var mutated = context.Store.PlaceBlockMutations(targetNode, m => (sourceNode as StatementSyntax).InjectMutation(m));
+            var mutated = context.InjectBlockLevel(targetNode, sourceNode);
             // ensure we still return a block!
             return mutated is BlockSyntax ? mutated : SyntaxFactory.Block(mutated);
         }
@@ -31,7 +30,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             IEnumerable<Mutant> mutations,
             MutationContext context)
         {
-            context.Store.StoreMutations(mutations, MutationControl.Block);
+            context.AddBlockLevel(mutations);
             return context;
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/ExpressionSpecificOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/ExpressionSpecificOrchestrator.cs
@@ -12,15 +12,21 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
     {
         /// <inheritdoc/>
         /// <remarks>Inject all pending mutations controlled with conditional operator(s).</remarks>
-        protected override ExpressionSyntax InjectMutations(T sourceNode, ExpressionSyntax targetNode, MutationContext context) => context.Store.PlaceExpressionMutations(targetNode, m => sourceNode.InjectMutation(m));
+        protected override ExpressionSyntax InjectMutations(T sourceNode, ExpressionSyntax targetNode, MutationContext context) => context.InjectExpressionLevel(targetNode, sourceNode);
 
         protected override MutationContext StoreMutations(T node,
             IEnumerable<Mutant> mutations,
             MutationContext context)
         {
             // if the expression contains a declaration, it must be controlled at the block level.
-            context.Store.StoreMutations(mutations,
-                !node.ContainsDeclarations() ? MutationControl.Expression : MutationControl.Block);
+            if (node.ContainsDeclarations())
+            {
+                context.AddBlockLevel(mutations);
+            }
+            else
+            {
+                context.AddExpressionLevel(mutations);
+            }
             return context;
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/PostfixUnaryExpressionOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/PostfixUnaryExpressionOrchestrator.cs
@@ -12,7 +12,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             IEnumerable<Mutant> mutations,
             MutationContext context)
         {
-            context.Store.StoreMutations(mutations, MutationControl.Statement);
+            context.AddStatementLevel(mutations);
             return context;
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/StatementSpecificOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/StatementSpecificOrchestrator.cs
@@ -17,8 +17,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
         /// <inheritdoc/>
         /// <remarks>Inject pending mutations that are controlled with 'if' statements.</remarks>
         protected override StatementSyntax InjectMutations(T sourceNode, StatementSyntax targetNode, MutationContext context) =>
-            context.Store.PlaceStatementMutations(targetNode,
-                m => (sourceNode as StatementSyntax).InjectMutation(m));
+            context.InjectStatementLevel(targetNode, sourceNode);
 
         /// <inheritdoc/>
         /// <remarks>Mutations are stored ath statement level.</remarks>
@@ -26,7 +25,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             IEnumerable<Mutant> mutations,
             MutationContext context)
         {
-            context.Store.StoreMutations(mutations, MutationControl.Statement);
+            context.AddStatementLevel(mutations);
             return context;
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
@@ -4,35 +4,36 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Extensions.Logging;
 using Stryker.Core.Mutators;
 using Stryker.Core.Helpers;
-using Stryker.Core.Logging;
 using Stryker.Core.Mutants.CsharpNodeOrchestrators;
-
 
 namespace Stryker.Core.Mutants
 {
-
     /// <summary>
     /// Describe the (syntax tree) context during mutation
     /// </summary>
     internal class MutationContext
     {
         private readonly CsharpMutantOrchestrator _mainOrchestrator;
-        public MutationStore Store = new();
-
+        private readonly MutationStore _store = new();
+        
         public MutationContext(CsharpMutantOrchestrator mutantOrchestrator) => _mainOrchestrator = mutantOrchestrator;
 
         private MutationContext(MutationContext parent)
         {
             _mainOrchestrator = parent._mainOrchestrator;
             InStaticValue = parent.InStaticValue;
-            Store = parent.Store;
+            _store = parent._store;
             FilteredMutators = parent.FilteredMutators;
             FilterComment = parent.FilterComment;
         }
 
+        /// <summary>
+        /// Call this to generate mutations using active mutators.
+        /// </summary>
+        /// <param name="node"><see cref="SyntaxNode"/> to mutate.</param>
+        /// <returns>A list of mutants.</returns>
         public IEnumerable<Mutant> GenerateMutantsForNode(SyntaxNode node) =>
             _mainOrchestrator.GenerateMutationsForNode(node, this);
 
@@ -48,14 +49,14 @@ namespace Stryker.Core.Mutants
         /// </summary>
         public bool MustInjectCoverageLogic => _mainOrchestrator.MustInjectCoverageLogic;
 
-        public Mutator[] FilteredMutators { get; private set; }
+        internal Mutator[] FilteredMutators { get; private set; }
 
-        public string FilterComment { get; set; }
+        internal string FilterComment { get; set; }
 
         /// <summary>
         /// true if there are pending statement or block level mutations
         /// </summary>
-        public bool HasStatementLevelMutant => Store.HasStatementLevel;
+        public bool HasStatementLevelMutant => _store.HasStatementLevel;
 
         /// <summary>
         /// Call this to signal mutation occurs in static method or fields
@@ -63,15 +64,21 @@ namespace Stryker.Core.Mutants
         /// <returns>A new context</returns>
         public MutationContext EnterStatic() => new MutationContext(this) { InStaticValue = true };
 
+        /// <summary>
+        /// Call this when beginning of a syntax structure that can control mutations (expression, statement, block)
+        /// </summary>
+        /// <param name="control">type of structure (see <see cref="MutationControl"/>)</param>
+        /// <returns>The context to use moving forward.</returns>
+        /// <remarks>You must use a <see cref="Leave(MutationControl)"/>when leaving the context.</remarks>
         public MutationContext Enter(MutationControl control)
         {
             switch (control)
             {
                 case MutationControl.Statement:
-                    Store.EnterStatement();
+                    _store.EnterStatement();
                     return this;
                 case MutationControl.Block:
-                    Store.EnterBlock();
+                    _store.EnterBlock();
                     return new MutationContext(this);
             }
 
@@ -79,13 +86,71 @@ namespace Stryker.Core.Mutants
         }
 
         /// <summary>
+        /// Call this when leaving a control syntax structure
+        /// </summary>
+        /// <param name="control">type of structure (see <see cref="MutationControl"/>)</param>
+        /// <remarks>A call must match a previous call to <see cref="Enter(MutationControl)"/></remarks>
+        public void Leave(MutationControl control)
+        {
+            switch (control)
+            {
+                case MutationControl.Statement:
+                    _store.LeaveStatement();
+                    break;
+                case MutationControl.Block:
+                    _store.LeaveBlock();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Register new statement level mutations
+        /// </summary>
+        /// <param name="mutants"></param>
+        public void AddExpressionLevel(IEnumerable<Mutant> mutants) =>
+            _store.StoreMutations(mutants, MutationControl.Expression);
+
+        /// <summary>
         /// Register new statement level mutations
         /// </summary>
         /// <param name="mutants"></param>
         public void AddStatementLevel(IEnumerable<Mutant> mutants) =>
-            Store.StoreMutations(mutants, MutationControl.Statement);
+            _store.StoreMutations(mutants, MutationControl.Statement);
 
         /// <summary>
+        /// Register new block level mutations
+        /// </summary>
+        /// <param name="mutants"></param>
+        public void AddBlockLevel(IEnumerable<Mutant> mutants) =>
+            _store.StoreMutations(mutants, MutationControl.Block);
+
+        /// <summary>
+        /// Injects pending expression level mutations.
+        /// </summary>
+        /// <param name="mutatedNode">Target node that will contain the mutations</param>
+        /// <param name="sourceNode">Source node, used to generate mutations</param>
+        /// <returns>A mutated node containing the mutations.</returns>
+        public ExpressionSyntax InjectExpressionLevel(ExpressionSyntax mutatedNode, ExpressionSyntax sourceNode)
+            => _store.PlaceExpressionMutations(mutatedNode, m => sourceNode.InjectMutation(m));
+
+        /// <summary>
+        /// Injects pending statement level mutations.
+        /// </summary>
+        /// <param name="mutatedNode">Target node that will contain the mutations</param>
+        /// <param name="sourceNode">Source node, used to generate mutations</param>
+        /// <returns>A mutated node containing the mutations.</returns>
+        public StatementSyntax InjectStatementLevel(StatementSyntax mutatedNode, StatementSyntax sourceNode) => _store.PlaceStatementMutations(mutatedNode, m => sourceNode.InjectMutation(m));
+
+        /// <summary>
+        /// Injects pending block level mutations.
+        /// </summary>
+        /// <param name="mutatedNode">Target node that will contain the mutations</param>
+        /// <param name="originalNode">Source node, used to generate mutations</param>
+        /// <returns>A mutated node containing the mutations.</returns>
+        public StatementSyntax InjectBlockLevel(StatementSyntax mutatedNode, StatementSyntax originalNode)
+        => _store.PlaceBlockMutations(mutatedNode, m => originalNode.InjectMutation(m));
+
+        /// <summary>s
         /// Injects pending block level mutations for expression body method or functions
         /// </summary>
         /// <param name="mutatedNode">Target node that will contain the mutations</param>
@@ -99,11 +164,18 @@ namespace Stryker.Core.Mutants
             var wrapper = needReturn
                 ? (Func<ExpressionSyntax, StatementSyntax>)SyntaxFactory.ReturnStatement
                 : SyntaxFactory.ExpressionStatement;
-            return Store.PlaceBlockMutations(mutatedNode, m =>
+            return _store.PlaceBlockMutations(mutatedNode, m =>
                 wrapper(originalNode.InjectMutation(m)));
-
         }
 
+        /// <summary>
+        /// Enable/Disable a list of mutators.
+        /// </summary>
+        /// <param name="mode">true to disable mutators, false to (re)enable some</param>
+        /// <param name="filteredMutators">list of mutators</param>
+        /// <param name="newContext">true to create a new context</param>
+        /// <param name="comment">comment used for ignored mutators</param>
+        /// <returns>a context with an updated list of active mutators</returns>
         public MutationContext FilterMutators(bool mode, Mutator[] filteredMutators, bool newContext, string comment)
         {
             var result = newContext ? new MutationContext(this) : this;
@@ -122,19 +194,6 @@ namespace Stryker.Core.Mutants
             }
 
             return result;
-        }
-
-        public void Leave(MutationControl control)
-        {
-            switch (control)
-            {
-                case MutationControl.Statement:
-                    Store.LeaveStatement();
-                    break;
-                case MutationControl.Block:
-                    Store.LeaveBlock();
-                    break;
-            }
         }
     }
 }


### PR DESCRIPTION
This is a small PR with some refactoring (mostly on MutationContext) to fix the orchestration classes design that were disrupted with the recent merge with `master`. 