### PR TITLE
fix(Ignore mutations): Ignoring statement mutations is now possible

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
@@ -141,5 +141,21 @@ namespace Stryker.Core.UnitTest.Options.Inputs
             linqExpressions.First().ShouldBe(LinqExpression.Max);
             linqExpressions.Last().ShouldBe(LinqExpression.Sum);
         }
+
+        /// <summary>
+        /// This test is needed as other mutators also have "statement" in their name. It should pick the right mutator.
+        /// </summary>
+        [Fact]
+        public void ShouldIgnoreStatementMutator()
+        {
+            var target = new IgnoreMutationsInput
+            {
+                SuppliedInput = new[] { "statement" }
+            };
+
+            var mutators = target.Validate();
+
+            mutators.ShouldHaveSingleItem().ShouldBe(Mutator.Statement);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
@@ -26,7 +26,7 @@ namespace Stryker.Core.UnitTest.Options.Inputs
 
             var ex = Should.Throw<InputException>(() => target.Validate());
 
-            ex.Message.ShouldBe($"Invalid excluded mutation (gibberish). The excluded mutations options are [Arithmetic, Block, Equality, Boolean, Logical, Assignment, Unary, Update, Checked, Linq, String, Statement, Bitwise, Initializer, Regex]");
+            ex.Message.ShouldBe($"Invalid excluded mutation (gibberish). The excluded mutations options are [Statement, Arithmetic, Block, Equality, Boolean, Logical, Assignment, Unary, Update, Checked, Linq, String, Bitwise, Initializer, Regex]");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Mutators/Mutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/Mutator.cs
@@ -7,6 +7,8 @@ namespace Stryker.Core.Mutators
 {
     public enum Mutator
     {
+        [Description("Statements")]
+        Statement,
         [Description("Arithmetic operators")]
         Arithmetic,
         [Description("Block statements")]
@@ -29,8 +31,6 @@ namespace Stryker.Core.Mutators
         Linq,
         [Description("String literals")]
         String,
-        [Description("Statements")]
-        Statement,
         [Description("Bitwise operators")]
         Bitwise,
         [Description("Array initializer")]


### PR DESCRIPTION
Flip statement mutation to first in the enum so it will be picked first in case the statement mutator is chosen

closes #1762 