### PR TITLE
fix: Dashboard baseline project name and version are not set

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -59,7 +59,11 @@ namespace Stryker.Core.UnitTest.Initialisation
                 testRunnerMock.Object,
                 assemblyReferenceResolverMock.Object);
 
-            var options = new StrykerOptions();
+            var options = new StrykerOptions
+            {
+                ProjectName = "TheProjectName",
+                ProjectVersion = "TheProjectVersion"
+            };
 
             var result = target.Initialize(options);
 
@@ -104,7 +108,11 @@ namespace Stryker.Core.UnitTest.Initialisation
                 initialTestProcessMock.Object,
                 testRunnerMock.Object,
                 assemblyReferenceResolverMock.Object);
-            var options = new StrykerOptions();
+            var options = new StrykerOptions
+            {
+                ProjectName = "TheProjectName",
+                ProjectVersion = "TheProjectVersion"
+            };
 
             target.Initialize(options);
             Assert.Throws<InputException>(() => target.InitialTest(options));

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -61,7 +61,7 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var options = new StrykerOptions();
 
-            var result = target.Initialize(options, dashboardReporter: null);
+            var result = target.Initialize(options);
 
             inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);
         }
@@ -106,7 +106,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 assemblyReferenceResolverMock.Object);
             var options = new StrykerOptions();
 
-            target.Initialize(options, dashboardReporter: null);
+            target.Initialize(options);
             Assert.Throws<InputException>(() => target.InitialTest(options));
 
             inputFileResolverMock.Verify(x => x.ResolveInput(It.IsAny<StrykerOptions>()), Times.Once);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -51,7 +51,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var options = new StrykerOptions();
             var target = new ProjectMutator(_initialisationProcessProviderMock.Object, _mutationTestProcessProviderMock.Object);
 
-            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>(), It.IsAny<DashboardReporter>())).Returns(_mutationTestInput);
+            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>())).Returns(_mutationTestInput);
             _initialisationProcessMock.Setup(x => x.InitialTest(options))
                 .Returns(new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(500)));
             // act

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
@@ -63,7 +63,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
             var target = new ProjectOrchestrator(_buildalyzerProviderMock.Object, _projectMutatorMock.Object);
 
-            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>(), It.IsAny<DashboardReporter>())).Returns(_mutationTestInput);
+            _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>())).Returns(_mutationTestInput);
             _initialisationProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>())).Returns(new InitialTestRun(new TestRunResult(true), new TimeoutValueCalculator(5)));
             _buildalyzerProviderMock.Setup(x => x.Provide(It.IsAny<string>(), It.IsAny<AnalyzerManagerOptions>())).Returns(buildalyzerAnalyzerManagerMock.Object);
             // The analyzer finds two projects

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -45,6 +45,7 @@ namespace Stryker.Core.Clients
             try
             {
                 using var response = await _httpClient.PutAsJsonAsync(url, report);
+                response.EnsureSuccessStatusCode();
                 var result = await response.Content.ReadFromJsonAsync<DashboardResult>();
                 return result?.Href;
             }

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -11,7 +11,6 @@ namespace Stryker.Core.Clients
 {
     public interface IDashboardClient
     {
-        string ProjectName { get; set; }
         Task<string> PublishReport(JsonReport json, string version);
         Task<JsonReport> PullReport(string version);
     }
@@ -35,10 +34,7 @@ namespace Stryker.Core.Clients
                 _httpClient = new HttpClient();
                 _httpClient.DefaultRequestHeaders.Add("X-Api-Key", _options.DashboardApiKey);
             }
-            ProjectName = _options.ProjectName;
         }
-
-        public string ProjectName { get; set; }
 
         public async Task<string> PublishReport(JsonReport report, string version)
         {
@@ -78,7 +74,7 @@ namespace Stryker.Core.Clients
 
         private Uri GetUrl(string version)
         {
-            var url = new Uri($"{_options.DashboardUrl}/api/reports/{ProjectName}/{version}");
+            var url = new Uri($"{_options.DashboardUrl}/api/reports/{_options.ProjectName}/{version}");
 
             if (_options.ModuleName != null)
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
@@ -27,8 +27,7 @@ namespace Stryker.Core.Initialisation
             // get a new instance of InitialisationProcess for each project
             var initialisationProcess = _initialisationProcessProvider.Provide();
             // initialize
-            var dashboardReporter = GetDashboardReporter(reporters);
-            var input = initialisationProcess.Initialize(options, dashboardReporter);
+            var input = initialisationProcess.Initialize(options);
 
             var process = _mutationTestProcessProvider.Provide(
                 mutationTestInput: input,
@@ -43,16 +42,6 @@ namespace Stryker.Core.Initialisation
             process.Mutate();
 
             return process;
-        }
-
-        private static DashboardReporter GetDashboardReporter(IReporter reporters)
-        {
-            if (reporters is BroadcastReporter broadcastReporter)
-            {
-                return broadcastReporter.Reporters.OfType<DashboardReporter>().FirstOrDefault();
-            }
-
-            return reporters as DashboardReporter;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -39,14 +39,12 @@ namespace Stryker.Core.Options
 
         public string DashboardUrl { get; init; }
         public string DashboardApiKey { get; init; }
-        public string ProjectName { get; init; }
 
         public bool Since { get; init; }
         public string SinceTarget { get; init; }
         public IEnumerable<FilePattern> DiffIgnoreChanges { get; init; } = Enumerable.Empty<FilePattern>();
 
         public string FallbackVersion { get; init; }
-        public string ProjectVersion { get; init; }
         public string ModuleName { get; init; }
 
         public IEnumerable<FilePattern> Mutate { get; init; } = new[] { FilePattern.Parse("**/*") };
@@ -56,8 +54,40 @@ namespace Stryker.Core.Options
 
         public OptimizationModes OptimizationMode { get; init; }
 
+        private string _projectName;
+        public string ProjectName
+        {
+            get => _projectName;
+            set
+            {
+                _projectName = value;
+                if (_parentOptions is not null)
+                {
+                    _parentOptions.ProjectName = value;
+                }
+            }
+        }
+
+        private string _projectVersion;
+        public string ProjectVersion
+        {
+            get => _projectVersion;
+            set
+            {
+                _projectVersion = value;
+                if (_parentOptions is not null)
+                {
+                    _parentOptions.ProjectVersion = value;
+                }
+            }
+        }
+
+        // Keep a reference on the parent instance in order to flow get/set properties (ProjectName and ProjectVersion) up to the parent
+        private StrykerOptions _parentOptions;
+
         public StrykerOptions Copy(string basePath, string projectUnderTest, IEnumerable<string> testProjects) => new()
         {
+            _parentOptions = this,
             AdditionalTimeout = AdditionalTimeout,
             AzureFileStorageSas = AzureFileStorageSas,
             AzureFileStorageUrl = AzureFileStorageUrl,

--- a/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
@@ -12,7 +12,7 @@ using System.IO;
 
 namespace Stryker.Core.Reporters
 {
-    public partial class DashboardReporter : IReporter
+    public class DashboardReporter : IReporter
     {
         private readonly StrykerOptions _options;
         private readonly IDashboardClient _dashboardClient;
@@ -25,22 +25,13 @@ namespace Stryker.Core.Reporters
             _dashboardClient = dashboardClient ?? new DashboardClient(options);
             _logger = logger ?? ApplicationLogging.LoggerFactory.CreateLogger<DashboardReporter>();
             _consoleWriter = consoleWriter ?? Console.Out;
-            ProjectVersion = _options.ProjectVersion;
         }
-
-        public string ProjectName
-        {
-            get => _dashboardClient.ProjectName;
-            set => _dashboardClient.ProjectName = value;
-        }
-
-        public string ProjectVersion { get; set; }
 
         public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent)
         {
             var mutationReport = JsonReport.Build(_options, reportComponent);
 
-            var reportUrl = _dashboardClient.PublishReport(mutationReport, ProjectVersion).Result;
+            var reportUrl = _dashboardClient.PublishReport(mutationReport, _options.ProjectVersion).Result;
 
             if (reportUrl != null)
             {

--- a/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportFileComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/JsonReporter/JsonReportFileComponent.cs
@@ -33,11 +33,11 @@ namespace Stryker.Core.Reporters.Json
                 var jsonMutant = new JsonMutant
                 {
                     Id = mutant.Id.ToString(),
-                    MutatorName = mutant.Mutation.DisplayName,
+                    MutatorName = mutant.Mutation.DisplayName ?? "",
                     Replacement = mutant.Mutation.ReplacementNode.ToFullString(),
                     Location = new JsonMutantLocation(mutant.Mutation.OriginalNode.GetLocation().GetMappedLineSpan()),
                     Status = mutant.ResultStatus.ToString(),
-                    Description = mutant.Mutation.Description
+                    Description = mutant.Mutation.Description ?? ""
                 };
 
                 if (!Mutants.Add(jsonMutant))


### PR DESCRIPTION
The automatic detection of project name and version introduced in https://github.com/stryker-mutator/stryker-net/pull/1663 broke the DashboardBaselineProvider because the project name would not be set and thus the report would be sent to an invalid URL: `/api/reports//version`

This commit addresses this issue by setting the project name and version on the StrykerOptions rather than on the DashboardClient and DashboardReporter (like it was originally done in https://github.com/stryker-mutator/stryker-net/pull/1532).