### PR TITLE
Disable copying to clipboard when using Verify

### DIFF
--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
@@ -48,6 +48,9 @@ namespace Stryker.Core.TestRunners.VsTest
                     // don't launch a diffing tool GUI on each failed test.
                     // See https://github.com/VerifyTests/DiffEngine/blob/6.6.1/src/DiffEngine/DisabledChecker.cs#L8
                     ["DiffEngine_Disabled"] = "true",
+                    // Disable copying the command to accept the received version to the clipboard when using Verify
+                    // See https://github.com/VerifyTests/Verify/blob/main/docs/clipboard.md
+                    ["Verify_DisableClipboard"] = "true",
                 },
             };
             _currentProcess = new Process { StartInfo = processInfo, EnableRaisingEvents = true };


### PR DESCRIPTION
Once again, approval testing workflow (accepting changes by pasting what was put in the clipboard) doesn't mix well with mutation testing.