### PR TITLE
Remove Newtonsoft.Json dependency

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFileTests.cs
@@ -18,7 +18,7 @@ namespace Stryker.CLI.UnitTest
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             var options = new StrykerOptions()
             {
-                Thresholds = new Thresholds()
+                Thresholds = new Stryker.Core.Options.Thresholds()
                 {
                     High = 80,
                     Low = 60,
@@ -45,7 +45,7 @@ namespace Stryker.CLI.UnitTest
         {
             IStrykerInputs actualInputs = null;
             var options = new StrykerOptions() {
-                Thresholds = new Thresholds() {
+                Thresholds = new Stryker.Core.Options.Thresholds() {
                     High = 80,
                     Low = 60,
                     Break = 0

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -31,7 +31,7 @@ namespace Stryker.CLI.UnitTest
 
         public StrykerCLITests()
         {
-            _options = new StrykerOptions() { Thresholds = new Thresholds { Break = 0 } };
+            _options = new StrykerOptions() { Thresholds = new Stryker.Core.Options.Thresholds { Break = 0 } };
             _runResults = new StrykerRunResult(_options, 0.3);
             _strykerRunnerMock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
                 .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => _inputs = c)
@@ -113,7 +113,7 @@ Options:";
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             var options = new StrykerOptions()
             {
-                Thresholds = new Thresholds
+                Thresholds = new Stryker.Core.Options.Thresholds
                 {
                     Break = 40
                 }
@@ -124,7 +124,7 @@ Options:";
                 .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => Core.Logging.ApplicationLogging.LoggerFactory = l)
                 .Returns(strykerRunResult)
                 .Verifiable();
-            
+
             var target = new StrykerCli(mock.Object);
             var result = target.Run(new string[] { });
 
@@ -139,7 +139,7 @@ Options:";
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             var options = new StrykerOptions()
             {
-                Thresholds = new Thresholds
+                Thresholds = new Stryker.Core.Options.Thresholds
                 {
                     Break = 0
                 }
@@ -163,7 +163,7 @@ Options:";
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             var options = new StrykerOptions()
             {
-                Thresholds = new Thresholds
+                Thresholds = new Stryker.Core.Options.Thresholds
                 {
                     Break = 40
                 }
@@ -187,7 +187,7 @@ Options:";
             var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
             var options = new StrykerOptions()
             {
-                Thresholds = new Thresholds
+                Thresholds = new Stryker.Core.Options.Thresholds
                 {
                     Break = 0
                 }

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -621,8 +621,32 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
@@ -1117,6 +1141,16 @@
           "Microsoft.Win32.Registry": "5.0.0",
           "System.Configuration.ConfigurationManager": "5.0.0",
           "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Diagnostics.TraceSource": {
@@ -2041,6 +2075,25 @@
           "System.Threading.Tasks.Extensions": "4.3.0"
         }
       },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
       "System.Xml.XmlDocument": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2130,7 +2183,6 @@
           "Microsoft.TestPlatform.TranslationLayer": "16.10.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.113",
           "Mono.Cecil": "0.11.4",
-          "Newtonsoft.Json": "13.0.1",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.0.1",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
@@ -1,103 +1,155 @@
-using Newtonsoft.Json;
-using Stryker.Core.Options;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Stryker.CLI
 {
-    public class FileBasedInputOuter
+    public interface IExtraData
     {
-        [JsonProperty(PropertyName = "stryker-config")]
-        public FileBasedInput Input { get; set; }
+        Dictionary<string, JsonElement> ExtraData { get; init; }
     }
 
-    public class FileBasedInput
+    public class FileBasedInputOuter : IExtraData
     {
-        [JsonProperty(PropertyName = "project-info")]
-        public ProjectInfo ProjectInfo { get; set; }
+        [JsonPropertyName("stryker-config")]
+        public FileBasedInput Input { get; init; }
 
-        public int? Concurrency { get; set; }
-
-        [JsonProperty(PropertyName = "mutation-level")]
-        public string MutationLevel { get; set; }
-
-        [JsonProperty(PropertyName = "language-version")]
-        public string LanguageVersion { get; set; }
-
-        [JsonProperty(PropertyName = "additional-timeout")]
-        public int AdditionalTimeout { get; set; }
-
-        public string[] Mutate { get; set; }
-
-        public string Solution { get; set; }
-
-        [JsonProperty(PropertyName = "target-framework")]
-        public string TargetFramework { get; set; }
-
-        public string Project { get; set; }
-
-        [JsonProperty(PropertyName = "coverage-analysis")]
-        public string CoverageAnalysis { get; set; }
-
-        [JsonProperty(PropertyName = "disable-bail")]
-        public bool DisableBail { get; set; }
-
-        [JsonProperty(PropertyName = "disable-mix-mutants")]
-        public bool DisableMixMutants { get; set; }
-
-        public Thresholds Thresholds { get; set; }
-
-        public string Verbosity { get; set; }
-
-        public string[] Reporters { get; set; }
-
-        public Since Since { get; set; }
-
-        public Baseline Baseline { get; set; }
-
-        [JsonProperty(PropertyName = "dashboard-url")]
-        public string DashboardUrl { get; set; }
-
-        [JsonProperty(PropertyName = "test-projects")]
-        public string[] TestProjects { get; set; }
-
-        [JsonProperty(PropertyName = "test-case-filter")]
-        public string TestCaseFilter { get; set; }
-
-        [JsonProperty(PropertyName = "ignore-mutations")]
-        public string[] IgnoreMutations { get; set; }
-
-        [JsonProperty(PropertyName = "ignore-methods")]
-        public string[] IgnoreMethods { get; set; }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
     }
 
-    public class Since
+    public class FileBasedInput : IExtraData
     {
-        public bool? Enabled { get; set; }
+        [JsonPropertyName("project-info")]
+        public ProjectInfo ProjectInfo { get; init; }
 
-        [JsonProperty(PropertyName = "ignore-changes-in")]
-        public string[] IgnoreChangesIn { get; set; }
+        [JsonPropertyName("concurrency")]
+        public int? Concurrency { get; init; }
 
-        [JsonProperty(PropertyName = "target")]
-        public string Target { get; set; }
+        [JsonPropertyName("mutation-level")]
+        public string MutationLevel { get; init; }
+
+        [JsonPropertyName("language-version")]
+        public string LanguageVersion { get; init; }
+
+        [JsonPropertyName("additional-timeout")]
+        public int? AdditionalTimeout { get; init; }
+
+        [JsonPropertyName("mutate")]
+        public string[] Mutate { get; init; }
+
+        [JsonPropertyName("solution")]
+        public string Solution { get; init; }
+
+        [JsonPropertyName("target-framework")]
+        public string TargetFramework { get; init; }
+
+        [JsonPropertyName("project")]
+        public string Project { get; init; }
+
+        [JsonPropertyName("coverage-analysis")]
+        public string CoverageAnalysis { get; init; }
+
+        [JsonPropertyName("disable-bail")]
+        public bool? DisableBail { get; init; }
+
+        [JsonPropertyName("disable-mix-mutants")]
+        public bool? DisableMixMutants { get; init; }
+
+        [JsonPropertyName("thresholds")]
+        public Thresholds Thresholds { get; init; }
+
+        [JsonPropertyName("verbosity")]
+        public string Verbosity { get; init; }
+
+        [JsonPropertyName("reporters")]
+        public string[] Reporters { get; init; }
+
+        [JsonPropertyName("since")]
+        public Since Since { get; init; }
+
+        [JsonPropertyName("baseline")]
+        public Baseline Baseline { get; init; }
+
+        [JsonPropertyName("dashboard-url")]
+        public string DashboardUrl { get; init; }
+
+        [JsonPropertyName("test-projects")]
+        public string[] TestProjects { get; init; }
+
+        [JsonPropertyName("test-case-filter")]
+        public string TestCaseFilter { get; init; }
+
+        [JsonPropertyName("ignore-mutations")]
+        public string[] IgnoreMutations { get; init; }
+
+        [JsonPropertyName("ignore-methods")]
+        public string[] IgnoreMethods { get; init; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
     }
 
-    public class Baseline
+    public class Since : IExtraData
     {
-        public bool? Enabled { get; set; }
+        [JsonPropertyName("enabled")]
+        public bool? Enabled { get; init; }
 
-        [JsonProperty(PropertyName = "provider")]
-        public string Provider { get; set; }
+        [JsonPropertyName("ignore-changes-in")]
+        public string[] IgnoreChangesIn { get; init; }
 
-        [JsonProperty(PropertyName = "azure-fileshare-url")]
-        public string AzureFileShareUrl { get; set; }
+        [JsonPropertyName("target")]
+        public string Target { get; init; }
 
-        [JsonProperty(PropertyName = "fallback-version")]
-        public string FallbackVersion { get; set; }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
     }
 
-    public class ProjectInfo
+    public class Baseline : IExtraData
     {
-        public string Name { get; set; }
-        public string Module { get; set; }
-        public string Version { get; set; }
+        [JsonPropertyName("enabled")]
+        public bool? Enabled { get; init; }
+
+        [JsonPropertyName("provider")]
+        public string Provider { get; init; }
+
+        [JsonPropertyName("azure-fileshare-url")]
+        public string AzureFileShareUrl { get; init; }
+
+        [JsonPropertyName("fallback-version")]
+        public string FallbackVersion { get; init; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
+    }
+
+    public class ProjectInfo : IExtraData
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; init; }
+
+        [JsonPropertyName("module")]
+        public string Module { get; init; }
+
+        [JsonPropertyName("version")]
+        public string Version { get; init; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
+    }
+
+    public class Thresholds : IExtraData
+    {
+        [JsonPropertyName("high")]
+        public int? High { get; init; }
+
+        [JsonPropertyName("low")]
+        public int? Low { get; init; }
+
+        [JsonPropertyName("break")]
+        public int? Break { get; init; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; init; }
     }
 }

--- a/src/Stryker.CLI/Stryker.CLI/JsonConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/JsonConfigHandler.cs
@@ -1,5 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
-using Newtonsoft.Json;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Options;
 
@@ -54,20 +59,52 @@ namespace Stryker.CLI
 
         private static FileBasedInput LoadJsonConfig(string configFilePath)
         {
-            var json = new StreamReader(configFilePath).ReadToEnd();
-
+            using var streamReader = new StreamReader(configFilePath);
+            var json = streamReader.ReadToEnd();
+            FileBasedInput input;
             try
             {
-                var settings = new JsonSerializerSettings()
+                var root = JsonSerializer.Deserialize<FileBasedInputOuter>(json);
+                if (root == null)
                 {
-                    MissingMemberHandling = MissingMemberHandling.Error
-                };
-
-                return JsonConvert.DeserializeObject<FileBasedInputOuter>(json, settings).Input;
+                    throw new InputException($"The config file at \"{configFilePath}\" could not be parsed.");
+                }
+                IReadOnlyCollection<string> extraKeys = root.ExtraData != null ? root.ExtraData.Keys : Array.Empty<string>();
+                if (extraKeys.Any())
+                {
+                    var description = extraKeys.Count == 1 ? $"\"{extraKeys.First()}\" was found" : $"several were found: {{ \"{string.Join("\", \"", extraKeys)}\" }}";
+                    throw new InputException($"The config file at \"{configFilePath}\" must contain a single \"stryker-config\" root object but {description}.");
+                }
+                input = root.Input ?? throw new InputException($"The config file at \"{configFilePath}\" must contain a single \"stryker-config\" root object.");
             }
-            catch (JsonSerializationException ex)
+            catch (JsonException jsonException)
             {
-                throw new InputException(@$"There was a problem with one of the json properties in your stryker config. Path ""{ex.Path}"", message: ""{ex.Message}""");
+                throw new InputException($"The config file at \"{configFilePath}\" could not be parsed.", jsonException.Message);
+            }
+
+            EnsureCorrectKeys(configFilePath, input, "stryker-config");
+
+            return input;
+        }
+
+        private static void EnsureCorrectKeys(string configFilePath, IExtraData @object, string namePath)
+        {
+            var properties = @object.GetType().GetProperties().Where(e => e.GetCustomAttribute<JsonPropertyNameAttribute>() != null).ToList();
+            foreach (var property in properties.Where(property => property.PropertyType.IsAssignableTo(typeof(IExtraData))))
+            {
+                var child = (IExtraData)property.GetValue(@object);
+                if (child != null)
+                {
+                    EnsureCorrectKeys(configFilePath, child, $"{namePath}.{property.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name}");
+                }
+            }
+            var extraData = @object.ExtraData;
+            IReadOnlyCollection<string> extraKeys = extraData != null ? extraData.Keys : Array.Empty<string>();
+            if (extraKeys.Any())
+            {
+                var allowedKeys = properties.Select(e => e.GetCustomAttribute<JsonPropertyNameAttribute>()!.Name).OrderBy(e => e);
+                var description = extraKeys.Count == 1 ? $"\"{extraKeys.First()}\" was found" : $"others were found (\"{string.Join("\", \"", extraKeys)}\")";
+                throw new InputException($"The allowed keys for the \"{namePath}\" object are {{ \"{string.Join("\", \"", allowedKeys)}\" }} but {description} in the config file at \"{configFilePath}\"");
             }
         }
     }

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -189,6 +189,29 @@
           "Microsoft.CodeAnalysis.Common": "[3.11.0]"
         }
       },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
       "Microsoft.DotNet.PlatformAbstractions": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -459,8 +482,32 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
@@ -749,6 +796,16 @@
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Diagnostics.TraceSource": {
@@ -1411,6 +1468,19 @@
           "System.Text.Encoding": "4.0.11"
         }
       },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "i88YCXpRTjCnoSQZtdlHkAOx4KNNik4hMy83n0+Ftlb7jvV6ZiZWMpnEZHhjBp6hQVh8gWd/iKNPzlPF7iyA2g==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
       "System.Threading": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1458,6 +1528,47 @@
           "System.Runtime": "4.1.0"
         }
       },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
       "stryker": {
         "type": "Project",
         "dependencies": {
@@ -1476,7 +1587,6 @@
           "Microsoft.TestPlatform.TranslationLayer": "16.10.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.113",
           "Mono.Cecil": "0.11.4",
-          "Newtonsoft.Json": "13.0.1",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.0.1",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Utils/BaselineMutantHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Utils/BaselineMutantHelperTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using Moq;
 using Shouldly;
 using Stryker.Core.Baseline.Utils;
 using Stryker.Core.Reporters.Json;
@@ -24,16 +20,19 @@ namespace Stryker.Core.UnitTest.Baseline.Utils
 
             var jsonMutant = new JsonMutant
             {
-                Location = new JsonMutantLocation(new JsonMutantPosition
+                Location = new JsonMutantLocation
                 {
-                    Column = 17,
-                    Line = 17
-                },
-                new JsonMutantPosition
-                {
-                    Column = 62,
-                    Line = 17
-                }),
+                    Start = new JsonMutantPosition
+                    {
+                        Column = 17,
+                        Line = 17
+                    },
+                    End = new JsonMutantPosition
+                    {
+                        Column = 62,
+                        Line = 17
+                    }
+                }
             };
 
             var target = new BaselineMutantHelper();
@@ -57,16 +56,19 @@ namespace Stryker.Core.UnitTest.Baseline.Utils
 
             var jsonMutant = new JsonMutant
             {
-                Location = new JsonMutantLocation(new JsonMutantPosition
+                Location = new JsonMutantLocation
                 {
-                    Column = 13,
-                    Line = 24
-                },
-                new JsonMutantPosition
-                {
-                    Column = 38,
-                    Line = 26
-                }),
+                    Start = new JsonMutantPosition
+                    {
+                        Column = 13,
+                        Line = 24
+                    },
+                    End = new JsonMutantPosition
+                    {
+                        Column = 38,
+                        Line = 26
+                    }
+                }
             };
 
             var target = new BaselineMutantHelper();
@@ -92,16 +94,19 @@ namespace Stryker.Core.UnitTest.Baseline.Utils
 
             var jsonMutant = new JsonMutant
             {
-                Location = new JsonMutantLocation(new JsonMutantPosition
+                Location = new JsonMutantLocation
                 {
-                    Column = 30,
-                    Line = 34
-                },
-                new JsonMutantPosition
-                {
-                    Column = 34,
-                    Line = 34
-                }),
+                    Start = new JsonMutantPosition
+                    {
+                        Column = 30,
+                        Line = 34
+                    },
+                    End = new JsonMutantPosition
+                    {
+                        Column = 34,
+                        Line = 34
+                    }
+                }
             };
 
             var target = new BaselineMutantHelper();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporter/MockJsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporter/MockJsonReport.cs
@@ -8,9 +8,11 @@ namespace Stryker.Core.UnitTest.Reporters
         public MockJsonReport(
             IDictionary<string, int> thresholds,
             IDictionary<string, JsonReportFileComponent> files
-        ) : base("1.3", thresholds, files)
+        )
         {
-
+            SchemaVersion = "1.3";
+            Thresholds = thresholds;
+            Files = files;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporter/MockJsonReportFileComponent.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporter/MockJsonReportFileComponent.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Stryker.Core.Reporters.Json;
 
 namespace Stryker.Core.UnitTest.Reporters
@@ -11,9 +9,11 @@ namespace Stryker.Core.UnitTest.Reporters
             string language,
             string source,
             ISet<JsonMutant> mutants
-        ) : base(language, source, mutants)
+        )
         {
-
+            Language = language;
+            Source = source;
+            Mutants = mutants;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/JsonReporterTests.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Shouldly;
-using Stryker.Core.Logging;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.Reporters.Json;
@@ -140,6 +139,10 @@ namespace Stryker.Core.UnitTest.Reporters
             reporter.OnAllMutantsTested(JsonReportTestHelper.CreateProjectWith().ToReadOnlyInputComponent());
             var reportPath = Path.Combine(options.OutputPath, "reports", $"mutation-report.json");
             mockFileSystem.FileExists(reportPath).ShouldBeTrue($"Path {reportPath} should exist but it does not.");
+            var fileContents = mockFileSystem.File.ReadAllText(reportPath);
+            fileContents.ShouldContain(@"""thresholds"": {");
+            fileContents.ShouldContain(@"""high"": 80");
+            fileContents.ShouldContain(@"""low"": 60");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -623,8 +623,32 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
+        }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
@@ -1109,6 +1133,16 @@
           "Microsoft.Win32.Registry": "5.0.0",
           "System.Configuration.ConfigurationManager": "5.0.0",
           "System.Security.Principal.Windows": "5.0.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Diagnostics.TraceSource": {
@@ -2033,6 +2067,25 @@
           "System.Threading.Tasks.Extensions": "4.3.0"
         }
       },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
+        }
+      },
       "System.Xml.XmlDocument": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2118,7 +2171,6 @@
           "Microsoft.TestPlatform.TranslationLayer": "16.10.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.113",
           "Mono.Cecil": "0.11.4",
-          "Newtonsoft.Json": "13.0.1",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.0.1",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Stryker.Core.Logging;
 using Stryker.Core.Options;
 using Stryker.Core.Reporters.Json;
@@ -48,9 +47,9 @@ namespace Stryker.Core.Baseline.Providers
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                var content = await response.Content.ReadAsStringAsync();
+                var stream = await response.Content.ReadAsStreamAsync();
 
-                return JsonConvert.DeserializeObject<JsonReport>(content);
+                return await stream.DeserializeJsonReportAsync();
             }
 
             _logger.LogDebug("No baseline was found at {0}", fileUrl);

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -48,7 +48,7 @@ namespace Stryker.Core.Clients
 
             try
             {
-                using var response = await _httpClient.PutAsJsonAsync(url, report);
+                using var response = await _httpClient.PutAsJsonAsync(url, report, JsonReportSerialization.Options);
                 var result = await response.Content.ReadFromJsonAsync<DashboardResult>();
                 return result?.Href;
             }
@@ -66,7 +66,7 @@ namespace Stryker.Core.Clients
             _logger.LogDebug("Sending GET to {DashboardUrl}", url);
             try
             {
-                var report = await _httpClient.GetFromJsonAsync<JsonReport>(url);
+                var report = await _httpClient.GetFromJsonAsync<JsonReport>(url, JsonReportSerialization.Options);
                 return report;
             }
             catch (Exception exception)

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonMutantLocation.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonMutantLocation.cs
@@ -1,18 +1,14 @@
 ﻿using Microsoft.CodeAnalysis;
-using Newtonsoft.Json;
 
 namespace Stryker.Core.Reporters.Json
 {
     public class JsonMutantLocation
     {
-        public JsonMutantPosition Start { get; }
-        public JsonMutantPosition End { get; }
+        public JsonMutantPosition Start { get; init; }
+        public JsonMutantPosition End { get; init; }
 
-        [JsonConstructor]
-        public JsonMutantLocation(JsonMutantPosition start, JsonMutantPosition end)
+        public JsonMutantLocation()
         {
-            Start = start;
-            End = end;
         }
 
         public JsonMutantLocation(FileLinePositionSpan location)

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReport.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 
@@ -14,10 +12,8 @@ namespace Stryker.Core.Reporters.Json
         public string ProjectRoot { get; init; }
         public IDictionary<string, JsonReportFileComponent> Files { get; init; } = new Dictionary<string, JsonReportFileComponent>();
 
-        [JsonConstructor]
         public JsonReport()
         {
-
         }
 
         private JsonReport(StrykerOptions options, IReadOnlyProjectComponent mutationReport)
@@ -30,36 +26,9 @@ namespace Stryker.Core.Reporters.Json
             Merge(Files, GenerateReportComponents(mutationReport));
         }
 
-        protected JsonReport(string schemaVersion, IDictionary<string, int> thresholds, IDictionary<string, JsonReportFileComponent> files)
-        {
-            SchemaVersion = schemaVersion ?? SchemaVersion;
-            Thresholds = thresholds ?? Thresholds;
-            Files = files ?? Files;
-        }
-
         public static JsonReport Build(StrykerOptions options, IReadOnlyProjectComponent mutationReport)
         {
             return new JsonReport(options, mutationReport);
-        }
-
-        public string ToJson()
-        {
-            var json = JsonConvert.SerializeObject(this, new JsonSerializerSettings
-            {
-                ContractResolver = new DefaultContractResolver
-                {
-                    NamingStrategy = new CamelCaseNamingStrategy()
-                },
-                Formatting = Formatting.Indented,
-                NullValueHandling = NullValueHandling.Ignore
-            });
-
-            return json;
-        }
-
-        public string ToJsonHtmlSafe()
-        {
-            return ToJson().Replace("<", "<\" + \"");
         }
 
         private IDictionary<string, JsonReportFileComponent> GenerateReportComponents(IReadOnlyProjectComponent component)

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportFileComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportFileComponent.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Stryker.Core.Logging;
 using Stryker.Core.ProjectComponents;
 using System.Collections.Generic;
@@ -8,16 +7,12 @@ namespace Stryker.Core.Reporters.Json
 {
     public class JsonReportFileComponent
     {
-        public string Language { get; }
-        public string Source { get; }
-        public ISet<JsonMutant> Mutants { get; }
+        public string Language { get; init; }
+        public string Source { get; init; }
+        public ISet<JsonMutant> Mutants { get; init; }
 
-        [JsonConstructor]
-        protected JsonReportFileComponent(string language, string source, ISet<JsonMutant> mutants)
+        public JsonReportFileComponent()
         {
-            Language = language;
-            Source = source;
-            Mutants = mutants;
         }
 
         public JsonReportFileComponent(ReadOnlyFileLeaf file, ILogger logger = null)

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportSerialization.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportSerialization.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Stryker.Core.Reporters.Json
+{
+    internal static class JsonReportSerialization
+    {
+        public static readonly JsonSerializerOptions Options = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+        };
+
+        public static async Task<JsonReport> DeserializeJsonReportAsync(this Stream stream)
+        {
+            return await JsonSerializer.DeserializeAsync<JsonReport>(stream, Options);
+        }
+
+        public static async Task SerializeAsync(this JsonReport report, Stream stream)
+        {
+            await JsonSerializer.SerializeAsync(stream, report, Options);
+        }
+
+        public static async Task<byte[]> SerializeAsync(this JsonReport report)
+        {
+            await using var stream = new MemoryStream();
+            await report.SerializeAsync(stream);
+            return stream.ToArray();
+        }
+
+        public static void Serialize(this JsonReport report, Stream stream)
+        {
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = Options.WriteIndented });
+            JsonSerializer.Serialize(writer, report, Options);
+        }
+
+        public static string ToJson(this JsonReport report)
+        {
+            return JsonSerializer.Serialize(report, Options);
+        }
+
+        public static string ToJsonHtmlSafe(this JsonReport report)
+        {
+            return report.ToJson().Replace("<", "<\" + \"");
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReporter.cs
@@ -28,7 +28,7 @@ namespace Stryker.Core.Reporters.Json
 
             var reportPath = Path.Combine(_options.OutputPath, "reports", "mutation-report.json");
 
-            WriteReportToJsonFile(reportPath, mutationReport.ToJson());
+            WriteReportToJsonFile(reportPath, mutationReport);
 
             var clickablePath = reportPath.Replace("\\", "/");
             clickablePath = clickablePath.StartsWith("/") ? clickablePath : $"/{clickablePath}";
@@ -36,12 +36,12 @@ namespace Stryker.Core.Reporters.Json
             _consoleWriter.Write(Output.Green($"\nYour json report has been generated at: \n file://{clickablePath} \n"));
         }
 
-        private void WriteReportToJsonFile(string filePath, string mutationReport)
+        private void WriteReportToJsonFile(string filePath, JsonReport mutationReport)
         {
             _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-            using (var file = _fileSystem.File.CreateText(filePath))
+            using (var file = _fileSystem.File.Create(filePath))
             {
-                file.WriteLine(mutationReport);
+                mutationReport.Serialize(file);
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftTestPlatform)" /> 				<!-- From Directory.Build.props -->
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />

--- a/src/Stryker.Core/Stryker.Core/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core/packages.lock.json
@@ -152,12 +152,6 @@
         "resolved": "0.11.4",
         "contentHash": "IC1h5g0NeJGHIUgzM1P82ld57knhP0IcQfrYITDPXlNpMYGUrsG5TxuaWTjaeqDNQMBDNZkB8L0rBnwsY6JHuQ=="
       },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.1, )",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
       "Serilog": {
         "type": "Direct",
         "requested": "[2.10.0, )",
@@ -320,6 +314,29 @@
           "System.Runtime.CompilerServices.Unsafe": "5.0.0",
           "System.Text.Encoding.CodePages": "4.5.1",
           "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Reflection.Primitives": "4.0.1",
+          "System.Reflection.TypeExtensions": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Threading": "4.0.11"
         }
       },
       "Microsoft.DotNet.PlatformAbstractions": {
@@ -525,6 +542,35 @@
         "contentHash": "7jnbRU+L08FXKMxqUflxEXtVymWvNOrS8yHgu9s6EM8Anr6T/wIX4nZ08j/u3Asz+tCufp3YVwFSEvFTPYmBPA==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "9.0.1",
+        "contentHash": "U82mHQSKaIk+lpSVCbWYKNavmNH1i5xrExDEquU1i6I5pV6UMOqRnJRSlKO3cMPfcpp0RgDY+8jUXHdQ4IfXvw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Dynamic.Runtime": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.ObjectModel": "4.0.12",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Serialization.Primitives": "4.1.1",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11",
+          "System.Xml.XDocument": "4.0.11"
         }
       },
       "NuGet.Frameworks": {
@@ -764,6 +810,16 @@
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "xBfJ8pnd4C17dWaC9FM6aShzbJcRNMChUMD42I6772KGGrqaFdumwhn9OdM68erj1ueNo3xdQ1EwiFjK5k8p0g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "Microsoft.NETCore.Targets": "1.0.1",
+          "System.Runtime": "4.1.0"
         }
       },
       "System.Diagnostics.TraceSource": {
@@ -1413,6 +1469,19 @@
           "System.Text.Encoding": "4.0.11"
         }
       },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.1.0",
+        "contentHash": "i88YCXpRTjCnoSQZtdlHkAOx4KNNik4hMy83n0+Ftlb7jvV6ZiZWMpnEZHhjBp6hQVh8gWd/iKNPzlPF7iyA2g==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11"
+        }
+      },
       "System.Threading": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1458,6 +1527,47 @@
           "Microsoft.NETCore.Platforms": "1.0.1",
           "Microsoft.NETCore.Targets": "1.0.1",
           "System.Runtime": "4.1.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.IO.FileSystem": "4.0.1",
+          "System.IO.FileSystem.Primitives": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.InteropServices": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Text.Encoding.Extensions": "4.0.11",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Extensions": "4.0.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "Mk2mKmPi0nWaoiYeotq1dgeNK1fqWh61+EK+w4Wu8SWuTYLzpUnschb59bJtGywaPq7SmTuPf44wrXRwbIrukg==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Text.Encoding": "4.0.11",
+          "System.Threading": "4.0.11",
+          "System.Xml.ReaderWriter": "4.0.11"
         }
       },
       "stryker.datacollector": {


### PR DESCRIPTION
Instead, use System.Text.Json everywhere.

### JSON Configuration File

Since there's [no equivalent][1] to `MissingMemberHandling` with `System.Text.Json`, the error messages in case of erroneous keys in the JSON configuration file have been improved. For example, if you have a typo in the `enabled` key you would get this error:

> The allowed keys for the "stryker-config.since" object are { "enabled", "ignore-changes-in", "target" } but "enable" was found in the config file at "[…]/tests/stryker-config.json"

Those better error messages also required to have a `JsonPropertyName` attribute on _all_ the properties. This is probably a good thing anyway since it makes the code more _greppable_.

### Newtonsoft.Json transitive dependency

Unfortunately, `Newtonsoft.Json` is still there transitively (through Buildalyzer/3.2.2 → Microsoft.Extensions.DependencyModel/2.1.0 → Newtonsoft.Json/9.0.1) but there's nothing we can do about it for now, see https://github.com/microsoft/vstest/issues/2488#issuecomment-932036883 for a full explanation.

[1]: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to#missingmemberhandling