### PR TITLE
chore: Use Serilog destructuring feature instead of serializing options as JSON

### DIFF
--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Logging;
@@ -51,7 +48,7 @@ namespace Stryker.Core
             projectOrchestrator ??= new ProjectOrchestrator();
 
             var options = inputs.ValidateAll();
-            _logger.LogDebug("Stryker started with options: {0}", JsonConvert.SerializeObject(options, new StringEnumConverter()));
+            _logger.LogDebug("Stryker started with options: {@Options}", options);
 
             var reporters = _reporterFactory.Create(options);
 


### PR DESCRIPTION
It's simpler and the output is more readable thanks to the colors.