### PR TITLE
fix(baseline): Use regular fallback version as well as baseline fallback version

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ The levels are:
 | Arithmetic Operators | Basic|
 | Block (not yet implemented) | Basic|
 | Equality Operators | Standard |
-| flagean Literals | Standard|
+| Boolean Literals | Standard|
 | Assignment statements | Standard |
 | Collection initializer | Standard |
 | Unary Operators | Standard |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,10 +9,10 @@ custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs
 You run stryker from the test project directory.
 
 On some dotnet core projects stryker can run without specifying any custom configuration. Simply run `dotnet stryker` to start testing.  
-On dotnet framework projects the solution path argument is always required. Run at least `dotnet stryker --solution <solution-path>` or specify the solution file path in the config file to start testing. See [solution](#solution-<path>).
+On dotnet framework projects the solution path argument is always required. Run at least `dotnet stryker --solution <solution-path>` or specify the solution file path in the config file to start testing. See [solution](#solution-path).
 
 ## Use a config file
-When using Stryker regularly we recommend using a config file. This way you won't have to document how to run Stryker, you can save the config file in version control. To use a config file create a file called `stryker-config.json` in the (unit test) project folder and add a configuration section called stryker-config. Alternatively use [init](#init-<bool>)
+When using Stryker regularly we recommend using a config file. This way you won't have to document how to run Stryker, you can save the config file in version control. To use a config file create a file called `stryker-config.json` in the (unit test) project folder and add a configuration section called stryker-config.
 
 Example `stryker-config.json` file:
 ``` javascript
@@ -24,14 +24,6 @@ Example `stryker-config.json` file:
     }
 }
 ```
-
-### `init` <`flag`>
-
-Default: `false`  
-Command line: `--init`  
-Config file: `N/A`  
-
-Creates a stryker config file with default options. Any options passed in the cli will override the defaults.
 
 ### `config-file` <`path`>
 
@@ -146,7 +138,7 @@ Default: `null`
 Command line: `N/A`  
 Config file: `"project-info": { "name": 'github.com/stryker-mutator/stryker-net' }`
 
-The name registered with the [Stryker dashboard](./reporters.md#dashboard-reporter). It is in the form of `gitProvider/organization/repository`. At the moment the dashboard backend only supports github.com as a git provider, but we want to also support gitlab.com/bitbucket.org etc in the future. It can have an indefinite number of levels. Slashes (/) in this name are not escaped. For example `github.com/stryker-mutator/stryker-net`.
+The name registered with the [Stryker dashboard](./reporters.md#dashboard-reporter). It is in the form of `gitProvider/organization/repository`. At the moment the dashboard backend only supports github.com as a git provider. It can have an indefinite number of levels. Slashes (/) in this name are not escaped. For example `github.com/stryker-mutator/stryker-net`.
 
 ### `project-info.module` <`string`>
 
@@ -158,7 +150,7 @@ If you want to store multiple reports for a given version you can use this optio
 
 See [Stryker dashboard](./reporters.md#dashboard-reporter)
 
-### `project-info.version` <`comittish`>
+### `project-info.version` <`committish`>
 
 Default: `null`  
 Command line: `[-v|--version] "feat/logging"`  
@@ -189,7 +181,7 @@ The levels are:
 | Arithmetic Operators | Basic|
 | Block (not yet implemented) | Basic|
 | Equality Operators | Standard |
-| Boolean Literals | Standard|
+| flagean Literals | Standard|
 | Assignment statements | Standard |
 | Collection initializer | Standard |
 | Unary Operators | Standard |
@@ -235,6 +227,14 @@ When this option is passed, generated reports should open in the browser automat
 Valid values:
 - html
 - dashboard
+
+### `report-file-name` <`string`>
+
+Default: `mutation-report`
+Command line: `N/A` 
+Config file: `report-file-name`
+
+If HTML and/or JSON reporting is being used you can use this option to change the report file name.
 
 ### `additional-timeout` <`number`>
 
@@ -287,7 +287,7 @@ Config file: `"thresholds": { "break": 0 }`
 
 When threshold break is set to anything other than 0 Stryker will exit with a non-zero code. This can be used in a CI pipeline to fail the pipeline when you mutation score is not sufficient. Must be less than or equal to threshold low.
 
-See [thresholds](#thresholds-<object>)
+See [thresholds](#thresholds-object)
 
 ### `ignore-mutations` <`string[]`>
 
@@ -369,7 +369,7 @@ are run against all tests as Stryker cannot reliably capture coverage for those.
 constructors/initialisers being called only once during tests. This heuristic is not needed when using
 `perTestInIsolation` due to test being run one by one.
 
-### `disable-bail` <`bool`>
+### `disable-bail` <`flag`>
 
 Default: `false`  
 Command line: `N/A`  
@@ -377,7 +377,7 @@ Config file: `"disable-bail": true`
 
 Stryker aborts a unit testrun for a mutant as soon as one test fails because this is enough to confirm the mutant is killed. This can reduce the total runtime but also means you miss information about individual unit tests (eg if a unit test does not kill any mutants and is therefore useless). You can disable this behavior and run all unit tests for a mutant to completion. This can be especially useful when you want to find useless unit tests.
 
-### `disable-mix-mutants` <`bool`>
+### `disable-mix-mutants` <`flag`>
 
 Default: `false`  
 Command line: `N/A`  
@@ -385,7 +385,7 @@ Config file: `"disable-mix-mutants": true`
 
 Stryker combines multiple mutants in the same testrun when the mutants are not covered by the same unit tests. This reduces the total runtime. You can disable this behavior and run every mutation in an isolated testrun. This can be useful when mixed mutants have unintended side effects.
 
-### `since` <`flag`>
+### `since` <`flag`> [`:committish`]
 
 Default: `false`  
 Command line: `--since:feat-2`  
@@ -393,28 +393,28 @@ Config file: `"since": { }`
 
 Use git information to test only code changes since the given target. Stryker will only report on mutants within the changed code. All other mutants will not have a result.
 
-If you wish to test only changed sources and tests but would like to have a complete mutation report see [with-baseline](#with-baseline-<flag>).
+If you wish to test only changed sources and tests but would like to have a complete mutation report see [with-baseline](#with-baseline-flag-committish).
 
-Set the diffing target on the command line by passing a comittish with the since flag in the format `--since:<comittish>`.
-Set the diffing target in the config file by setting the [since.target](#since.target-<comittish>) option.
+Set the diffing target on the command line by passing a committish with the since flag in the format `--since:<committish>`.
+Set the diffing target in the config file by setting the [since target](#sincetarget-committish) option.
 
 *\* For changes on test project files all mutants covered by tests in that file will be seen as changed.*
 
-### `since.enabled` <`bool`>
+### `since.enabled` <`flag`>
 
 Default: `null`  
 Command line: `N/A`  
 Config file: `"since": { "enabled": false }`
 
-Enable or disable [since](#since-<flag>). If the enabled property is not set but the `since` object exists in the config file it is assumed to be enabled. Use this option to (temporarily) disable `since` without having to delete the other `since` configuration.
+Enable or disable [since](#since-flag-committish). If the enabled property is not set but the `since` object exists in the config file it is assumed to be enabled. Use this option to (temporarily) disable `since` without having to delete the other `since` configuration.
 
-### `since.target` <`comittish`>
+### `since.target` <`committish`>
 
 Default: `master`  
 Command line: `N/A`  
 Config file: `"since": { "target": 'feat-2' }`
 
-Set the diffing target for the [since](#since-<flag>) feature.
+Set the diffing target for the [since](#since-flag-committish) feature.
 
 ### `since.ignore-changes-in` <`string[]`>
 
@@ -433,36 +433,36 @@ Use [globbing syntax](https://en.wikipedia.org/wiki/Glob_(programming)) for wild
 
 ## Baseline
 
-### `with-baseline` <`flag`>
+### `with-baseline` <`flag`> [`:committish`]
 
 Default: `false`  
 Command line: `--with-baseline:feat-2`  
 Config file: `"baseline": { }`
 
-Enabling `with-baseline` saves the mutation report to a storage location such as the filesystem. The mutation report is loaded at the start of the next mutation run. Any changed source code or unit test results in a reset of the mutants affected by the change. For unchanged mutants the previous result is reused. This feature expands on the [since](#since-<flag>) feature by providing you with a full report after a partial mutation testrun.
+Enabling `with-baseline` saves the mutation report to a storage location such as the filesystem. The mutation report is loaded at the start of the next mutation run. Any changed source code or unit test results in a reset of the mutants affected by the change. For unchanged mutants the previous result is reused. This feature expands on the [since](#since-flag-committish) feature by providing you with a full report after a partial mutation testrun.
 
-The report name is based on the current branch name or the [project-info version](#project-info.version-<string>).
+The report name is based on the current branch name or the [project-info.version](#project-infoversion-committish).
 
-Set the diffing target on the command line by passing a comittish with the since flag.
-Set the diffing target in the config file by setting the [since target](#since.target-<comittish>) option.
+Set the diffing target on the command line by passing a committish with the since flag.
+Set the diffing target in the config file by setting the [since target](#sincetarget-committish) option.
 
-*\* This feature automatically enables the [since](#since-<flag>) feature.*
+*\* This feature automatically enables the [since](#since-flag-committish) feature.*
 
-### `baseline.enabled` <`bool`>
+### `baseline.enabled` <`flag`>
 
 Default: `null`  
 Command line: `N/A`  
 Config file: `"baseline": { "enabled": false }`
 
-Enable or disable [with-baseline](#with-baseline-<flag>). If the enabled property is not set but the `baseline` object exists in the config file it is assumed to be enabled. Use this option to (temporarily) disable `with-baseline` without having to delete the other baseline configuration.
+Enable or disable [with-baseline](#with-baseline-flag-committish). If the enabled property is not set but the `baseline` object exists in the config file it is assumed to be enabled. Use this option to (temporarily) disable `with-baseline` without having to delete the other baseline configuration.
 
 ### `baseline.fallback-version` <`string`>
 
-Default: [since-target](#since-target-<comittish>)  
+Default: [since-target](#since-flag-committish)  
 Command line: `N/A`  
 Config file: `"baseline": { "fallback-version": 'develop' }`
 
-When [with-baseline](#with-baseline-<bool[<:comittish>]>) is enabled and Stryker cannot find an existing report for the current branch the fallback version is used. When Stryker is still unable to find a baseline we will do a complete instead of partial testrun. The complete testrun will then be saved as the new baseline for the next mutation testrun.
+When [with-baseline](#with-baseline-flag-committish) is enabled and Stryker cannot find an existing report for the current branch the fallback version is used. When Stryker is still unable to find a baseline we will do a complete instead of partial testrun. The complete testrun will then be saved as the new baseline for the next mutation testrun.
 
 **Example**:
 ```json
@@ -491,7 +491,7 @@ baseline used: feat-2
 new baseline saved to: feat-2
 ```
 
-*\* The [since-target](#since-target-<comittish>) explicit or default value is used as the fallback version unless the fallback version is explicitly set.*
+*\* The [since-target](#since-target-committish) explicit or default value is used as the fallback version unless the fallback version is explicitly set.*
 
 ### `baseline.provider` <`string`>
 
@@ -499,7 +499,7 @@ Default: `Disk`
 Command line: `N/A`  
 Config file: `"baseline": { "provider": 'AzureFileStorage'}`
 
-Sets the storage provider for the baseline used by [with-baseline](#with-baseline-<bool[<:comittish>]>). By default this is set to disk, when the dashboard [reporter](#reporter-<string>) is enabled this is automatically set to Dashboard.
+Sets the storage provider for the baseline used by [with-baseline](#with-baseline-flag-committish). By default this is set to disk, when the dashboard [reporter](#reporter-string) is enabled this is automatically set to Dashboard.
 
 Supported storage providers are:
 
@@ -517,12 +517,13 @@ Default: `null`
 Command line: `N/A`  
 Config file: `"baseline": { "azure-fileshare-url": 'https://stryker-net.file.core.windows.net/baselines'}`
 
-When using the azure file storage [provider](#baseline.provider-<string>) you must set the file share url.
+When using the azure file storage [provider](#baselineprovider-string) you must set the file share url.
 The file share url should be in the the format:
 
 `https://<STORAGE_ACCOUNT_NAME>.file.core.windows.net/<FILE_SHARE_NAME>/<OPTIONAL_SUBFOLDER_NAME>`
 
-Providing a subfolder is optional but allowed. The baseline are always stored in a folder called `StrykerOutput/Baselines`. In the case of a custom subfolder the complete url to the baselines would become `https://<FILE_SHARE_URL>/<OPTIONAL_SUBFOLDER_NAME>/StrykerOutput/Baselines`
+The baseline are stored in a folder called `StrykerOutput/Baselines` by default. Or in `StrykerOutput/<projectName>` if a [project name](#project-infoname-string) is set.
+Providing a subfolder is optional but allowed. In the case of a custom subfolder the complete url to the baselines would become `https://<FILE_SHARE_URL>/<OPTIONAL_SUBFOLDER_NAME>/StrykerOutput/Baselines`
 
 ### `azure-storage-sas` <`string`>
 
@@ -530,7 +531,7 @@ Default: `null`
 Command line: `--azure-storage-sas "adfdf34343242323rewfe323434"`  
 Config file: `N/A`
 
-When using the azure file storage [provider](#baseline.provider-<string>) you must pass credentials for the fileshare to Stryker.
+When using the azure file storage [provider](#baselineprovider-string) you must pass credentials for the fileshare to Stryker.
 For authentication with the azure fileshare we support Shared Access Signatures. For more information on how to configure a SAS check the [Azure documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview).
 
 # Troubleshooting
@@ -579,7 +580,7 @@ Config file: `N/A`
 Environment variable: `STRYKER_DASHBOARD_API_KEY="afdfsgarg3wr32r3r32f3f3"`
 
 The API key for authentication with the Stryker dashboard.  
-Get your api key at [stryker dashboard](https://dashboard.stryker-mutator.io/). To keep your api key safe, store it in an encrypted variable in your pipeline.
+Get your api key at the [stryker dashboard](https://dashboard.stryker-mutator.io/). To keep your api key safe, store it in an encrypted variable in your pipeline.
 
 ### `dashboard-url` <`string`>
 
@@ -597,10 +598,3 @@ Command line: `--msbuild-path "c://MsBuild/MsBuild.exe"`
 Config file: `N/A`  
 
 By default stryker tries to autodiscover msbuild on your system. If stryker fails to discover msbuild you may supply the path to msbuild manually with this option.
-
-### `report-file-name` <`string`>
-
-Default: `mutation-report`
-Config file: `report-file-name`
-
-If HTML or JSON reporting is being used, this sets the filename of the output file.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -51,8 +51,8 @@ Options migration overview:
 | log-file                      | L \| log-to-file                            | log-file                      | ❌                           |
 | log-level                     | V \| verbosity                              | log-level                     | verbosity                    |
 | mutation-level                | l \| mutation-level                         | mutation-level                | mutation-level               |
-| threshold-high                | ❌                                          | thresholds.high               | thresholds.high              |
-| threshold-low                 | ❌                                          | thresholds.low                | thresholds.low               |
+| threshold-high                | threshold-high                              | thresholds.high               | thresholds.high              |
+| threshold-low                 | threshold-low                               | thresholds.low                | thresholds.low               |
 | threshold-break               | b \| break-at                               | thresholds.break              | thresholds.break             |
 | reporters                     | r \| reporter (flag allowed multiple times) | reporters                     | reporters                    |
 | project-file                  | p \| project                                | project-file                  | project                      |
@@ -76,7 +76,7 @@ Options migration overview:
 | dashboard-fallback-version    | ❌                                          | dashboard-fallback-version    | baseline.fallback-version    |
 | baseline-storage-location     | ❌                                          | baseline-storage-location     | baseline.provider            |
 | dashboard-compare             | with-baseline                               | dashboard-compare             | baseline                     |
-| git-diff-target               | \--since ...                                | git-diff-target               | since.target                 |
+| git-diff-target               | since                                       | git-diff-target               | since.target                 |
 | azure-storage-sas             | azure-fileshare-sas                         | azure-storage-sas             | ❌                           |
 | files-to-exclude              | ❌                                          | files-to-exclude              | ❌                           |
 | test-runner                   | ❌                                          | test-runner                   | ❌                           |

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -38,10 +38,10 @@ dotnet stryker --reporter "dashboard"
 ```
 
 The following options are relevant when using the dashboard reporter:
-- [Api key](./configuration.md#dashboard-api-key-<string>) - required
-- [Project name](./configuration.md#project-info.name-<string>) - required
-- [Project version](./configuration.md#project-info.version-<string>) - required
-- [Project module](./configuration.md#project-info.module-<string>) - optional
+- [Api key](./configuration.md#dashboard-api-key-string) - required
+- [Project name](./configuration.md#project-infoname-string) - required
+- [Project version](./configuration.md#project-infoversion-string) - required
+- [Project module](./configuration.md#project-infomodule-string) - optional
 
 # Cleartext reporter
 It displays all files right after the mutation testrun is done. Ideal for a quick run, as it leaves no file on your system.

--- a/docs/stryker-in-pipeline.md
+++ b/docs/stryker-in-pipeline.md
@@ -33,22 +33,19 @@ And then running this locally installed tool:
       script: $(Agent.BuildDirectory)/tools/dotnet-stryker
 ```
 
-## Configuring dashboard compare in pull requests
+## Configuring baseline in pull requests
 Dashboard compare is very useful when running stryker in pipelines because it cuts down on the total runtime by only testing mutations that have changed compared to for example master
 The following minimal steps are needed to use dashboard compare
 
-1. Enable --with-baseline
+1. Enable --with-baseline and choose the comparison target
 1. Choose a storage provider (Dashboard for public projects or Azure File Share for private projects)
 1. Set up authentication for the chosen storage provider 
 1. Set --version to the name of the source branch (usually current branch)
-1. Set --since to the name of the target branch (usually master/main or development)
 1. Set any other options needed for your chosen storage provider (see: [storage provider docs](https://stryker-mutator.io/docs/stryker-net/configuration#baselineprovider-string))
 
 Example for azure devops with dashboard storage provider:
 ```
-dotnet stryker --with-baseline --dashboard-api-key $(Stryker.Dashboard.Api.Key) --version $(System.PullRequest.SourceBranch) --since $(System.PullRequest.TargetBranch)
-or short:
-dotnet stryker --dashboard-api-key $(Stryker.Dashboard.Api.Key) -v $(System.PullRequest.SourceBranch) --since $(System.PullRequest.TargetBranch)
+dotnet stryker --with-baseline:$(System.PullRequest.TargetBranch) --dashboard-api-key $(Stryker.Dashboard.Api.Key) --version $(System.PullRequest.SourceBranch)
 ```
 
 ```json

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
@@ -49,9 +49,9 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var target = new AzureFileShareBaselineProvider(options, httpClient: httpClient);
 
-            var result = await target.Load("project_version");
+            var result = await target.Load("baseline/project_version");
 
-            var expectedUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
 
             handlerMock
                 .Protected()
@@ -83,13 +83,13 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var jsonReport = JsonReport.Build(options, readonlyInputComponent);
 
-            var expectedGetUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedGetUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedCreateDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/project_version?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version?restype=directory&sv=AZURE_SAS_KEY");
 
-            var expectedFileAllocationUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedFileAllocationUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/project_version/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
 
             handlerMock
                 .Protected()
@@ -132,7 +132,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var target = new AzureFileShareBaselineProvider(options, new HttpClient(handlerMock.Object));
 
-            await target.Save(jsonReport, "project_version");
+            await target.Save(jsonReport, "baseline/project_version");
 
             // assert
             handlerMock
@@ -185,7 +185,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
         {
             // arrange
             var projectName = "my-project-name";
-            var projectVersion = "my-project-version";
+            var projectVersion = "baseline/my-project-version";
 
             var options = new StrykerOptions
             {
@@ -201,15 +201,16 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var jsonReport = JsonReport.Build(options, readonlyInputComponent);
 
-            var expectedGetUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedGetUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedCreateProjectOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateBaselinesDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateProjectOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateBaselinesDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/baseline/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/?restype=directory&sv=AZURE_SAS_KEY");
 
-            var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/{projectName}/Baselines/{projectVersion}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
 
             handlerMock
                 .Protected()
@@ -224,6 +225,17 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
                 })
                 .Verifiable();
 
+            handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(requestMessage => requestMessage.RequestUri == expectedCreateOutputDirectoryUri && requestMessage.Method == HttpMethod.Put),
+                ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = System.Net.HttpStatusCode.Created
+                })
+                .Verifiable();
             handlerMock
                 .Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -292,10 +304,10 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
         }
 
         [Theory]
-        [InlineData("2.0.0")]
-        [InlineData("2.0.0-beta001")]
-        [InlineData("master")]
-        [InlineData("project_version")]
+        [InlineData("baseline/2.0.0")]
+        [InlineData("baseline/2.0.0-beta001")]
+        [InlineData("baseline/master")]
+        [InlineData("baseline/project_version")]
         public async Task Save_Calls_CreateDictionary_And_AllocateFileLocation_When_Baseline_Does_Not_Exists(string version)
         {
             // arrange
@@ -311,15 +323,15 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var jsonReport = JsonReport.Build(options, readonlyInputComponent);
 
-            var expectedGetUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/Baselines/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedGetUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
 
             var expectedCreateStrykerOutputDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateBaselinesDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/Baselines/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/Baselines/{version}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateBaselinesDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/?restype=directory&sv=AZURE_SAS_KEY");
 
-            var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/Baselines/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
+            var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/Baselines/{version}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
 
             handlerMock
                 .Protected()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
@@ -23,10 +23,10 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var sut = new DiskBaselineProvider(options, fileSystemMock);
 
             // Act
-            await sut.Save(JsonReport.Build(options, JsonReportTestHelper.CreateProjectWith().ToReadOnlyInputComponent()), "version");
+            await sut.Save(JsonReport.Build(options, JsonReportTestHelper.CreateProjectWith().ToReadOnlyInputComponent()), "baseline/version");
 
             // Assert
-            var path = FilePathUtils.NormalizePathSeparators(@"C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/Baselines/version/stryker-report.json");
+            var path = FilePathUtils.NormalizePathSeparators(@"C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/baseline/version/stryker-report.json");
 
             MockFileData file = fileSystemMock.GetFile(path);
             file.ShouldNotBeNull();
@@ -57,12 +57,12 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             };
             var report = JsonReport.Build(options, JsonReportTestHelper.CreateProjectWith().ToReadOnlyInputComponent());
 
-            fileSystemMock.AddFile("C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/Baselines/version/stryker-report.json", report.ToJson());
+            fileSystemMock.AddFile("C:/Users/JohnDoe/Project/TestFolder/StrykerOutput/baseline/version/stryker-report.json", report.ToJson());
 
             var target = new DiskBaselineProvider(options, fileSystemMock);
 
             // Act
-            var result = await target.Load("version");
+            var result = await target.Load("baseline/version");
 
             // Assert
             result.ShouldNotBeNull();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
@@ -59,14 +59,14 @@ namespace Stryker.Core.UnitTest.MutantFilters
 
             gitInfoProvider.Setup(x => x.GetCurrentBranchName()).Returns(branchName);
 
-            baselineProvider.Setup(x => x.Load(branchName)).Returns(Task.FromResult<JsonReport>(null));
+            baselineProvider.Setup(x => x.Load($"baseline/{branchName}")).Returns(Task.FromResult<JsonReport>(null));
             baselineProvider.Setup(x => x.Load($"baseline/{options.FallbackVersion}")).Returns(Task.FromResult(jsonReport));
 
             // Act
             var target = new BaselineMutantFilter(options, baselineProvider.Object, gitInfoProvider.Object);
 
             // Assert
-            baselineProvider.Verify(x => x.Load(branchName), Times.Once);
+            baselineProvider.Verify(x => x.Load($"baseline/{branchName}"), Times.Once);
             baselineProvider.Verify(x => x.Load($"baseline/{options.FallbackVersion}"), Times.Once);
             baselineProvider.VerifyNoOtherCalls();
         }
@@ -140,8 +140,9 @@ namespace Stryker.Core.UnitTest.MutantFilters
             var target = new BaselineMutantFilter(options, gitInfoProvider: gitInfoProvider.Object, baselineProvider: baselineProvider.Object);
 
             // Assert
-            baselineProvider.Verify(x => x.Load("dashboard-compare/refs/heads/master"), Times.Once);
-            baselineProvider.Verify(x => x.Load("fallback/version"), Times.Never);
+            baselineProvider.Verify(x => x.Load($"baseline/{branchName}"), Times.Once);
+            baselineProvider.Verify(x => x.Load($"baseline/{options.FallbackVersion}"), Times.Never);
+            baselineProvider.VerifyNoOtherCalls();
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DashboardMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/DashboardMutantFilterTests.cs
@@ -28,7 +28,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             var baselineMutantHelperMock = new Mock<IBaselineMutantHelper>(MockBehavior.Loose);
 
             // Act
-            var target = new DashboardMutantFilter(new StrykerOptions(), baselineProviderMock.Object, gitInfoProvider.Object, baselineMutantHelperMock.Object) as IMutantFilter;
+            var target = new BaselineMutantFilter(new StrykerOptions(), baselineProviderMock.Object, gitInfoProvider.Object, baselineMutantHelperMock.Object) as IMutantFilter;
 
             // Assert
             target.DisplayName.ShouldBe("dashboard filter");
@@ -62,7 +62,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             baselineProvider.Setup(x => x.Load("fallback/version")).Returns(Task.FromResult(jsonReport));
 
             // Act
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, gitInfoProvider.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, gitInfoProvider.Object);
 
             // Assert
             baselineProvider.Verify(x => x.Load("dashboard-compare/refs/heads/master"), Times.Once);
@@ -95,7 +95,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             baselineProvider.Setup(x => x.Load("dashboard-compare/refs/heads/master")).Returns(Task.FromResult(jsonReport));
 
             // Act
-            var target = new DashboardMutantFilter(options, gitInfoProvider: gitInfoProvider.Object, baselineProvider: baselineProvider.Object);
+            var target = new BaselineMutantFilter(options, gitInfoProvider: gitInfoProvider.Object, baselineProvider: baselineProvider.Object);
 
             // Assert
             baselineProvider.Verify(x => x.Load("dashboard-compare/refs/heads/master"), Times.Once);
@@ -115,7 +115,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
                 ProjectVersion = "version",
             };
 
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, branchProvider.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, branchProvider.Object);
 
             var file = new Mock<ReadOnlyFileLeaf>(new CsharpFileLeaf());
 
@@ -177,7 +177,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             baselineMutantHelper.Setup(mock => mock.GetMutantSourceCode(It.IsAny<string>(), It.IsAny<JsonMutant>())).Returns(string.Empty);
 
             // Act
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
 
             var results = target.FilterMutants(mutants, file, options);
 
@@ -239,7 +239,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
                 It.Is<string>(source => source == "var foo = \"bar\";"))).Returns(mutants).Verifiable();
 
             // Act
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
 
             var results = target.FilterMutants(mutants, file, options);
 
@@ -306,7 +306,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
                 It.Is<string>(source => source == "var foo = \"bar\";"))).Returns(mutants).Verifiable();
 
             // Act
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
 
             var results = target.FilterMutants(mutants, file, options);
 
@@ -359,7 +359,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             baselineProvider.Setup(mock => mock.Load(It.IsAny<string>())).Returns(Task.FromResult((JsonReport)baseline));
 
             // Act
-            var target = new DashboardMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
+            var target = new BaselineMutantFilter(options, baselineProvider.Object, branchProvider.Object, baselineMutantHelper.Object);
 
             var results = target.FilterMutants(mutants, file, options);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/MutantFilterFactoryTests.cs
@@ -123,7 +123,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
             var resultAsBroadcastFilter = result as BroadcastMutantFilter;
 
             resultAsBroadcastFilter.MutantFilters.Count().ShouldBe(6);
-            resultAsBroadcastFilter.MutantFilters.Where(x => x.GetType() == typeof(DashboardMutantFilter)).Count().ShouldBe(1);
+            resultAsBroadcastFilter.MutantFilters.Where(x => x.GetType() == typeof(BaselineMutantFilter)).Count().ShouldBe(1);
             resultAsBroadcastFilter.MutantFilters.Where(x => x.GetType() == typeof(DiffMutantFilter)).Count().ShouldBe(1);
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
@@ -18,16 +18,6 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         }
 
         [Fact]
-        public void FallbackVersionCannotBeProjectVersion()
-        {
-            var input = new FallbackVersionInput { SuppliedInput = "master" };
-
-            var exception = Should.Throw<InputException>(() => input.Validate(withBaseline: true, projectVersion: "master", sinceTarget: "master"));
-
-            exception.Message.ShouldBe("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
-        }
-
-        [Fact]
         public void ShouldNotValidate_IfNotEnabled()
         {
             var input = new FallbackVersionInput { SuppliedInput = "master" };

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
@@ -22,19 +22,39 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         {
             var input = new FallbackVersionInput { SuppliedInput = "master" };
 
-            var exception = Should.Throw<InputException>(() => input.Validate("master", true));
+            var exception = Should.Throw<InputException>(() => input.Validate(projectVersion: "master", dashboardEnabled: true));
 
             exception.Message.ShouldBe("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
         }
 
         [Fact]
-        public void ShouldAllowDevelopment()
+        public void ShouldNotValidate_IfNotEnabled()
+        {
+            var input = new FallbackVersionInput { SuppliedInput = "master" };
+
+            var validatedInput = input.Validate("master", dashboardEnabled: false);
+
+            validatedInput.ShouldBe(string.Empty);
+        }
+
+        [Fact]
+        public void ShouldUseProvidedInputValue()
         {
             var input = new FallbackVersionInput { SuppliedInput = "development" };
 
             var validatedInput = input.Validate("master", true);
 
             validatedInput.ShouldBe("development");
+        }
+
+        [Fact]
+        public void ShouldUseSinceTarget_IfNotExplicitlySet()
+        {
+            var input = new FallbackVersionInput();
+
+            var validatedInput = input.Validate("development", true);
+
+            validatedInput.ShouldBe("master");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/FallbackVersionInputTests.cs
@@ -14,7 +14,7 @@ namespace Stryker.Core.UnitTest.Options.Inputs
             target.HelpText.ShouldBe(@"Commitish used as a fallback when no report could be found based on Git information for the baseline feature.
 Can be semver, git commit hash, branch name or anything else to indicate what version of your software you're testing.
 When you don't specify a fallback version the since target will be used as fallback version.
-Example: If the current branch is based on the main branch, set 'main' as the fallback version | default: ''");
+Example: If the current branch is based on the main branch, set 'main' as the fallback version | default: 'master'");
         }
 
         [Fact]
@@ -22,7 +22,7 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         {
             var input = new FallbackVersionInput { SuppliedInput = "master" };
 
-            var exception = Should.Throw<InputException>(() => input.Validate(projectVersion: "master", dashboardEnabled: true));
+            var exception = Should.Throw<InputException>(() => input.Validate(withBaseline: true, projectVersion: "master", sinceTarget: "master"));
 
             exception.Message.ShouldBe("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
         }
@@ -32,9 +32,9 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         {
             var input = new FallbackVersionInput { SuppliedInput = "master" };
 
-            var validatedInput = input.Validate("master", dashboardEnabled: false);
+            var validatedInput = input.Validate(withBaseline: false, projectVersion: "master", sinceTarget: "master");
 
-            validatedInput.ShouldBe(string.Empty);
+            validatedInput.ShouldBe(new SinceTargetInput().Default);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         {
             var input = new FallbackVersionInput { SuppliedInput = "development" };
 
-            var validatedInput = input.Validate("master", true);
+            var validatedInput = input.Validate(withBaseline: true, projectVersion: "feat/feat4", sinceTarget: "master");
 
             validatedInput.ShouldBe("development");
         }
@@ -52,9 +52,9 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
         {
             var input = new FallbackVersionInput();
 
-            var validatedInput = input.Validate("development", true);
+            var validatedInput = input.Validate(withBaseline: true, projectVersion: "development", sinceTarget: "main");
 
-            validatedInput.ShouldBe("master");
+            validatedInput.ShouldBe("main");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/SinceTargetInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/SinceTargetInputTests.cs
@@ -37,14 +37,14 @@ namespace Stryker.Core.UnitTest.Options.Inputs
             {
                 new SinceTargetInput { SuppliedInput = "" }.Validate(sinceEnabled: true);
             });
-            ex.Message.ShouldBe("The target branch/commit cannot be empty when the since feature is enabled");
+            ex.Message.ShouldBe("The since target cannot be empty when the since feature is enabled");
         }
 
         [Fact]
         public void ShouldNotValidateSinceTargetWhenSinceDisabled()
         {
             var validatedSinceBranch = new SinceTargetInput { SuppliedInput = "develop" }.Validate(sinceEnabled: false);
-            validatedSinceBranch.ShouldBe(null);
+            validatedSinceBranch.ShouldBe("master");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
@@ -129,7 +129,7 @@ namespace Stryker.Core.UnitTest.Options
             _target.ReportersInput.SuppliedInput = new[] { "html" };
             _target.BaselineProviderInput.SuppliedInput = "dashboard";
             _target.WithBaselineInput.SuppliedInput = true;
-            _target.FallbackVersionInput.SuppliedInput = "develop";
+            _target.ProjectVersionInput.SuppliedInput = "develop";
 
             var result = _target.ValidateAll();
 
@@ -143,7 +143,7 @@ namespace Stryker.Core.UnitTest.Options
             _target.ReportersInput.SuppliedInput = new[] { "html" };
             _target.BaselineProviderInput.SuppliedInput = "disk";
             _target.WithBaselineInput.SuppliedInput = true;
-            _target.FallbackVersionInput.SuppliedInput = "develop";
+            _target.ProjectVersionInput.SuppliedInput = "develop";
 
             var result = _target.ValidateAll();
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/BaselineReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/BaselineReporterTests.cs
@@ -31,7 +31,7 @@ namespace Stryker.Core.UnitTest.Reporters
 
             target.OnAllMutantsTested(readOnlyInputComponent.Object);
 
-            baselineProvider.Verify(x => x.Save(It.IsAny<JsonReport>(), It.Is<string>(x => x == "dashboard-compare/new-feature")), Times.Once);
+            baselineProvider.Verify(x => x.Save(It.IsAny<JsonReport>(), It.Is<string>(x => x == "baseline/new-feature")), Times.Once);
             baselineProvider.Verify(x => x.Save(It.IsAny<JsonReport>(), It.Is<string>(x => x == "new-feature")), Times.Never);
         }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/BaselineReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/BaselineReporterTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Stryker.Core.UnitTest.Reporters
 {
-    public class GitBaselineReporterTests : TestBase
+    public class BaselineReporterTests : TestBase
     {
         [Fact]
         public void Doesnt_Use_ProjectVersion_When_CurrentBranch_Is_Not_Null()
@@ -27,7 +27,7 @@ namespace Stryker.Core.UnitTest.Reporters
 
             gitInfoProvider.Setup(x => x.GetCurrentBranchName()).Returns("new-feature");
 
-            var target = new GitBaselineReporter(options, baselineProvider.Object, gitInfoProvider.Object);
+            var target = new BaselineReporter(options, baselineProvider.Object, gitInfoProvider.Object);
 
             target.OnAllMutantsTested(readOnlyInputComponent.Object);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
@@ -47,7 +47,7 @@ namespace Stryker.Core.UnitTest.Reporters
             broadcastReporter.Reporters.ShouldContain(r => r is ClearTextTreeReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is ProgressReporter);
             broadcastReporter.Reporters.ShouldContain(r => r is DashboardReporter);
-            broadcastReporter.Reporters.ShouldContain(r => r is GitBaselineReporter);
+            broadcastReporter.Reporters.ShouldContain(r => r is BaselineReporter);
 
             result.Reporters.Count().ShouldBe(8);
         }

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
@@ -13,7 +13,7 @@ namespace Stryker.Core.Baseline.Providers
         private readonly StrykerOptions _options;
         private readonly IFileSystem _fileSystem;
         private readonly ILogger<DiskBaselineProvider> _logger;
-        private const string _outputPath = "StrykerOutput/Baselines/";
+        private const string _outputPath = "StrykerOutput";
 
         public DiskBaselineProvider(StrykerOptions options, IFileSystem fileSystem = null)
         {

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/BaselineMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/BaselineMutantFilter.cs
@@ -14,22 +14,22 @@ using Stryker.Core.Reporters.Json;
 
 namespace Stryker.Core.MutantFilters
 {
-    public class DashboardMutantFilter : IMutantFilter
+    public class BaselineMutantFilter : IMutantFilter
     {
 
         private readonly IBaselineProvider _baselineProvider;
         private readonly IGitInfoProvider _gitInfoProvider;
-        private readonly ILogger<DashboardMutantFilter> _logger;
+        private readonly ILogger<BaselineMutantFilter> _logger;
         private readonly IBaselineMutantHelper _baselineMutantHelper;
 
         private readonly StrykerOptions _options;
         private readonly JsonReport _baseline;
 
-        public string DisplayName => "dashboard filter";
+        public string DisplayName => "baseline filter";
 
-        public DashboardMutantFilter(StrykerOptions options, IBaselineProvider baselineProvider = null, IGitInfoProvider gitInfoProvider = null, IBaselineMutantHelper baselineMutantHelper = null)
+        public BaselineMutantFilter(StrykerOptions options, IBaselineProvider baselineProvider = null, IGitInfoProvider gitInfoProvider = null, IBaselineMutantHelper baselineMutantHelper = null)
         {
-            _logger = ApplicationLogging.LoggerFactory.CreateLogger<DashboardMutantFilter>();
+            _logger = ApplicationLogging.LoggerFactory.CreateLogger<BaselineMutantFilter>();
             _baselineProvider = baselineProvider ?? BaselineProviderFactory.Create(options);
             _gitInfoProvider = gitInfoProvider ?? new GitInfoProvider(options);
             _baselineMutantHelper = baselineMutantHelper ?? new BaselineMutantHelper();

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -41,7 +41,7 @@ namespace Stryker.Core.MutantFilters
 
             if (options.WithBaseline)
             {
-                enabledFilters.Add(new DashboardMutantFilter(options, _baselineProvider, _gitInfoProvider));
+                enabledFilters.Add(new BaselineMutantFilter(options, _baselineProvider, _gitInfoProvider));
             }
             if (options.Since || options.WithBaseline)
             {

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/FallbackVersionInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/FallbackVersionInput.cs
@@ -9,17 +9,26 @@ Can be semver, git commit hash, branch name or anything else to indicate what ve
 When you don't specify a fallback version the since target will be used as fallback version.
 Example: If the current branch is based on the main branch, set 'main' as the fallback version";
 
-        public override string Default => string.Empty;
+        public override string Default => new SinceTargetInput().Default;
 
-        public string Validate(string projectVersion, bool? dashboardEnabled)
+        public string Validate(bool withBaseline, string projectVersion, string sinceTarget)
         {
-            if (dashboardEnabled.IsNotNullAndTrue() && SuppliedInput == projectVersion)
+            if (withBaseline)
             {
-                // Fallback version is used when the current branch cannot be found on the dashboard for the baseline feature. Thus fallback needs to be another version
-                throw new InputException("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
+                if(SuppliedInput is null)
+                {
+                    return sinceTarget;
+                }
+
+                if (SuppliedInput == projectVersion)
+                {
+                    // Fallback version is used when a baseline for the project version cannot be found by the baseline provider. Thus fallback needs to be different.
+                    throw new InputException("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
+                }
+                return SuppliedInput;
             }
 
-            return SuppliedInput;
+            return Default;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/FallbackVersionInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/FallbackVersionInput.cs
@@ -20,11 +20,6 @@ Example: If the current branch is based on the main branch, set 'main' as the fa
                     return sinceTarget;
                 }
 
-                if (SuppliedInput == projectVersion)
-                {
-                    // Fallback version is used when a baseline for the project version cannot be found by the baseline provider. Thus fallback needs to be different.
-                    throw new InputException("Fallback version cannot be set to the same value as the current project version, please provide a different fallback version");
-                }
                 return SuppliedInput;
             }
 

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectVersionInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/ProjectVersionInput.cs
@@ -11,16 +11,18 @@ namespace Stryker.Core.Options.Inputs
 
         protected override string Description => "Project version used in dashboard reporter and baseline feature.";
 
-        public string Validate(string fallbackVersion, IEnumerable<Reporter> reporters, bool? dashboardCompareEnabled)
+        public string Validate(IEnumerable<Reporter> reporters, bool withBaseline)
         {
-            if (reporters.Contains(Reporter.Dashboard))
+            if (reporters.Contains(Reporter.Dashboard) || withBaseline)
             {
-                if (dashboardCompareEnabled.IsNotNullAndTrue() && fallbackVersion == SuppliedInput)
+                if (withBaseline && string.IsNullOrWhiteSpace(SuppliedInput))
                 {
-                    throw new InputException("Project version cannot be the same as the fallback version. Please provide a different version for one of them.");
+                    throw new InputException("Project version cannot be empty when baseline is enabled");
                 }
+                return SuppliedInput ?? Default;
             }
-            return SuppliedInput ?? Default;
+
+            return Default;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceTargetInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceTargetInput.cs
@@ -9,20 +9,16 @@ namespace Stryker.Core.Options.Inputs
 
         public string Validate(bool sinceEnabled)
         {
-            if (sinceEnabled)
+            if (sinceEnabled && SuppliedInput is not null)
             {
-                if (!string.IsNullOrWhiteSpace(SuppliedInput))
+                if (string.IsNullOrWhiteSpace(SuppliedInput))
                 {
-                    return SuppliedInput;
+                    throw new InputException("The since target cannot be empty when the since feature is enabled");
                 }
 
-                if(SuppliedInput is null)
-                {
-                    return Default;
-                }
-                throw new InputException("The target branch/commit cannot be empty when the since feature is enabled");
+                return SuppliedInput;
             }
-            return null;
+            return Default;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
@@ -111,6 +111,8 @@ namespace Stryker.Core.Options
             var reporters = ReportersInput.Validate(withBaseline);
             var baselineProvider = BaselineProviderInput.Validate(reporters);
             var sinceEnabled = SinceInput.Validate(WithBaselineInput.SuppliedInput);
+            var sinceTarget = SinceTargetInput.Validate(sinceEnabled);
+            var projectVersion = ProjectVersionInput.Validate(reporters, withBaseline);
 
             _strykerOptionsCache ??= new StrykerOptions()
             {
@@ -146,18 +148,18 @@ namespace Stryker.Core.Options
                 TestProjects = TestProjectsInput.Validate(),
                 TestCaseFilter = TestCaseFilterInput.Validate(),
                 DashboardUrl = DashboardUrlInput.Validate(),
-                DashboardApiKey = DashboardApiKeyInput.Validate(WithBaselineInput.SuppliedInput, baselineProvider, reporters),
+                DashboardApiKey = DashboardApiKeyInput.Validate(withBaseline, baselineProvider, reporters),
                 ProjectName = ProjectNameInput.Validate(),
                 ModuleName = ModuleNameInput.Validate(),
-                ProjectVersion = ProjectVersionInput.Validate(FallbackVersionInput.SuppliedInput, reporters, WithBaselineInput.SuppliedInput),
+                ProjectVersion = ProjectVersionInput.Validate(reporters, withBaseline),
                 DiffIgnoreChanges = DiffIgnoreChangesInput.Validate(),
                 AzureFileStorageSas = AzureFileStorageSasInput.Validate(baselineProvider),
                 AzureFileStorageUrl = AzureFileStorageUrlInput.Validate(baselineProvider),
                 WithBaseline = withBaseline,
                 BaselineProvider = baselineProvider,
-                FallbackVersion = FallbackVersionInput.Validate(ProjectVersionInput.SuppliedInput, WithBaselineInput.SuppliedInput),
+                FallbackVersion = FallbackVersionInput.Validate(withBaseline, projectVersion, sinceTarget),
                 Since = sinceEnabled,
-                SinceTarget = SinceTargetInput.Validate(sinceEnabled),
+                SinceTarget = sinceTarget,
                 ReportTypeToOpen = OpenReportInput.Validate(OpenReportEnabledInput.Validate())
             };
             return _strykerOptionsCache;

--- a/src/Stryker.Core/Stryker.Core/Reporters/BaselineReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/BaselineReporter.cs
@@ -24,7 +24,7 @@ namespace Stryker.Core.Reporters
         {
             var mutationReport = JsonReport.Build(_options, reportComponent);
             var projectVersion = _gitInfoProvider.GetCurrentBranchName();
-            var baselineVersion = $"dashboard-compare/{projectVersion}";
+            var baselineVersion = $"baseline/{projectVersion}";
 
             _baselineProvider.Save(mutationReport, baselineVersion).Wait();
         }

--- a/src/Stryker.Core/Stryker.Core/Reporters/BaselineReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/BaselineReporter.cs
@@ -7,13 +7,13 @@ using Stryker.Core.Reporters.Json;
 
 namespace Stryker.Core.Reporters
 {
-    public class GitBaselineReporter : IReporter
+    public class BaselineReporter : IReporter
     {
         private readonly StrykerOptions _options;
         private readonly IBaselineProvider _baselineProvider;
         private readonly IGitInfoProvider _gitInfoProvider;
 
-        public GitBaselineReporter(StrykerOptions options, IBaselineProvider baselineProvider = null, IGitInfoProvider gitInfoProvider = null)
+        public BaselineReporter(StrykerOptions options, IBaselineProvider baselineProvider = null, IGitInfoProvider gitInfoProvider = null)
         {
             _options = options;
             _baselineProvider = baselineProvider ?? BaselineProviderFactory.Create(options);

--- a/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
@@ -31,7 +31,7 @@ namespace Stryker.Core.Reporters
                 { Reporter.Json, new JsonReporter(options) },
                 { Reporter.Html, new Html.reporter.HtmlReporter(options) },
                 { Reporter.Dashboard, new DashboardReporter(options) },
-                { Reporter.Baseline, new GitBaselineReporter(options) }
+                { Reporter.Baseline, new BaselineReporter(options) }
             };
         }
 


### PR DESCRIPTION
fix #1798

Technically this is a breaking change since I changed the folder paths but I don't think this will have a huge impact as it will simply mean regenerating the baseline once.

@richardwerkman do you agree with allowing this 'breaking' change in a fix?
@sbergen since you actually use this feature, do you agree with changing the folder path from `dashboard-compare` to `baseline`?