### PR TITLE
Fix disable all issue

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -70,7 +70,7 @@ namespace Stryker.CLI
             {
                 return app.Execute(args);
             }
-            catch (CommandParsingException ex)  
+            catch (CommandParsingException ex)
             {
                 Console.Error.WriteLine(ex.Message);
 

--- a/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
+++ b/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs
@@ -70,7 +70,7 @@ namespace Stryker.CLI
             {
                 return app.Execute(args);
             }
-            catch (CommandParsingException ex)
+            catch (CommandParsingException ex)  
             {
                 Console.Error.WriteLine(ex.Message);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -733,7 +733,7 @@ if(StrykerNamespace.MutantControl.IsActive(2)){    x*=2;
         {
             string source = @"public void SomeMethod() {
 	var x = 0;
-// Stryker disable Update,Statement: comment
+// Stryker disable Update , Statement : comment
 	x++;
 // Stryker restore all
 	x/=2;
@@ -872,6 +872,7 @@ static Mutator_Flag_MutatedStatics()
 			if(StrykerNamespace.MutantControl.IsActive(4)){;}else{
 				request.Headers.TryAddWithoutValidation((StrykerNamespace.MutantControl.IsActive(5)?"""":""Date""), date);
 			}
+            return default;
 		}, ensureSuccessStatusCode: (StrykerNamespace.MutantControl.IsActive(6)?true:false));
 	}
 }";
@@ -1101,7 +1102,7 @@ string Value {get => Out(out var x)? ""empty"": """";}
 static TestClass(){}}";
 
             var expected = @"class Test {
-string Value {get {if(StrykerNamespace.MutantControl.IsActive(0)){return!(Out(out var x))? ""empty"": """";}else{return Out(out var x)? (StrykerNamespace.MutantControl.IsActive(1)?"""":""empty""): (StrykerNamespace.MutantControl.IsActive(2)?""Stryker was here!"":"""");}}}
+string Value {get {if(StrykerNamespace.MutantControl.IsActive(0)){return!(Out(out var x))? ""empty"": """";}else{return Out(out var x)? (StrykerNamespace.MutantControl.IsActive(1)?"""":""empty""): (StrykerNamespace.MutantControl.IsActive(2)?""Stryker was here!"":"""");}return default(string);}}
 static TestClass(){using(new StrykerNamespace.MutantContext()){}}}";
 
             ShouldMutateSourceToExpected(source, expected);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -625,6 +625,46 @@ if(StrykerNamespace.MutantControl.IsActive(5)){    x*=2;
         }
 
         [Fact]
+        public void ShouldNotMutateIfDisabledByCommentAtMethodLevel()
+        {
+            string source = @"
+// Stryker disable all : testing
+public void SomeMethod()
+ {
+	var x = 0;
+	x++;
+	x/=2;
+}";
+            string expected = @"public void SomeMethod() {
+	var x = 0;
+	 x++;
+	 x/=2;
+	}
+}";
+
+            ShouldMutateSourceToExpected(source, expected);
+            source = @"public void SomeMethod()
+{
+	var x = 0;
+	{
+	// Stryker disable once all
+	  x++;
+	}
+	x/=2;
+}";
+            expected = @"public void SomeMethod() {
+	var x = 0;
+	{
+	// Stryker disable once all
+	  x++;
+	}
+if(StrykerNamespace.MutantControl.IsActive(5)){    x*=2;
+}else{    x/=2;
+}}";
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
         public void ShouldNotMutateOneLineIfDisabledByComment()
         {
             string source = @"public void SomeMethod() {
@@ -635,7 +675,7 @@ if(StrykerNamespace.MutantControl.IsActive(5)){    x*=2;
 }";
             string expected = @"public void SomeMethod() {
 	var x = 0;
-// Stryker disable all
+// Stryker disable once all
 	 x++;
 if(StrykerNamespace.MutantControl.IsActive(2)){    x*=2;
 }else{    x/=2;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
@@ -126,10 +126,22 @@ namespace Stryker.Core.UnitTest.Mutants
         }
 
         [Theory]
-        [InlineData("public int X { get => 1;}", "public int X { get {return 1;}}")]
-        [InlineData("public int X { get => 1; set { }}", "public int X { get {return 1;} set { }}")]
-        [InlineData("public int X { set => value++;}", "public int X { set { value++;}}")]
+        [InlineData("() => Call(2)","() => {return Call(2);}")]
+        [InlineData("(x) => Call(2)","(x) => {return Call(2);}")]
+        [InlineData("x => Call(2)","x => {return Call(2);}")]
+        [InlineData("(out x) => Call(out x)","(out x) => {return Call(out x);}")]
+        [InlineData("(x, y) => Call(2)","(x, y) => {return Call(2);}")]
         public void ShouldConvertAccessorExpressionBodyBackAndForth(string original, string injected)
+        {
+            var source = $"class Test {{ private void Any(){{ Register({original});}}}}";
+            var expectedCode = $"class Test {{ private void Any(){{ Register({injected});}}}}";
+
+            CheckMutantPlacerProperlyPlaceAndRemoveHelpers<AnonymousFunctionExpressionSyntax>(source, expectedCode, MutantPlacer.ConvertExpressionToBody);
+        }
+
+        [Theory]
+        [InlineData("public int X { get => 1;}", "public int X { get {return 1;}}")]
+        public void ShouldConvertAnonymousFunctionExpressionBodyBackAndForth(string original, string injected)
         {
             var source = $"class Test {{{original}}}";
             var expectedCode = $"class Test {{{injected}}}";

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutationSpecificSyntaxTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutationSpecificSyntaxTests.cs
@@ -119,7 +119,7 @@ string Value {get => Out(out var x)? ""empty"": """";}
 static TestClass(){}}";
 
             var expected = @"class Test {
-string Value {get {if(StrykerNamespace.MutantControl.IsActive(0)){return!(Out(out var x))? ""empty"": """";}else{return Out(out var x)? (StrykerNamespace.MutantControl.IsActive(1)?"""":""empty""): (StrykerNamespace.MutantControl.IsActive(2)?""Stryker was here!"":"""");}}}
+string Value {get {if(StrykerNamespace.MutantControl.IsActive(0)){return!(Out(out var x))? ""empty"": """";}else{return Out(out var x)? (StrykerNamespace.MutantControl.IsActive(1)?"""":""empty""): (StrykerNamespace.MutantControl.IsActive(2)?""Stryker was here!"":"""");}return default(string);}}
 static TestClass(){using(new StrykerNamespace.MutantContext()){}}}";
 
             ShouldMutateSourceToExpected(source, expected);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutationSpecificSyntaxTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutationSpecificSyntaxTests.cs
@@ -68,6 +68,17 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     		    }}";
 
             ShouldMutateSourceToExpected(source, expected);
+
+            source = @"private int Move()
+			{
+				;
+			}";
+            expected = @"private int Move()
+    {if(StrykerNamespace.MutantControl.IsActive(1)){}else		    {
+    			    ;
+    		    } return default(int);}";
+
+            ShouldMutateSourceToExpected(source, expected);
         }
 
         [Theory]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -84,7 +84,12 @@ namespace Stryker.Core.UnitTest.MutationTest
             var mockMutants = new Collection<Mutant>() { new() { Mutation = new Mutation() }, mutantToBeSkipped };
 
             // create mocks
-            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict);
+            var options = new StrykerOptions()
+            {
+                DevMode = true,
+                ExcludedMutations = new Mutator[] { }
+            };
+            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict, options);
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             var mutationTestExecutorMock = new Mock<IMutationTestExecutor>(MockBehavior.Strict);
             var coverageAnalyzerMock = new Mock<ICoverageAnalyser>(MockBehavior.Strict);
@@ -93,12 +98,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             orchestratorMock.Setup(x => x.GetLatestMutantBatch()).Returns(mockMutants);
             orchestratorMock.Setup(x => x.Mutate(It.IsAny<SyntaxNode>())).Returns(CSharpSyntaxTree.ParseText(SourceFile).GetRoot());
             orchestratorMock.SetupAllProperties();
-            var options = new StrykerOptions()
-            {
-                DevMode = true,
-                ExcludedMutations = new Mutator[] { }
-            };
-
+ 
             var target = new MutationTestProcess(input,
                 reporterMock.Object,
                 mutationTestExecutorMock.Object,
@@ -166,7 +166,13 @@ namespace Stryker.Core.UnitTest.MutationTest
             var mockMutants = new Collection<Mutant>() { new Mutant() { Mutation = new Mutation() }, mutantToBeSkipped, compileErrorMutant };
 
             // create mocks
-            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict);
+            var options = new StrykerOptions()
+            {
+                DevMode = true,
+                ExcludedMutations = new Mutator[] { }
+            };
+
+            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict, options);
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             var mutationTestExecutorMock = new Mock<IMutationTestExecutor>(MockBehavior.Strict);
             var mutantFilterMock = new Mock<IMutantFilter>(MockBehavior.Strict);
@@ -183,11 +189,6 @@ namespace Stryker.Core.UnitTest.MutationTest
                 .Callback<IEnumerable<Mutant>, ReadOnlyFileLeaf, StrykerOptions>((mutants, _, __) => mutantsPassedToFilter = mutants)
                 .Returns((IEnumerable<Mutant> mutants, ReadOnlyFileLeaf file, StrykerOptions o) => mutants.Take(1));
 
-            var options = new StrykerOptions()
-            {
-                DevMode = true,
-                ExcludedMutations = new Mutator[] { }
-            };
 
             var target = new MutationTestProcess(input,
                 reporterMock.Object,
@@ -250,10 +251,11 @@ namespace Stryker.Core.UnitTest.MutationTest
                 },
                 AssemblyReferences = _assemblies
             };
-            var mockMutants = new Collection<Mutant>() { new Mutant() { Mutation = new Mutation() } };
+            var mockMutants = new Collection<Mutant>() { new() { Mutation = new Mutation() } };
 
             // create mocks
-            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict);
+            var options = new StrykerOptions();
+            var orchestratorMock = new Mock<BaseMutantOrchestrator<SyntaxNode>>(MockBehavior.Strict, options);
             var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
             var mutationTestExecutorMock = new Mock<IMutationTestExecutor>(MockBehavior.Strict);
             var coverageAnalyzerMock = new Mock<ICoverageAnalyser>(MockBehavior.Strict);
@@ -266,7 +268,6 @@ namespace Stryker.Core.UnitTest.MutationTest
             orchestratorMock.Setup(x => x.GetLatestMutantBatch()).Returns(mockMutants);
             reporterMock.Setup(x => x.OnMutantsCreated(It.IsAny<ReadOnlyProjectComponent>()));
 
-            var options = new StrykerOptions();
             var target = new MutationTestProcess(input,
                 reporterMock.Object,
                 mutationTestExecutorMock.Object,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -120,38 +120,6 @@ struct Program
         }
 
         [Fact]
-        private void ShouldMutateNonVoidReturnsAsDefaultWhenContainsReturns()
-        {
-            var source = @"
-class Program
-{
-    int Method(bool input)
-    {
-        if (input)
-        {
-            input = false;
-        }
-
-        if (input)
-        {
-            return 0;
-        }
-
-        return 1;
-    }
-}";
-
-            var mutations = GetMutations(source).ToList();
-            mutations.Count.ShouldBe(3);
-
-            var (methodBlock, firstIfBlock, secondIfBlock) = (mutations[0], mutations[1], mutations[2]);
-
-            AssertDefaultReturn(methodBlock);
-            firstIfBlock.ReplacementNode.ChildNodes().ShouldBeEmpty();
-            AssertDefaultReturn(secondIfBlock);
-        }
-
-        [Fact]
         private void ShouldMutateVoidReturnsAsEmptyInMethod()
         {
             var source = @"

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
@@ -516,6 +516,25 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
+        public void WorksWhenAllMutantsAreIgnored()
+        {
+            var options = new StrykerOptions
+            {
+                OptimizationMode = OptimizationModes.SkipUncoveredMutants
+            };
+
+            using (var endProcess = new EventWaitHandle(false, EventResetMode.ManualReset))
+            {
+                var mockVsTest = BuildVsTestRunner(options, endProcess, out var runner);
+                // test 0 and 1 cover mutant 1
+                SetupMockCoverageRun(mockVsTest, new Dictionary<string, string> { ["T0"] = ";", ["T1"] = ";" }, endProcess);
+
+                runner.CaptureCoverage(Enumerable.Empty<Mutant>());
+               _mutant.CoveringTests.Count.ShouldBe(0);
+            }
+        }
+
+        [Fact]
         public void RunOnlyUsefulTest()
         {
             var options = new StrykerOptions

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -27,6 +27,30 @@ namespace Stryker.Core.Helpers
             };
 
         /// <summary>
+        /// Gets the return type of a (get accessor)
+        /// </summary>
+        /// <param name="accessor">accessor</param>
+        /// <returns>method returns type. Null if this not relevant</returns>
+        public static TypeSyntax ReturnType(this AccessorDeclarationSyntax accessor)
+        {
+            if (accessor.Keyword.Text == "get" && accessor.Parent is AccessorListSyntax accessorList && accessorList.Parent is PropertyDeclarationSyntax propertyDeclaration)
+            {
+                return propertyDeclaration.Type;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// True if the block does not contain any statement.
+        /// </summary>
+        /// <param name="blockSyntax">block to test</param>
+        /// <returns>true when the block contains no statement.</returns>
+        public static bool IsEmpty(this BlockSyntax blockSyntax) => blockSyntax.Statements.Count == 0;
+
+        /// <summary>
         /// Checks if a method ends with return.
         /// </summary>
         /// <param name="baseMethod">method to analyze.</param>

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -9,7 +9,6 @@ namespace Stryker.Core.Helpers
 {
     internal static class RoslynHelper
     {
-
         /// <summary>
         /// Gets the return type of a method (incl. constructor, destructor...)
         /// </summary>
@@ -33,14 +32,12 @@ namespace Stryker.Core.Helpers
         /// <returns>method returns type. Null if this not relevant</returns>
         public static TypeSyntax ReturnType(this AccessorDeclarationSyntax accessor)
         {
-            if (accessor.Keyword.Text == "get" && accessor.Parent is AccessorListSyntax accessorList && accessorList.Parent is PropertyDeclarationSyntax propertyDeclaration)
+            if (accessor.IsGetter() && accessor.Parent is AccessorListSyntax accessorList && accessorList.Parent is PropertyDeclarationSyntax propertyDeclaration)
             {
                 return propertyDeclaration.Type;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         /// <summary>
@@ -60,11 +57,16 @@ namespace Stryker.Core.Helpers
             {
                 MethodDeclarationSyntax method => !(method.ReturnType is PredefinedTypeSyntax predefinedType &&
                                                     predefinedType.Keyword.IsKind(SyntaxKind.VoidKeyword)),
-                OperatorDeclarationSyntax _ => true,
-                ConversionOperatorDeclarationSyntax _ => true,
+                OperatorDeclarationSyntax => true,
+                ConversionOperatorDeclarationSyntax => true,
                 _ => false
             };
 
+        /// <summary>
+        /// Checks if a local function returns a value.
+        /// </summary>
+        /// <param name="localFunction">local function to evaluate</param>
+        /// <returns>true is the method as non void return value</returns>
         public static bool NeedsReturn(this LocalFunctionStatementSyntax localFunction) =>
             !localFunction.ReturnType.IsVoid();
 
@@ -80,9 +82,7 @@ namespace Stryker.Core.Helpers
         /// </summary>
         /// <param name="baseMethod"></param>
         /// <returns>true if this is a getter</returns>
-        public static bool NeedsReturn(this AccessorDeclarationSyntax baseMethod) =>
-            baseMethod.Keyword.Text == "get";
-
+        public static bool NeedsReturn(this AccessorDeclarationSyntax baseMethod) => baseMethod.IsGetter();
 
         /// <summary>
         /// Returns true if the given type is 'void'.
@@ -117,7 +117,14 @@ namespace Stryker.Core.Helpers
         /// <param name="propertyDeclaration">Property.</param>
         /// <returns>Get accessor for the property, or null if none.</returns>
         public static AccessorDeclarationSyntax GetAccessor(this PropertyDeclarationSyntax propertyDeclaration)
-            => propertyDeclaration?.AccessorList?.Accessors.FirstOrDefault(a => a.Keyword.Text == "get");
+            => propertyDeclaration?.AccessorList?.Accessors.FirstOrDefault(IsGetter);
+
+        /// <summary>
+        /// Checks if the accessor is a getter.
+        /// </summary>
+        /// <param name="accessor">accessor to evaluate</param>
+        /// <returns>true if <paramref name="accessor"/> is a getter.</returns>
+        public static bool IsGetter(this AccessorDeclarationSyntax accessor) => accessor.Keyword.IsKind(SyntaxKind.GetKeyword);
 
         /// <summary>
         /// Return a default(type) expression.

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
@@ -50,7 +50,7 @@ namespace Stryker.Core.Initialisation
             if (!initTestRunResult.FailingTests.IsEmpty)
             {
                 var failingTestsCount = initTestRunResult.FailingTests.Count;
-                _logger.LogWarning($"{failingTestsCount} tests are failing. Stryker will continue but outcome will be impacted.");
+                _logger.LogWarning($"{(failingTestsCount == 1 ? "A test is ": $"{failingTestsCount} tests are")} failing. Stryker will continue but outcome will be impacted.");
                 if (((double)failingTestsCount) / initTestRunResult.RanTests.Count >= .5)
                 {
                     throw new InputException("Initial testrun has more han 50% failing tests.", initTestRunResult.ResultMessage);

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Stryker.Core.Instrumentation
+{
+    /// <summary>
+    /// Helper that converts a method (including operators) from expression body to statement body form (or arrow to curly braces).
+    /// </summary>
+    internal class AnonymousFunctionExpressionToBodyEngine : BaseEngine<AnonymousFunctionExpressionSyntax>
+    {
+        /// <summary>
+        /// Converts the given method (or operator) from expression to body form.
+        /// </summary>
+        /// <typeparam name="T">Specific node type</typeparam>
+        /// <param name="method">Method/operator to be converted.</param>
+        /// <returns>the converted method/operator</returns>
+        /// <remarks>returns the original node if no conversion is needed/possible</remarks>
+        public T ConvertToBody<T>(T method) where T: AnonymousFunctionExpressionSyntax
+        {
+            if (method.ExpressionBody == null || method.Block != null)
+            {
+                // no need to convert
+                return method;
+            }
+
+            var  statementLine = SyntaxFactory.ReturnStatement(method.ExpressionBody.WithLeadingTrivia(SyntaxFactory.Space));
+
+            // do we need add return to the expression body?
+            return method.WithBody(SyntaxFactory.Block(statementLine)).WithAdditionalAnnotations(Marker) as T;
+        }
+
+        protected override SyntaxNode Revert(AnonymousFunctionExpressionSyntax node)
+        {
+            // get expression
+            var expression = node.Block?.Statements[0] switch
+            {
+                ReturnStatementSyntax returnStatement => returnStatement.Expression!,
+                ExpressionStatementSyntax expressionStatement => expressionStatement.Expression!,
+                _ => throw new InvalidOperationException($"Can't extract original expression from {node.Body}")
+            };
+
+            return node.WithBody(expression!)
+                .WithoutAnnotations(Marker);
+        }
+
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
@@ -17,7 +17,7 @@ namespace Stryker.Core.Instrumentation
         /// <param name="method">Method/operator to be converted.</param>
         /// <returns>the converted method/operator</returns>
         /// <remarks>returns the original node if no conversion is needed/possible</remarks>
-        public T ConvertToBody<T>(T method) where T: AnonymousFunctionExpressionSyntax
+        public T ConvertToBody<T>(T method) where T : AnonymousFunctionExpressionSyntax
         {
             if (method.ExpressionBody == null || method.Block != null)
             {

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -48,6 +48,26 @@ namespace Stryker.Core.Instrumentation
             return ret == null ? block : ret.WithAdditionalAnnotations(Marker);
         }
 
+        public BlockSyntax InjectReturn(BlockSyntax block, SyntaxTokenList modifiers)
+        {
+            BlockSyntax ret;
+            // if we had no body or the the last statement was a return, no need to add one, or this is an iterator method
+            if (block == null
+                || block.Statements.Count == 0
+                || block!.Statements.Last().Kind() == SyntaxKind.ReturnStatement
+                || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement)|| x.IsKind(SyntaxKind.YieldBreakStatement), false))
+            {
+                ret = null;
+            }
+            else
+            {
+                ret = block.AddStatements(
+                    SyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression).WithLeadingTrivia(SyntaxFactory.Space)));
+            }
+
+            return ret == null ? block : ret.WithAdditionalAnnotations(Marker);
+        }
+
         protected override SyntaxNode Revert(BlockSyntax node)
         {
             if (node?.Statements.Last().IsKind(SyntaxKind.ReturnStatement) != true)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -55,7 +55,7 @@ namespace Stryker.Core.Instrumentation
             if (block == null
                 || block.Statements.Count == 0
                 || block!.Statements.Last().Kind() == SyntaxKind.ReturnStatement
-                || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement)|| x.IsKind(SyntaxKind.YieldBreakStatement), false))
+                || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement) || x.IsKind(SyntaxKind.YieldBreakStatement), false))
             {
                 ret = null;
             }

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -1,23 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
 using Stryker.Core.Options;
 
 namespace Stryker.Core.Mutants
 {
-    public abstract class BaseMutantOrchestrator<T> : BaseMutantOrchestrator
-    {
-        protected  BaseMutantOrchestrator() : base(null)
-        {
-        }
-        protected BaseMutantOrchestrator(StrykerOptions input) : base(input)
-        {
-        }
-
-        public abstract T Mutate(T input);
-    }
-
     public abstract class BaseMutantOrchestrator
     {
         public readonly StrykerOptions _options;
@@ -40,5 +26,17 @@ namespace Stryker.Core.Mutants
             Mutants = new Collection<Mutant>();
             return (IReadOnlyCollection<Mutant>)tempMutants;
         }
+    }
+
+    public abstract class BaseMutantOrchestrator<T> : BaseMutantOrchestrator
+    {
+        protected  BaseMutantOrchestrator() : base(null)
+        {
+        }
+        protected BaseMutantOrchestrator(StrykerOptions input) : base(input)
+        {
+        }
+
+        public abstract T Mutate(T input);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -30,9 +30,6 @@ namespace Stryker.Core.Mutants
 
     public abstract class BaseMutantOrchestrator<T> : BaseMutantOrchestrator
     {
-        protected  BaseMutantOrchestrator() : base(null)
-        {
-        }
         protected BaseMutantOrchestrator(StrykerOptions input) : base(input)
         {
         }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -70,6 +70,7 @@ namespace Stryker.Core.Mutants
                 new PropertyDeclarationOrchestrator(),
                 new ArrayInitializerOrchestrator(),
                 new LocalFunctionStatementOrchestrator(),
+                new AnonymousFunctionExpressionOrchestrator(),
                 new BaseMethodDeclarationOrchestrator<BaseMethodDeclarationSyntax>(),
                 new AccessorSyntaxOrchestrator(),
                 new LocalDeclarationOrchestrator(),

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
@@ -20,6 +20,10 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
 
             if (!context.HasStatementLevelMutant)
             {
+                if (result.Body!=null &&  sourceNode.NeedsReturn())
+                {
+                    result = MutantPlacer.AddEndingReturn(result, sourceNode.ReturnType());
+                }
                 return result;
             }
 
@@ -29,7 +33,12 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             }
 
             var newBody = context.InjectBlockLevelExpressionMutation(result.Body, sourceNode.ExpressionBody!.Expression, sourceNode.NeedsReturn());
-            return result.WithBody(SyntaxFactory.Block(newBody));
+            result = result.WithBody(SyntaxFactory.Block(newBody));
+            if (sourceNode.NeedsReturn())
+            {
+                result = MutantPlacer.AddEndingReturn(result, sourceNode.ReturnType());
+            }
+            return result;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AccessorSyntaxOrchestrator.cs
@@ -20,7 +20,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
 
             if (!context.HasStatementLevelMutant)
             {
-                if (result.Body!=null &&  sourceNode.NeedsReturn())
+                if (result.Body != null && sourceNode.NeedsReturn())
                 {
                     result = MutantPlacer.AddEndingReturn(result, sourceNode.ReturnType());
                 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AnonymousFunctionExpressionOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/AnonymousFunctionExpressionOrchestrator.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
+{
+    internal class AnonymousFunctionExpressionOrchestrator : NodeSpecificOrchestrator<AnonymousFunctionExpressionSyntax, AnonymousFunctionExpressionSyntax>
+    {
+        protected override AnonymousFunctionExpressionSyntax InjectMutations(AnonymousFunctionExpressionSyntax sourceNode,
+            AnonymousFunctionExpressionSyntax targetNode, MutationContext context)
+        {
+            targetNode = base.InjectMutations(sourceNode, targetNode, context);
+
+            if (targetNode.Block == null)
+            {
+                if (targetNode.ExpressionBody == null)
+                {
+                    // only a definition (eg interface)
+                    return targetNode;
+                }
+
+                // this is an expression body method
+                if (!context.HasStatementLevelMutant)
+                {
+                    // there is no statement or block level mutant, so the method control flow is not changed by mutations
+                    // there is no need to change the method in any may
+                    return targetNode;
+                }
+
+                // we need to convert it to expression body form
+                targetNode = MutantPlacer.ConvertExpressionToBody(targetNode);
+
+                // we need to inject pending block (and statement) level mutations
+                targetNode = targetNode.WithBody(
+                    SyntaxFactory.Block(context.InjectBlockLevelExpressionMutation(targetNode.Block,
+                        sourceNode.ExpressionBody, true)));
+            }
+            else
+            {
+                // we add an ending return, just in case
+                targetNode = MutantPlacer.AddEndingReturn(targetNode);
+            }
+
+            if (targetNode is SimpleLambdaExpressionSyntax lambdaExpression && lambdaExpression.Parameter.Modifiers.Any(m => m.Kind() == SyntaxKind.OutKeyword))
+            {
+                targetNode = targetNode.WithBody(MutantPlacer.AddDefaultInitializers(targetNode.Block, new List<ParameterSyntax>{lambdaExpression.Parameter}));
+            }
+            else if (targetNode is ParenthesizedLambdaExpressionSyntax parenthesizedLambda)
+            // inject initialization to default for all out parameters
+            {
+                targetNode = targetNode.WithBody(MutantPlacer.AddDefaultInitializers(targetNode.Block, parenthesizedLambda.ParameterList.Parameters.Where(p =>
+                p.Modifiers.Any(m => m.Kind() == SyntaxKind.OutKeyword))));
+            }
+            return targetNode;
+        }
+
+        protected override MutationContext PrepareContext(AnonymousFunctionExpressionSyntax node, MutationContext context)
+        {
+            context.Enter(MutationControl.Block);
+            return base.PrepareContext(node, context);
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseMethodDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseMethodDeclarationOrchestrator.cs
@@ -52,7 +52,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             }
             else
             {
-                // we add an ending rreturn, just in case
+                // we add an ending return, just in case
                 targetNode = MutantPlacer.AddEndingReturn(targetNode);
             }
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/NodeSpecificOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/NodeSpecificOrchestrator.cs
@@ -136,7 +136,7 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
             };
 
             Mutator[] filteredMutators;
-            if (match.Groups[MutatorsGroup].Value.ToLower() == "all")
+            if (match.Groups[MutatorsGroup].Value.ToLower().Trim() == "all")
             {
                 filteredMutators = Enum.GetValues<Mutator>();
             }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -67,11 +67,11 @@ namespace Stryker.Core.Mutants
         public static LocalFunctionStatementSyntax ConvertExpressionToBody(LocalFunctionStatementSyntax method) =>
             localFunctionExpressionToBodyEngine.ConvertToBody(method);
 
-        public static PropertyDeclarationSyntax ConvertPropertyExpressionToBodyAccessor(PropertyDeclarationSyntax property) =>
-            propertyExpressionToBodyEngine.ConvertExpressionToBody(property);
-
         public static AnonymousFunctionExpressionSyntax ConvertExpressionToBody(AnonymousFunctionExpressionSyntax property) =>
             anonymousFunctionExpressionToBodyEngine.ConvertToBody(property);
+
+        public static PropertyDeclarationSyntax ConvertPropertyExpressionToBodyAccessor(PropertyDeclarationSyntax property) =>
+            propertyExpressionToBodyEngine.ConvertExpressionToBody(property);
 
         public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax method) =>
             method.WithBody(endingReturnEngine.InjectReturn(method.Body, method.ReturnType(), method.Modifiers));

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -17,7 +17,7 @@ namespace Stryker.Core.Mutants
     public static class MutantPlacer
     {
         private const string MutationMarker = "Mutation";
-        public readonly static string Injector = "Injector";
+        public static readonly string Injector = "Injector";
 
         private static readonly StaticInstrumentationEngine staticEngine = new ();
         private static readonly StaticInitializerMarkerEngine staticInitializerEngine = new ();
@@ -27,6 +27,7 @@ namespace Stryker.Core.Mutants
         private static readonly LocalFunctionExpressionToBodyEngine localFunctionExpressionToBodyEngine = new();
         private static readonly AccessorExpressionToBodyEngine accessorExpressionToBodyEngine = new();
         private static readonly PropertyExpressionToBodyEngine propertyExpressionToBodyEngine = new();
+        private static readonly AnonymousFunctionExpressionToBodyEngine anonymousFunctionExpressionToBodyEngine = new();
         private static readonly EndingReturnEngine endingReturnEngine = new();
         private static readonly DefaultInitializationEngine defaultInitializationEngine = new();
         private static ExpressionSyntax _binaryExpression;
@@ -44,6 +45,7 @@ namespace Stryker.Core.Mutants
             RegisterEngine(expressionMethodEngine);
             RegisterEngine(accessorExpressionToBodyEngine);
             RegisterEngine(propertyExpressionToBodyEngine);
+            RegisterEngine(anonymousFunctionExpressionToBodyEngine);
             RegisterEngine(endingReturnEngine);
             RegisterEngine(defaultInitializationEngine);
             RegisterEngine(staticInitializerEngine);
@@ -68,8 +70,17 @@ namespace Stryker.Core.Mutants
         public static PropertyDeclarationSyntax ConvertPropertyExpressionToBodyAccessor(PropertyDeclarationSyntax property) =>
             propertyExpressionToBodyEngine.ConvertExpressionToBody(property);
 
-        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax method) => method.WithBody(endingReturnEngine.InjectReturn(method.Body, method.ReturnType(), method.Modifiers));
-        public static LocalFunctionStatementSyntax AddEndingReturn(LocalFunctionStatementSyntax function) => function.WithBody(endingReturnEngine.InjectReturn(function.Body, function.ReturnType, function.Modifiers));
+        public static AnonymousFunctionExpressionSyntax ConvertExpressionToBody(AnonymousFunctionExpressionSyntax property) =>
+            anonymousFunctionExpressionToBodyEngine.ConvertToBody(property);
+
+        public static BaseMethodDeclarationSyntax AddEndingReturn(BaseMethodDeclarationSyntax method) =>
+            method.WithBody(endingReturnEngine.InjectReturn(method.Body, method.ReturnType(), method.Modifiers));
+        public static AccessorDeclarationSyntax AddEndingReturn(AccessorDeclarationSyntax method, TypeSyntax propertyType) =>
+            method.WithBody(endingReturnEngine.InjectReturn(method.Body, propertyType, method.Modifiers));
+        public static LocalFunctionStatementSyntax AddEndingReturn(LocalFunctionStatementSyntax function) =>
+            function.WithBody(endingReturnEngine.InjectReturn(function.Body, function.ReturnType, function.Modifiers));
+        public static AnonymousFunctionExpressionSyntax AddEndingReturn(AnonymousFunctionExpressionSyntax function) =>
+            function.WithBlock(endingReturnEngine.InjectReturn(function.Block, function.Modifiers));
 
         public static BlockSyntax PlaceStaticContextMarker(BlockSyntax block) => 
             staticEngine.PlaceStaticContextMarker(block);

--- a/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
@@ -15,59 +15,31 @@ namespace Stryker.Core.Mutators
 
         public override IEnumerable<Mutation> ApplyMutations(BlockSyntax node)
         {
-            if (IsEmptyBlock(node) ||
+            if (node.IsEmpty() ||
                 IsInfiniteWhileLoop(node) ||
                 (IsInStructConstructor(node) && ContainsAssignments(node)))
             {
                 yield break;
             }
 
-            if (FirstReturnTypedAncestorReturnsNonVoid(node) && ContainsReturns(node))
-            {
-                yield return new Mutation()
-                {
-                    OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.Block(SyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression))),
-                    DisplayName = MutationName,
-                    Type = Mutator.Block
-                };
-            }
-            else
-            {
-                yield return new Mutation()
-                {
-                    OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.Block(),
-                    DisplayName = MutationName,
-                    Type = Mutator.Block
-                };
-            }
-        }
 
-        private static bool IsEmptyBlock(BlockSyntax node) => !node.ChildNodes().Any();
+            yield return new Mutation()
+            {
+                OriginalNode = node,
+                ReplacementNode = SyntaxFactory.Block(),
+                DisplayName = MutationName,
+                Type = Mutator.Block
+            };
+        }
 
         private static bool IsInfiniteWhileLoop(BlockSyntax node) =>
             node.Parent is WhileStatementSyntax { Condition: LiteralExpressionSyntax cond } &&
             cond.Kind() == SyntaxKind.TrueLiteralExpression;
 
-        private static bool ContainsReturns(BlockSyntax node) => node
-            .ChildNodes()
-            .OfType<ReturnStatementSyntax>()
-            .Any();
-
         private static bool ContainsAssignments(BlockSyntax node) => node
             .ChildNodes()
             .OfType<ExpressionStatementSyntax>()
             .Any(expressionSyntax => expressionSyntax.Expression is AssignmentExpressionSyntax);
-
-        private static bool FirstReturnTypedAncestorReturnsNonVoid(BlockSyntax node) => node
-                .Ancestors()
-                .FirstOrDefault(ancestor => ancestor is MethodDeclarationSyntax or LocalFunctionStatementSyntax) switch
-            {
-                MethodDeclarationSyntax method => !method.ReturnType.IsVoid(),
-                LocalFunctionStatementSyntax localFunction => !localFunction.ReturnType.IsVoid(),
-                _ => false,
-            };
 
         private static bool IsInStructConstructor(BlockSyntax node)
         {

--- a/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
@@ -13,26 +13,13 @@ namespace Stryker.Core.Mutators
 
         public override IEnumerable<Mutation> ApplyMutations(BlockSyntax node)
         {
-            if (node.Parent is MethodDeclarationSyntax methodDeclaration && methodDeclaration.ReturnType.ToString() != "void")
+            yield return new Mutation()
             {
-                yield return new Mutation()
-                {
-                    OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.Block(SyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression))),
-                    DisplayName = MutationName,
-                    Type = Mutator.Block
-                };
-            }
-            else
-            {
-                yield return new Mutation()
-                {
-                    OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.Block(),
-                    DisplayName = MutationName,
-                    Type = Mutator.Block
-                };
-            }
+                OriginalNode = node,
+                ReplacementNode = SyntaxFactory.Block(),
+                DisplayName = MutationName,
+                Type = Mutator.Block
+            };
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -308,11 +308,11 @@ namespace Stryker.Core.TestRunners.VsTest
             // since we analyze mutant coverage, mutants are assumed as not covered
             var seenTestCases = new HashSet<Guid>();
             var dynamicTestCases = new HashSet<Guid>();
-            var mutantCount = mutants.Any() ? mutants.Max(m => m.Id) + 1 : 0;
-            var map = new List<ICollection<TestDescription>>(mutantCount);
+            var maxMutantId = mutants.Any() ? mutants.Max(m => m.Id) + 1 : 0;
+            var map = new List<ICollection<TestDescription>>(maxMutantId);
             var staticMutantLists = new HashSet<int>();
             // initialize the map
-            for (var i = 0; i < mutantCount; i++)
+            for (var i = 0; i < maxMutantId; i++)
             {
                 map.Add(new List<TestDescription>());
             }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -308,7 +308,7 @@ namespace Stryker.Core.TestRunners.VsTest
             // since we analyze mutant coverage, mutants are assumed as not covered
             var seenTestCases = new HashSet<Guid>();
             var dynamicTestCases = new HashSet<Guid>();
-            var mutantCount = mutants.Max(m => m.Id) + 1;
+            var mutantCount = mutants.Any() ? mutants.Max(m => m.Id) + 1 : 0;
             var map = new List<ICollection<TestDescription>>(mutantCount);
             var staticMutantLists = new HashSet<int>();
             // initialize the map


### PR DESCRIPTION
This PR brings a bunch of minor to medium fixes and improvements:
1. ignores any trailing spaces for `all` when disabling mutations via code comments (such as :`//Stryker disable all`), fixes #1781. Updated tests to add trailing whitespaces to prevent regression
2. fixes raised exception when there is no mutant to test. added a unit test to prevent regression. Fixes #1776 
3. add orchestrator for anonymous lambdas (and a return injection engine as well). This will reduce the risk of safe mode triggering on anonymous lambdas
4. refactored `BlockMutator`: `return` injection now (properly) relies on the orchestration logic; besides cleaning up the design, it removes some 'safe mode' triggers.Some helpers method have been moved to the `RoslynHelper` class.
5. improves the message when only one test is failing (the previous message assumed more than one test failed and used a plural form, it annoyed me while I was testing it against NFluent).
6. Minor opportunistic refactoring/typo corrections.

I tested this PR agains NFluent and it works as usual, with a bit of 'safe mode' warning vs the release.