### PR TITLE
Fix finding the project under test

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -48,7 +48,6 @@ namespace Stryker.Core.Initialisation
             var projectInfo = new ProjectInfo(_fileSystem);
             // Determine test projects
             var testProjectFiles = new List<string>();
-            string projectUnderTest = null;
             if (options.TestProjects != null && options.TestProjects.Any())
             {
                 testProjectFiles = options.TestProjects.Select(FindTestProject).ToList();
@@ -67,14 +66,7 @@ namespace Stryker.Core.Initialisation
             projectInfo.TestProjectAnalyzerResults = testProjectAnalyzerResults;
 
             // Determine project under test
-            if (options.TestProjects != null && options.TestProjects.Any())
-            {
-                projectUnderTest = FindProjectFile(options.BasePath);
-            }
-            else
-            {
-                projectUnderTest = FindProjectUnderTest(projectInfo.TestProjectAnalyzerResults, options.ProjectUnderTestName);
-            }
+            var projectUnderTest = FindProjectUnderTest(projectInfo.TestProjectAnalyzerResults, options.ProjectUnderTestName);
 
             _logger.LogInformation("The project {0} will be mutated.", projectUnderTest);
 


### PR DESCRIPTION
If the test projects are defined in the stryker-config.json file (under stryker-config.test-projects), it becomes impossible to find the project under test unless it is in the current working directory since `FindProjectFile` is used instead of `FindProjectUnderTest`.

It used to work before #1039 where a behavioural change was introduced. @richardwerkman do you remember what was the intention behind that change?