### PR TITLE
Miscellaneous fixes and improvments

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Shouldly;
 using Stryker.Core.MutantFilters;
@@ -184,6 +185,99 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
 
             // Assert
             filteredMutants.ShouldNotContain(mutant);
+        }
+
+        [Fact]
+        public void ShouldFilterStatementAndBlockWithOnlyIgnoredMethods()
+        {
+            // Arrange
+            var source = @"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        Dispose();
+        Dispose();
+    }
+}";
+            var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+            var originalNode = (StatementSyntax)baseSyntaxTree.DescendantNodes().First(t => t is StatementSyntax and not BlockSyntax);
+
+            var mutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = originalNode,
+                }
+            };
+
+            var options = new StrykerOptions
+            {
+                IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { "Dispose" } }.Validate()
+            };
+
+            var blockMutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = (BlockSyntax)baseSyntaxTree.DescendantNodes().First(t => t is BlockSyntax),
+                }
+            };
+
+            var sut = new IgnoredMethodMutantFilter();
+
+            // Act
+            var filteredMutants = sut.FilterMutants(new[] { mutant, blockMutant }, null, options);
+
+            // Assert
+            filteredMutants.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ShouldFilterStatementAndBlockWithNonIgnoredMethods()
+        {
+            // Arrange
+            var source = @"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        Dispose();
+        TestMethod();
+    }
+}";
+            var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+            var originalNode = (StatementSyntax)baseSyntaxTree.DescendantNodes().First(t => t is StatementSyntax and not BlockSyntax);
+
+            var mutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = originalNode,
+                }
+            };
+
+            var options = new StrykerOptions
+            {
+                IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { "Dispose" } }.Validate()
+            };
+
+            var blockMutant = new Mutant
+            {
+                Mutation = new Mutation
+                {
+                    OriginalNode = (BlockSyntax)baseSyntaxTree.DescendantNodes().First(t => t is BlockSyntax),
+                }
+            };
+
+            var sut = new IgnoredMethodMutantFilter();
+
+            // Act
+            var filteredMutants = sut.FilterMutants(new[] { mutant, blockMutant }, null, options);
+
+            // Assert
+            filteredMutants.ShouldNotContain(mutant);
+            filteredMutants.ShouldContain(blockMutant);
         }
 
         [Theory]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -278,7 +278,7 @@ private bool Out(int test, Func<int, bool>lambda )
             string expected = @"void TestMethod()
 {if(StrykerNamespace.MutantControl.IsActive(0)){}else{
 	int i = 0;
-	var result = (StrykerNamespace.MutantControl.IsActive(1)?!(Out(i, (x) => { int.TryParse(""3"", out int y); return x == y;} ) ):Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ int.TryParse((StrykerNamespace.MutantControl.IsActive(3)?"""":""3""), out int y); return (StrykerNamespace.MutantControl.IsActive(4)?x != y:x == y);} return default;}) )? i.ToString() : (StrykerNamespace.MutantControl.IsActive(5)?""Stryker was here!"":"""");
+	var result = (StrykerNamespace.MutantControl.IsActive(1)?!(Out(i, (x) => { int.TryParse(""3"", out int y); return x == y;} ) ):Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ int.TryParse((StrykerNamespace.MutantControl.IsActive(3)?"""":""3""), out int y); return (StrykerNamespace.MutantControl.IsActive(4)?x != y:x == y);}}) )? i.ToString() : (StrykerNamespace.MutantControl.IsActive(5)?""Stryker was here!"":"""");
 }
     }
     private bool Out(int test, Func<int, bool> lambda)
@@ -946,7 +946,7 @@ if(StrykerNamespace.MutantControl.IsActive(3)){;}else{		request.Headers.Add((Str
 }if(StrykerNamespace.MutantControl.IsActive(6)){;}else{		request.Headers.TryAddWithoutValidation((StrykerNamespace.MutantControl.IsActive(7)?"""":""Date""), date);
 }
 }
-return default;}, ensureSuccessStatusCode: (StrykerNamespace.MutantControl.IsActive(8) ? true : false));
+}, ensureSuccessStatusCode: (StrykerNamespace.MutantControl.IsActive(8) ? true : false));
 }}}";
 
             ShouldMutateSourceToExpected(source, expected);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -278,8 +278,7 @@ private bool Out(int test, Func<int, bool>lambda )
             string expected = @"void TestMethod()
 {if(StrykerNamespace.MutantControl.IsActive(0)){}else{
 	int i = 0;
-	var result = (StrykerNamespace.MutantControl.IsActive(1)?!(Out(i, (x) => { int.TryParse(""3"", out int y); return x == y;} ) ):Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ int.TryParse((StrykerNamespace.MutantControl.IsActive(3)?"""":""3""), out int y); return (StrykerNamespace.MutantControl.IsActive(4)?x != y:x == y);}}) )? i.ToString() : (StrykerNamespace.MutantControl.IsActive(5)?""Stryker was here!"":"""");
-}
+	var result = (StrykerNamespace.MutantControl.IsActive(1)?!(Out(i, (x) => { int.TryParse(""3"", out int y); return x == y;} ) ):Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ int.TryParse((StrykerNamespace.MutantControl.IsActive(3)?"""":""3""), out int y); return (StrykerNamespace.MutantControl.IsActive(4)?x != y:x == y);} return default;}) )? i.ToString() : (StrykerNamespace.MutantControl.IsActive(5)?""Stryker was here!"":"""");}
     }
     private bool Out(int test, Func<int, bool> lambda)
     {
@@ -291,6 +290,43 @@ private bool Out(int test, Func<int, bool>lambda )
         }
         return default(bool);
     }";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
+        public void ShouldMutateWhenDeclarationInInnerScopeInExpressionForm()
+        {
+            var source = @"void TestMethod()
+{
+	int i = 0;
+	var result = Out(i, (x) => int.TryParse(""3"", out int y) ? true : false);
+}
+";
+            var expected = @"void TestMethod()
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+	int i = 0;
+	var result = Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(1)){return!(int.TryParse(""3"", out int y) )? true : false;}else{return int.TryParse((StrykerNamespace.MutantControl.IsActive(2)?"""":""3""), out int y) ? (StrykerNamespace.MutantControl.IsActive(3)?false:true ): (StrykerNamespace.MutantControl.IsActive(4)?true:false);}});
+}}
+";
+
+            ShouldMutateSourceToExpected(source, expected);
+        }
+
+        [Fact]
+        public void ShouldMutateLambdaAndAddDefaultReturn()
+        {
+            var source = @"void TestMethod()
+{
+	int i = 0;
+	var result = Out(i, (x) => {if (x>2) return false; i++;});
+}
+";
+            var expected = @"void TestMethod()
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+	int i = 0;
+	var result = Out(i, (x) => {if(StrykerNamespace.MutantControl.IsActive(1)){}else{if ((StrykerNamespace.MutantControl.IsActive(4)?!(x>2):(StrykerNamespace.MutantControl.IsActive(3)?x>=2:(StrykerNamespace.MutantControl.IsActive(2)?x<2:x>2)))) return (StrykerNamespace.MutantControl.IsActive(5)?true:false); if(StrykerNamespace.MutantControl.IsActive(6)){;}else{if(StrykerNamespace.MutantControl.IsActive(7)){i--;}else{i++;}}}return default;});}}
+";
 
             ShouldMutateSourceToExpected(source, expected);
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BlockMutatorTests.cs
@@ -57,6 +57,30 @@ struct Program
         }
 
         [Fact]
+        public void ShouldNotMutateSwitchCasesBlock()
+        {
+            var source = @"
+struct Program
+{
+    int mustBeInitialized;
+    bool alsoThisMustBeInitialized;
+
+    Program(int value)
+    {
+        switch(value)
+        {
+            default:
+            {
+                value++;
+            }
+        }
+    }
+}";
+            // there should be only a mutation for the whole method body
+            GetMutations(source).ShouldHaveSingleItem();
+        }
+
+        [Fact]
         public void ShouldMutateLocalFunctionsInStructConstructors()
         {
             var source = @"

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
@@ -187,6 +187,18 @@ namespace Stryker.Core.UnitTest.Reporters.Progress
             }
         }
 
+
+        [Fact]
+        public void ProgressBarSmokeCheck()
+        {
+            var progress = new ProgressBar();
+            progress.Start(0, "test");
+            progress.Tick("next");
+            progress.Stop();
+
+            progress.Dispose();
+        }
+
         private void VerifyProgress(string progressBar, int tested, int total, int percentage, string estimate)
         {
             if (tested > 0)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using Shouldly;
 using Stryker.Core.Mutants;
 using Stryker.Core.Reporters.Progress;
 using Xunit;
@@ -194,9 +195,11 @@ namespace Stryker.Core.UnitTest.Reporters.Progress
             var progress = new ProgressBar();
             progress.Start(0, "test");
             progress.Tick("next");
+            progress.Ticks().ShouldBe(1);
             progress.Stop();
 
             progress.Dispose();
+            progress.Ticks().ShouldBe(-1);
         }
 
         private void VerifyProgress(string progressBar, int tested, int total, int percentage, string estimate)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -1854,8 +1854,8 @@
           "Serilog.Extensions.Logging.File": "2.0.0",
           "Serilog.Sinks.Console": "4.0.1",
           "ShellProgressBar": "5.1.0",
-          "Stryker.DataCollector": "1.2.2",
-          "Stryker.RegexMutators": "1.2.2",
+          "Stryker.DataCollector": "1.0.0",
+          "Stryker.RegexMutators": "1.0.0",
           "System.IO.Abstractions": "16.1.4",
           "System.Net.Http.Json": "6.0.0"
         }

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -152,16 +152,16 @@ namespace Stryker.Core.Compiling
 
         private void ScanAllMutationsIfsAndIds(SyntaxNode node,  IList<(SyntaxNode, int)> scan)
         {
+            foreach (var childNode in node.ChildNodes())
+            {
+                ScanAllMutationsIfsAndIds(childNode, scan);
+            }
             var id = ExtractMutationIfAndId(node);
             if (id != null)
             {
                 scan.Add((node, id.Value));
             }
 
-            foreach (var childNode in node.ChildNodes())
-            {
-                ScanAllMutationsIfsAndIds(childNode, scan);
-            }
         }
 
         private void DumpBuildErrors(KeyValuePair<SyntaxTree, ICollection<Diagnostic>> syntaxTreeMap)

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -148,7 +148,7 @@ namespace Stryker.Core.Helpers
             var hasReturn = false;
             syntax.ScanChildStatements(s =>
             {
-                if (syntax is not ReturnStatementSyntax { Expression: { } })
+                if (s is not ReturnStatementSyntax { Expression: { } })
                 {
                     return true;
                 }

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -76,18 +76,18 @@ namespace Stryker.Core.Helpers
             !localFunction.ReturnType.IsVoid();
 
         /// <summary>
-        /// Checks if a member is static
-        /// </summary>
-        /// <param name="node">Member to analyze</param>
-        /// <returns>true if it is a static method, properties, fields...</returns>
-        public static bool IsStatic(this MemberDeclarationSyntax node) => node.Modifiers.Any(x => x.Kind() == SyntaxKind.StaticKeyword);
-
-        /// <summary>
         /// Checks if an accessor is a getter and needs to end with a return
         /// </summary>
         /// <param name="baseMethod"></param>
         /// <returns>true if this is a getter</returns>
         public static bool NeedsReturn(this AccessorDeclarationSyntax baseMethod) => baseMethod.IsGetter();
+
+        /// <summary>
+        /// Checks if a member is static
+        /// </summary>
+        /// <param name="node">Member to analyze</param>
+        /// <returns>true if it is a static method, properties, fields...</returns>
+        public static bool IsStatic(this MemberDeclarationSyntax node) => node.Modifiers.Any(x => x.Kind() == SyntaxKind.StaticKeyword);
 
         /// <summary>
         /// Returns true if the given type is 'void'.
@@ -137,5 +137,53 @@ namespace Stryker.Core.Helpers
         /// <param name="type">Type used in the resulting default expression.</param>
         /// <returns>An expression representing `default(<paramref name="type"/>'.</returns>
         public static ExpressionSyntax BuildDefaultExpression(this TypeSyntax type) => SyntaxFactory.DefaultExpression(type.WithoutTrailingTrivia()).WithLeadingTrivia(SyntaxFactory.Space);
+
+        /// <summary>
+        /// Check (recursively) if the statement returns some value.
+        /// </summary>
+        /// <param name="syntax">statement to analyze.</param>
+        /// <returns>true is the statement returns a value in at least one path.</returns>
+        public static bool ContainsValueReturn(this StatementSyntax syntax)
+        {
+            var hasReturn = false;
+            syntax.ScanChildStatements(s =>
+            {
+                if (syntax is not ReturnStatementSyntax { Expression: { } })
+                {
+                    return true;
+                }
+                hasReturn = true;
+                return false;
+
+            });
+            return hasReturn;
+        }
+
+        public static bool ScanChildStatements(this StatementSyntax syntax, Func<StatementSyntax, bool> predicate)
+        {
+            switch (syntax)
+            {
+                case BlockSyntax block:
+                    return block.Statements.All(s => ScanChildStatements(s, predicate));
+                case LocalFunctionStatementSyntax:
+                    break;
+                case ForStatementSyntax forStatement:
+                    return forStatement.Statement.ScanChildStatements(predicate);
+                case WhileStatementSyntax whileStatement:
+                    return whileStatement.Statement.ScanChildStatements(predicate);
+                case DoStatementSyntax doStatement:
+                    return doStatement.Statement.ScanChildStatements(predicate);
+                case SwitchStatementSyntax switchStatement:
+                    return switchStatement.Sections.SelectMany(s => s.Statements).All(statement => ScanChildStatements(statement, predicate));
+                case IfStatementSyntax ifStatement:
+                    if (!ifStatement.Statement.ScanChildStatements(predicate))
+                        return false;
+                    return ifStatement.Else?.Statement.ScanChildStatements(predicate) != false;
+                default:
+                    return predicate(syntax);
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
@@ -24,7 +24,6 @@ namespace Stryker.Core.Instrumentation
                 // no need to convert
                 return method;
             }
-
             var  statementLine = SyntaxFactory.ReturnStatement(method.ExpressionBody.WithLeadingTrivia(SyntaxFactory.Space));
 
             // do we need add return to the expression body?

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/EndingReturnEngine.cs
@@ -16,13 +16,13 @@ namespace Stryker.Core.Instrumentation
         {
             var returnType = type;
             BlockSyntax ret;
-            // if we had no body or the the last statement was a return, no need to add one, or this is an iterator method
+            // if we had no body or the last statement is a return, no need to add one, or this is an iterator method
             if (block == null
                 || returnType == null
                 || block.Statements.Count == 0
                 || block!.Statements.Last().Kind() == SyntaxKind.ReturnStatement
                 || returnType.IsVoid()
-                || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement)|| x.IsKind(SyntaxKind.YieldBreakStatement), false))
+                || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement) || x.IsKind(SyntaxKind.YieldBreakStatement), false))
             {
                 ret = null;
             }
@@ -48,19 +48,21 @@ namespace Stryker.Core.Instrumentation
             return ret == null ? block : ret.WithAdditionalAnnotations(Marker);
         }
 
-        public BlockSyntax InjectReturn(BlockSyntax block, SyntaxTokenList modifiers)
+        public BlockSyntax InjectReturn(BlockSyntax block)
         {
             BlockSyntax ret;
             // if we had no body or the the last statement was a return, no need to add one, or this is an iterator method
             if (block == null
                 || block.Statements.Count == 0
                 || block!.Statements.Last().Kind() == SyntaxKind.ReturnStatement
+                || !block.ContainsValueReturn()
                 || block.ContainsNodeThatVerifies(x => x.IsKind(SyntaxKind.YieldReturnStatement) || x.IsKind(SyntaxKind.YieldBreakStatement), false))
             {
                 ret = null;
             }
             else
             {
+                
                 ret = block.AddStatements(
                     SyntaxFactory.ReturnStatement(SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression).WithLeadingTrivia(SyntaxFactory.Space)));
             }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -80,7 +80,7 @@ namespace Stryker.Core.Mutants
         public static LocalFunctionStatementSyntax AddEndingReturn(LocalFunctionStatementSyntax function) =>
             function.WithBody(endingReturnEngine.InjectReturn(function.Body, function.ReturnType, function.Modifiers));
         public static AnonymousFunctionExpressionSyntax AddEndingReturn(AnonymousFunctionExpressionSyntax function) =>
-            function.WithBlock(endingReturnEngine.InjectReturn(function.Block, function.Modifiers));
+            function.WithBlock(endingReturnEngine.InjectReturn(function.Block));
 
         public static BlockSyntax PlaceStaticContextMarker(BlockSyntax block) => 
             staticEngine.PlaceStaticContextMarker(block);

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
@@ -14,7 +14,7 @@ namespace Stryker.Core.Reporters.Progress
 
     public class ProgressBar : IProgressBar, IDisposable
     {
-        private readonly ProgressBarOptions _options = new ProgressBarOptions
+        private readonly ProgressBarOptions _options = new()
         {
             ForegroundColor = ConsoleColor.Yellow,
             ForegroundColorDone = ConsoleColor.Green,

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
@@ -32,6 +32,8 @@ namespace Stryker.Core.Reporters.Progress
 
         public void Stop() => Dispose();
 
+        public int Ticks() => _progressBar?.CurrentTick ?? -1;
+
         protected virtual void Dispose(bool disposing)
         {
             if (_disposedValue)
@@ -41,6 +43,7 @@ namespace Stryker.Core.Reporters.Progress
             if (disposing)
             {
                 _progressBar?.Dispose();
+                _progressBar = null;
             }
 
             _disposedValue = true;

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBar.cs
@@ -1,4 +1,4 @@
-﻿using ShellProgressBar;
+using ShellProgressBar;
 using System;
 
 namespace Stryker.Core.Reporters.Progress
@@ -26,32 +26,24 @@ namespace Stryker.Core.Reporters.Progress
         private bool _disposedValue;
         private ShellProgressBar.ProgressBar _progressBar;
 
-        public void Start(int maxTicks, string message)
-        {
-            _progressBar = new ShellProgressBar.ProgressBar(maxTicks, message, _options);
-        }
+        public void Start(int maxTicks, string message) => _progressBar = new ShellProgressBar.ProgressBar(Math.Max(maxTicks, 1), message, _options);
 
-        public void Tick(string message)
-        {
-            _progressBar.Tick(message);
-        }
+        public void Tick(string message) => _progressBar.Tick(message);
 
-        public void Stop()
-        {
-            Dispose();
-        }
+        public void Stop() => Dispose();
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposedValue)
+            if (_disposedValue)
             {
-                if (disposing)
-                {
-                    _progressBar?.Dispose();
-                }
-
-                _disposedValue = true;
+                return;
             }
+            if (disposing)
+            {
+                _progressBar?.Dispose();
+            }
+
+            _disposedValue = true;
         }
 
         public void Dispose()


### PR DESCRIPTION
1. Block and statement mutations may now be ignored by IgnoredMethod option. Technically, statement mutations are ignored if the original code is an invocation of an 'ignored' method; block mutations are ignored if they only contain invocations of ignored method (or blocks of).
2. Fix exceptions when rolling back some expression body to statement body conversion. Technically, mutations are (now) rolled back with a depth first approach
3. Fix breaking `return default;` added to anonymous lambda that do not return any value. Technically, there is now a check to verify if the lambda contains a `return xxx` statement.-; if not, the lambda is assumed as `void`. This removes all related compilation errors but it should not have any impact on overall result.
4. Fix compilation errors with switch case due to block mutations. Technically, `BlockMutator` no longer mutates `case` related blocks. As this problem triggers safe mode, it should result in having more mutations tested for impacted code base.
5. (Definitive?) Fix for NREs linked to progress bar. Technically, the number of ticks is always at least '1', even when there is no mutant.