### PR TITLE
Use the NuGet.Frameworks package to parse target frameworks

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -666,8 +666,8 @@
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA=="
+        "resolved": "6.1.0",
+        "contentHash": "koaAF1Uoocky37pffe9CK3gowq4iZtusAmsl2hSV6fRv0Pmq0ik9ncAAbiMCCuycqsd9jO6HHBwzTEH9m8wusg=="
       },
       "NuGet.Versioning": {
         "type": "Transitive",
@@ -1858,6 +1858,7 @@
           "Microsoft.TestPlatform.TranslationLayer": "17.1.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.161",
           "Mono.Cecil": "0.11.4",
+          "NuGet.Frameworks": "6.1.0",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -524,8 +524,8 @@
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA=="
+        "resolved": "6.1.0",
+        "contentHash": "koaAF1Uoocky37pffe9CK3gowq4iZtusAmsl2hSV6fRv0Pmq0ik9ncAAbiMCCuycqsd9jO6HHBwzTEH9m8wusg=="
       },
       "RegexParser": {
         "type": "Transitive",
@@ -1260,6 +1260,7 @@
           "Microsoft.TestPlatform.TranslationLayer": "17.1.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.161",
           "Mono.Cecil": "0.11.4",
+          "NuGet.Frameworks": "6.1.0",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -43,7 +43,8 @@ namespace Stryker.Core.UnitTest.Initialisation
                     ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
                         references: new string[0]).Object,
                     TestProjectAnalyzerResults = new List<IAnalyzerResult> { TestHelper.SetupProjectAnalyzerResult(
-                        projectFilePath: "C://Example/Dir/ProjectFolder").Object
+                        projectFilePath: "C://Example/Dir/ProjectFolder",
+                        targetFramework: "netcoreapp2.1").Object
                     },
                     ProjectContents = folder
                 });
@@ -89,7 +90,8 @@ namespace Stryker.Core.UnitTest.Initialisation
                     ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
                         references: new string[0]).Object,
                     TestProjectAnalyzerResults = new List<IAnalyzerResult> { TestHelper.SetupProjectAnalyzerResult(
-                        projectFilePath: "C://Example/Dir/ProjectFolder").Object
+                        projectFilePath: "C://Example/Dir/ProjectFolder",
+                        targetFramework: "netcoreapp2.1").Object
                     },
                     ProjectContents = folder
                 });

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
@@ -40,6 +40,8 @@ namespace Stryker.Core.UnitTest.Initialisation
             var analyzerResultFrameworkXMock = new Mock<IAnalyzerResult>();
             var analyzerResultFrameworkYMock = new Mock<IAnalyzerResult>();
 
+            analyzerResultFrameworkXMock.Setup(m => m.Succeeded).Returns(true);
+            analyzerResultFrameworkYMock.Setup(m => m.Succeeded).Returns(true);
             analyzerResultFrameworkXMock.Setup(m => m.TargetFramework).Returns("X");
             analyzerResultFrameworkYMock.Setup(m => m.TargetFramework).Returns("Y");
 
@@ -59,6 +61,8 @@ namespace Stryker.Core.UnitTest.Initialisation
             var analyzerResultFrameworkXMock = new Mock<IAnalyzerResult>();
             var analyzerResultFrameworkYMock = new Mock<IAnalyzerResult>();
 
+            analyzerResultFrameworkXMock.Setup(m => m.Succeeded).Returns(true);
+            analyzerResultFrameworkYMock.Setup(m => m.Succeeded).Returns(true);
             analyzerResultFrameworkXMock.Setup(m => m.TargetFramework).Returns("X");
             analyzerResultFrameworkYMock.Setup(m => m.TargetFramework).Returns("Y");
 
@@ -78,6 +82,8 @@ namespace Stryker.Core.UnitTest.Initialisation
             var analyzerResultFrameworkXMock = new Mock<IAnalyzerResult>();
             var analyzerResultFrameworkYMock = new Mock<IAnalyzerResult>();
 
+            analyzerResultFrameworkXMock.Setup(m => m.Succeeded).Returns(true);
+            analyzerResultFrameworkYMock.Setup(m => m.Succeeded).Returns(true);
             analyzerResultFrameworkXMock.Setup(m => m.TargetFramework).Returns("X");
             analyzerResultFrameworkYMock.Setup(m => m.TargetFramework).Returns("Y");
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnersTest.cs
@@ -101,7 +101,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                         { "TargetDir", Path.GetDirectoryName(_testAssemblyPath) },
                         { "TargetFileName", Path.GetFileName(_testAssemblyPath) }
                     },
-                    targetFramework: "toto").Object
+                    targetFramework: "netcoreapp2.1").Object
                 },
                 ProjectUnderTestAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
                     properties: new Dictionary<string, string>() {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -668,8 +668,8 @@
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA=="
+        "resolved": "6.1.0",
+        "contentHash": "koaAF1Uoocky37pffe9CK3gowq4iZtusAmsl2hSV6fRv0Pmq0ik9ncAAbiMCCuycqsd9jO6HHBwzTEH9m8wusg=="
       },
       "RegexParser": {
         "type": "Transitive",
@@ -1846,6 +1846,7 @@
           "Microsoft.TestPlatform.TranslationLayer": "17.1.0",
           "Microsoft.Web.LibraryManager.Build": "2.1.161",
           "Mono.Cecil": "0.11.4",
+          "NuGet.Frameworks": "6.1.0",
           "Serilog": "2.10.0",
           "Serilog.Extensions.Logging": "3.1.0",
           "Serilog.Extensions.Logging.File": "2.0.0",

--- a/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Logging;
+using NuGet.Frameworks;
 using Stryker.Core.Exceptions;
 
 namespace Stryker.Core.Initialisation.Buildalyzer
@@ -97,37 +97,21 @@ namespace Stryker.Core.Initialisation.Buildalyzer
             public Assembly LoadFromPath(string fullPath) => Assembly.LoadFrom(fullPath);
         }
 
-        public static Framework GetTargetFramework(this IAnalyzerResult analyzerResult)
+        internal static NuGetFramework GetNuGetFramework(this IAnalyzerResult analyzerResult)
         {
-            try
+            var framework = NuGetFramework.Parse(analyzerResult.TargetFramework ?? "");
+            if (framework == NuGetFramework.UnsupportedFramework)
             {
-                return ParseTargetFramework(analyzerResult.TargetFramework);
+                var atPath = string.IsNullOrEmpty(analyzerResult.ProjectFilePath) ? "" : $" at '{analyzerResult.ProjectFilePath}'";
+                var message = $"The target framework '{analyzerResult.TargetFramework}' is not supported. Please fix the target framework in the csproj{atPath}.";
+                throw new InputException(message);
             }
-            catch (ArgumentException)
-            {
-                throw new InputException($"Unable to parse framework version string {analyzerResult.TargetFramework}. Please fix the framework version in the csproj.");
-            }
+            return framework;
         }
 
-        /// <summary>
-        /// Extracts a target <c>Framework</c> and <c>Version</c> from the MSBuild property TargetFramework
-        /// </summary>
-        /// <returns>
-        /// A tuple of <c>Framework</c> and <c>Version</c> which together form the target framework and framework version of the project.
-        /// </returns>
-        /// <example>
-        /// <c>(Framework.NetCore, 3.0)</c>
-        /// </example>
-        public static (Framework Framework, Version Version) GetTargetFrameworkAndVersion(this IAnalyzerResult analyzerResult)
+        internal static bool TargetsFullFramework(this IAnalyzerResult analyzerResult)
         {
-            try
-            {
-                return (ParseTargetFramework(analyzerResult.TargetFramework), ParseTargetFrameworkVersion(analyzerResult.TargetFramework));
-            }
-            catch (ArgumentException)
-            {
-                throw new InputException($"Unable to parse framework version string {analyzerResult.TargetFramework}. Please fix the framework version in the csproj.");
-            }
+            return GetNuGetFramework(analyzerResult).IsDesktop();
         }
 
         public static Language GetLanguage(this IAnalyzerResult analyzerResult)
@@ -148,39 +132,6 @@ namespace Stryker.Core.Initialisation.Buildalyzer
                 .Contains("{3AC096D0-A1C2-E12C-1390-A8335801FDAB}");
 
             return isTestProject || hasTestProjectTypeGuid;
-        }
-
-        private static Framework ParseTargetFramework(string targetFrameworkVersionString)
-        {
-            return targetFrameworkVersionString switch
-            {
-                string framework when framework.StartsWith("netcoreapp") => Framework.DotNet,
-                string framework when framework.StartsWith("netstandard") => Framework.DotNetStandard,
-                string framework when framework.StartsWith("net") && char.GetNumericValue(framework[3]) >= 5 => Framework.DotNet,
-                string framework when framework.StartsWith("net") && char.GetNumericValue(framework[3]) <= 4 => Framework.DotNetClassic,
-                _ => Framework.Unknown
-            };
-        }
-
-        private static Version ParseTargetFrameworkVersion(string targetFrameworkVersionString)
-        {
-            var analysis = Regex.Match(targetFrameworkVersionString ?? string.Empty, "(?<version>[\\d\\.]+)");
-            if (analysis.Success)
-            {
-                var version = analysis.Groups["version"].Value;
-                if (!version.Contains('.'))
-                {
-                    version = version.Length switch
-                    {
-                        1 => $"{version}.0",
-                        2 => $"{version[0]}.{version.Substring(1)}",
-                        3 => $"{version[0]}.{version[1]}.{version[2]}",
-                        _ => throw new ArgumentException("invalid version")
-                    };
-                }
-                return new Version(version);
-            }
-            return new Version();
         }
 
         private static OutputKind GetOutputKind(this IAnalyzerResult analyzerResult)

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -73,7 +73,7 @@ namespace Stryker.Core.Initialisation
                     projectInfo.TestProjectAnalyzerResults.Count());
 
                 _initialBuildProcess.InitialBuild(
-                    testProjects[i].GetTargetFramework() == Framework.DotNetClassic,
+                    testProjects[i].TargetsFullFramework(),
                     testProjects[i].ProjectFilePath,
                     options.SolutionPath,
                     options.MsBuildPath);

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -58,7 +58,7 @@ namespace Stryker.Core.Initialisation
 
             if (!analyzerResult.Succeeded)
             {
-                if (analyzerResult.GetTargetFramework() == Framework.DotNetClassic)
+                if (analyzerResult.TargetsFullFramework())
                 {
                     // buildalyzer failed to find restored packages, retry after nuget restore
                     _logger.LogDebug("Project analyzer result not successful, restoring packages");

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -61,12 +61,4 @@ namespace Stryker.Core.Initialisation
 
         private static string GetBackupName(string injectionPath) => injectionPath + ".stryker-unchanged";
     }
-
-    public enum Framework
-    {
-        DotNetClassic,
-        DotNet,
-        DotNetStandard,
-        Unknown
-    };
 }

--- a/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
+++ b/src/Stryker.Core/Stryker.Core/Stryker.Core.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftTestPlatform)" /> 				<!-- From Directory.Build.props -->
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />

--- a/src/Stryker.Core/Stryker.Core/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core/packages.lock.json
@@ -155,6 +155,12 @@
         "resolved": "0.11.4",
         "contentHash": "IC1h5g0NeJGHIUgzM1P82ld57knhP0IcQfrYITDPXlNpMYGUrsG5TxuaWTjaeqDNQMBDNZkB8L0rBnwsY6JHuQ=="
       },
+      "NuGet.Frameworks": {
+        "type": "Direct",
+        "requested": "[6.1.0, )",
+        "resolved": "6.1.0",
+        "contentHash": "koaAF1Uoocky37pffe9CK3gowq4iZtusAmsl2hSV6fRv0Pmq0ik9ncAAbiMCCuycqsd9jO6HHBwzTEH9m8wusg=="
+      },
       "Serilog": {
         "type": "Direct",
         "requested": "[2.10.0, )",
@@ -588,11 +594,6 @@
           "System.Xml.ReaderWriter": "4.0.11",
           "System.Xml.XDocument": "4.0.11"
         }
-      },
-      "NuGet.Frameworks": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "pEWTGa8sGEbSBE7VtKBlWZafG5tWNCGPzyNL91zneWoxZubNEWK1MN5QPN3fk+cV5CaySePT5reYjCAqELn5DA=="
       },
       "RegexParser": {
         "type": "Transitive",


### PR DESCRIPTION
This is safer to use than a hand-rolled version. The public methods and the public `Framework` enum have been marked obsolete.