### PR TITLE
fix(Block mutator): Prevent false positives from block mutations

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Shouldly;
+using Stryker.Core.Mutants;
+using Stryker.Core.Mutators;
+using Xunit;
+
+namespace Stryker.Core.UnitTest.Mutators
+{
+    public class BlockMutatorTests
+    {
+        [Fact]
+        private void ShouldMutateNonEmptyConstructorOnClass()
+        {
+            var source = @"
+class Program
+{
+    int doesNotNeedToBeInitialized;
+
+    Program()
+    {
+        this.doesNotNeedToBeInitialized = 42;
+    }
+}";
+
+            var mutation = GetMutations(source).ShouldHaveSingleItem();
+            mutation.ReplacementNode.ChildNodes().ShouldBeEmpty();
+        }
+
+        [Fact]
+        private void ShouldNotMutateStructConstructorAssignments()
+        {
+            var source = @"
+struct Program
+{
+    int mustBeInitialized;
+    bool alsoThisMustBeInitialized;
+
+    Program(int value)
+    {
+        this.mustBeInitialized = value;
+
+        if (value == 0)
+        {
+            this.alsoThisMustBeInitialized = true;
+        }
+        else
+        {
+            this.alsoThisMustBeInitialized = false;
+        }
+    }
+}";
+
+            GetMutations(source).ShouldBeEmpty();
+        }
+
+        [Fact]
+        private void ShouldMutateStructConstructorNonAssignmentsAtRoot()
+        {
+            var source = @"
+struct Program
+{
+    Program(int value)
+    {
+        throw new Exception();
+    }
+}";
+
+            GetMutations(source).Count().ShouldBe(1);
+        }
+
+        [Fact]
+        private void ShouldMutateStructConstructorNonAssignmentChild()
+        {
+            var source = @"
+struct Program
+{
+    int mustBeInitialized;
+
+    Program(int value)
+    {
+        if (value == 0)
+        {
+            throw new Exception();
+        }
+
+        this.mustBeInitialized = value;
+    }
+}";
+
+            GetMutations(source).Count().ShouldBe(1);
+        }
+
+        [Fact]
+        private void ShouldMutateNonVoidReturnsAsDefaultWhenContainsReturns()
+        {
+            var source = @"
+class Program
+{
+    int Method(bool input)
+    {
+        if (input)
+        {
+            input = false;
+        }
+
+        if (input)
+        {
+            return 0;
+        }
+
+        return 1;
+    }
+}";
+
+            var mutations = GetMutations(source).ToList();
+            mutations.Count.ShouldBe(3);
+
+            AssertDefaultReturn(mutations[0]); // Whole method
+            mutations[1].ReplacementNode.ChildNodes().ShouldBeEmpty(); // First if
+            AssertDefaultReturn(mutations[2]); // Second if
+        }
+
+        [Fact]
+        private void ShouldMutateVoidReturnsAsEmptyInMethod()
+        {
+            var source = @"
+class Program
+{
+    void Method(bool input)
+    {
+        if (input)
+        {
+            return;
+        }
+    }
+}";
+
+            GetMutations(source).ShouldAllBe(mutation => !mutation.ReplacementNode.ChildNodes().Any());
+        }
+
+        [Fact]
+        private void ShouldMutateVoidReturnsAsEmptyInLocalFunction()
+        {
+            var source = @"
+class Program
+{
+    int Method(bool input)
+    {
+        void LocalFunction()
+        {
+            return;
+        }
+
+        return 42;
+    }
+}";
+
+            var mutation = GetMutations(source)
+                .Where(mutation => mutation.OriginalNode.Parent is LocalFunctionStatementSyntax
+                {
+                    Identifier: { Text: "LocalFunction" }
+                })
+                .ShouldHaveSingleItem();
+            mutation.ReplacementNode.ChildNodes().ShouldBeEmpty();
+        }
+
+        [Fact]
+        private void ShouldNotMutateAlreadyEmptyBlocks()
+        {
+            // E.g. empty constructors bodies and method overrides are totally valid
+            // and produce false positives if mutated.
+
+            var source = @"
+class Program
+{
+    private Program()
+    {
+        // Nothing to do
+    }
+
+    void Method()
+    {
+        // Nothing to do
+    }
+}";
+            GetMutations(source).ShouldBeEmpty();
+        }
+
+        private static IEnumerable<Mutation> GetMutations(string source)
+        {
+            var statements = CSharpSyntaxTree
+                .ParseText(source)
+                .GetRoot()
+                .DescendantNodes()
+                .OfType<BlockSyntax>();
+
+            var target = new BlockMutator();
+            return statements.SelectMany(target.ApplyMutations);
+        }
+
+        private static void AssertDefaultReturn(Mutation mutation)
+        {
+            var block = mutation.ReplacementNode.ShouldBeOfType<BlockSyntax>();
+            var returnStatement = block.Statements.OfType<ReturnStatementSyntax>().ShouldHaveSingleItem();
+            returnStatement.Expression?.Kind().ShouldBe(SyntaxKind.DefaultLiteralExpression);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -217,6 +217,26 @@ class Program
             GetMutations(source).ShouldBeEmpty();
         }
 
+        [Fact]
+        private void ShouldNotMutateInfiniteWhileLoops()
+        {
+            var source = @"
+class Program
+{
+    void Method()
+    {
+        while (true)
+        {
+            // Should not be mutated or it will always time out
+            break; // Just to make this more realistic...
+        }
+    }
+}";
+            GetMutations(source)
+                .Where(mutation => mutation.OriginalNode.Parent is WhileStatementSyntax)
+                .ShouldBeEmpty();
+        }
+
         private static IEnumerable<Mutation> GetMutations(string source)
         {
             var statements = CSharpSyntaxTree

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -144,9 +144,11 @@ class Program
             var mutations = GetMutations(source).ToList();
             mutations.Count.ShouldBe(3);
 
-            AssertDefaultReturn(mutations[0]); // Whole method
-            mutations[1].ReplacementNode.ChildNodes().ShouldBeEmpty(); // First if
-            AssertDefaultReturn(mutations[2]); // Second if
+            var (methodBlock, firstIfBlock, secondIfBlock) = (mutations[0], mutations[1], mutations[2]);
+
+            AssertDefaultReturn(methodBlock);
+            firstIfBlock.ReplacementNode.ChildNodes().ShouldBeEmpty();
+            AssertDefaultReturn(secondIfBlock);
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -57,6 +57,32 @@ struct Program
         }
 
         [Fact]
+        private void ShouldMutateLocalFunctionsInStructConstructors()
+        {
+            var source = @"
+struct Program
+{
+    int mustBeInitialized;
+
+    Program(int value)
+    {
+        int CalculateValue()
+        {
+            int value;
+            value = 42; // Try to fool with this assignment
+            return value;
+        }
+
+        this.mustBeInitialized = CalculateValue();
+    }
+}";
+
+            GetMutations(source).Count().ShouldBe(
+                1,
+                "Should mutate the local function and only the local function");
+        }
+
+        [Fact]
         private void ShouldMutateStructConstructorNonAssignmentsAtRoot()
         {
             var source = @"

--- a/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
@@ -15,7 +15,9 @@ namespace Stryker.Core.Mutators
 
         public override IEnumerable<Mutation> ApplyMutations(BlockSyntax node)
         {
-            if (!node.ChildNodes().Any() || (IsInStructConstructor(node) && ContainsAssignments(node)))
+            if (IsEmptyBlock(node) ||
+                IsInfiniteWhileLoop(node) ||
+                (IsInStructConstructor(node) && ContainsAssignments(node)))
             {
                 yield break;
             }
@@ -41,6 +43,12 @@ namespace Stryker.Core.Mutators
                 };
             }
         }
+
+        private static bool IsEmptyBlock(BlockSyntax node) => !node.ChildNodes().Any();
+
+        private static bool IsInfiniteWhileLoop(BlockSyntax node) =>
+            node.Parent is WhileStatementSyntax { Condition: LiteralExpressionSyntax cond } &&
+            cond.Kind() == SyntaxKind.TrueLiteralExpression;
 
         private static bool ContainsReturns(BlockSyntax node) => node
             .ChildNodes()


### PR DESCRIPTION
* Don't mutate empty blocks
* Don't mutate blocks in struct constructors containing assignments
* Don't mutate infinite while loops (thanks for the suggestion @Pentiva)
* Correctly deduce the first return-typed ancestor
* Only return `default` if the block contains a return statement
* Add tests

Only thing I'm not happy with is the struct constructor logic, which treats *any* assignment as a potential member assignment. Also, if some of the helper functions I wrote already exist, or should be elsewhere, please comment on that, I'm not too familiar with the code base.

Fixes issues (false positives) and warnings I faced while [updating my project to 1.0](https://github.com/sbergen/Responsible/runs/4059889905?check_suite_focus=true).