### PR TITLE
feat: Show commandline hint when unrecognized option is used

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using Crayon;
 using McMaster.Extensions.CommandLineUtils;
@@ -63,7 +64,24 @@ namespace Stryker.CLI
                 RunStryker(inputs);
                 return ExitCode;
             });
-            return app.Execute(args);
+
+            try
+            {
+                return app.Execute(args);
+            }
+            catch (CommandParsingException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+
+                if (ex is UnrecognizedCommandParsingException uex && uex.NearestMatches.Any())
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine("Did you mean this?");
+                    Console.Error.WriteLine("    " + uex.NearestMatches.First());
+                }
+
+                return ExitCodes.OtherError;
+            }
         }
 
         private void RunStryker(IStrykerInputs inputs)


### PR DESCRIPTION
Before this commit:

```
$ dotnet stryker --verbose
Specify --help for a list of available options and commands.
Unhandled exception. McMaster.Extensions.CommandLineUtils.UnrecognizedCommandParsingException: Unrecognized option '--verbose'
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessUnexpectedArg(String argTypeName, String argValue)
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.ProcessNext()
   at McMaster.Extensions.CommandLineUtils.CommandLineProcessor.Process()
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Parse(String[] args)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Stryker.CLI.StrykerCli.Run(String[] args) in C:\git\stryker\stryker-net\src\Stryker.CLI\Stryker.CLI\StrykerCLI.cs:line 66
   at Stryker.CLI.Program.Main(String[] args) in C:\git\stryker\stryker-net\src\Stryker.CLI\Stryker.CLI\Program.cs:line 15
```

After this commit:

```
$ dotnet stryker --verbose
Specify --help for a list of available options and commands.
Unrecognized option '--verbose'

Did you mean this?
    verbosity
```

Note that catching `CommandParsingException` is [done automatically][1] only if using the static method `McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute<TApp>`. This is not the case for Stryker.CLI which manually instantiate and configure a `CommandLineApplication` instance.

[1]: https://github.com/natemcmaster/CommandLineUtils/blob/v3.1.0/src/CommandLineUtils/CommandLineApplication.Execute.cs#L74-L93