### PR TITLE
Potential fix for handling self-contained apps

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Buildalyzer;
+using Buildalyzer.Environment;
 using Moq;
 using Shouldly;
 using Stryker.Core.Initialisation;
@@ -24,7 +25,7 @@ namespace Stryker.Core.UnitTest.Initialisation
                 .Returns(projectAnalyzerMock.Object);
 
             projectAnalyzerMock
-                .Setup(m => m.Build())
+                .Setup(m => m.Build(It.IsAny<EnvironmentOptions>()))
                 .Returns(analyzerResultsMock.Object);
 
             analyzerResultsMock

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Buildalyzer;
+using Buildalyzer.Environment;
 using Microsoft.Build.Exceptions;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.Exceptions;
@@ -51,7 +52,7 @@ namespace Stryker.Core.Initialisation
             }
 
             _logger.LogDebug("Analyzing project file {0}", projectFilePath);
-            var analyzerResults = _manager.GetProject(projectFilePath).Build();
+            var analyzerResults = _manager.GetProject(projectFilePath).Build(new EnvironmentOptions { DesignTime = false });
             var analyzerResult = SelectAnalyzerResult(analyzerResults, targetFramework);
 
             LogAnalyzerResult(analyzerResult);


### PR DESCRIPTION
#1855 

See discussion [here](https://github.com/daveaglick/Buildalyzer/pull/194).

So technically this is not a pinpoint solution for the original problem, in that it fixes the problem in quite a dramatic way. 
On the other hand, from what I understand, similar problems were encountered before, probably for the same reason. So maybe it's worth applying as a prevention.

Giving that you guys here know quite a lot of stuff about MSBuild and I don't, this PR is partially meant as a discussion :) thoughts?