### PR TITLE
Adding a CLI option to specify test projects in the command line

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ The project file name is required when your test project has more than one proje
 ### `test-projects` <`string[]`>
 
 Default: `null`  
-Command line: `N/A`  
+Command line: `[-tp|--test-project] "../Tests/Tests.csproj" -tp "../MoreTests/MoreTests.csproj"`
 Config file: `"test-projects": ['../MyProject.UnitTests/MyProject.UnitTests.csproj', '../MyProject.SpecFlow/MyProject.SpecFlow.csproj']`
 
 When you have multiple test projects covering one project under test you may specify all relevant test projects in the config file. You must run stryker from the project under test instead of the test project directory when using multiple test projects.

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -268,6 +268,19 @@ Options:";
         }
 
         [Theory]
+        [InlineData("--test-project")]
+        [InlineData("-tp")]
+        public void ShouldPassTestProjectArgumentsToStryker_WithTestProjectArgument(string argName)
+        {
+            _target.Run(new string[] { argName, "SomeProjectName1.csproj", argName, "SomeProjectName2.csproj" });
+
+            _strykerRunnerMock.VerifyAll();
+
+            _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName1.csproj");
+            _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName2.csproj");
+        }
+
+        [Theory]
         [InlineData("--verbosity")]
         [InlineData("-V")]
         public void ShouldPassLogConsoleArgumentsToStryker_WithLogConsoleArgument(string argName)

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigHandler.cs
@@ -121,6 +121,7 @@ namespace Stryker.CLI
             AddCliInput(inputs.ConcurrencyInput, "concurrency", "c", argumentHint: "number");
 
             AddCliInput(inputs.SolutionInput, "solution", "s", argumentHint: "file-path", category: InputCategory.Build);
+            AddCliInput(inputs.TestProjectsInput, "test-project", "tp", CommandOptionType.MultipleValue, InputCategory.Build);
             AddCliInput(inputs.ProjectUnderTestNameInput, "project", "p", argumentHint: "project-name.csproj", category: InputCategory.Build);
             AddCliInput(inputs.MsBuildPathInput, "msbuild-path", null, category: InputCategory.Build);
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
@@ -27,7 +27,6 @@ namespace Stryker.Core.Initialisation
         {
             _logger.LogDebug("Started initial build using {0}", fullFramework ? "msbuild.exe" : "dotnet build");
 
-            projectPath = Path.GetDirectoryName(projectPath);
             ProcessResult result;
             if (fullFramework)
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -38,7 +38,7 @@ namespace Stryker.Core.Initialisation
             foreach (var testProject in TestProjectAnalyzerResults)
             {
                 var injectionPath = GetInjectionFilePath(testProject);
-                _fileSystem.File.Move(GetBackupName(injectionPath), injectionPath, true);
+                _fileSystem.File.Copy(GetBackupName(injectionPath), injectionPath, true);
             }
         }
         public virtual void BackupOriginalAssembly()


### PR DESCRIPTION
closes #1883 

So this turned out to be a much less intervention than I thought :D This is a suspiciously easy fix whereas I planned to spend with this task more than a day, so instead I spent a day on testing this very meticulously :D Here's the example repo I created for that: [repo.zip](https://github.com/stryker-mutator/stryker-net/files/8124711/repo.zip)
 
It consists of:
- A project with a "control library" and a project with tests for that: this is basically the normal and most common Stryker case so it's here just to prove there are no regressions (`repo\ControlLibrary\ControlLibrary.csproj` and `repo\ControlLibrary.Tests\ControlLibrary.Tests.csproj`)
- A project with two project files and a test project with two correspondent project files, inspired by the ticket in question (`repo\Library\Library.Roslyn3.8.csproj`, `repo\Library\Library.Roslyn4.0.csproj`, `repo\Library.Tests\Library.Roslyn3.8.Tests.csproj` and `repo\Library.Tests\Library.Roslyn4.0.Tests.csproj`)
- A project with <s>mess</s> tests for everything (`repo\MoreTests\MoreTests.Roslyn3.8.csproj` and `repo\MoreTests\MoreTests.Roslyn4.0.csproj`)

So here are the testing matrixes! (I was testing with absolute paths which I removed from here for succinctness)

Level "easy":
| | Location | Stryker command | Result |
| - | - | - | - |
|:white_check_mark:| repo\ControlLibrary.Tests | - | works |
|:white_check_mark:| repo\ControlLibrary | - | fails (expected - not clear what to do) |
|:white_check_mark:| repo | `-p repo\ControlLibrary\ControlLibrary.csproj -tp repo\ControlLibrary.Tests\ControlLibrary.Tests.csproj` | works

Level "medium"
| | Location | Stryker command | Result |
| - | - | - | - |
|:white_check_mark:| repo\Library.Tests | - | fails (expected - multiple project here) |
|:white_check_mark:| repo\Library.Tests | `-tp repo\Library.Tests\Library.Roslyn3.8.Tests.csproj` | works |
|:white_check_mark:| repo | `-p repo\Library\Library.Roslyn3.8.csproj -tp repo\Library.Tests\Library.Roslyn3.8.Tests.csproj` | works |
|:white_check_mark:| repo | `-p repo\Library\Library.Roslyn3.8.csproj -tp repo\Library.Tests\Library.Roslyn3.8.Tests.csproj -tp repo\Library.Tests\Library.Roslyn4.0.Tests.csproj` | fails (expected - 2nd test project doesn't reference the target project) |

Level "boss"
| | Location | Stryker command line | Result |
| - | - | - | - |
|:white_check_mark:| repo | `-p repo\Library\Library.Roslyn3.8.csproj -tp repo\MoreTests\MoreTests.Roslyn3.8.csproj` | works (**this is our case and why I started the whole thing**) |
|:white_check_mark:| repo | `-p repo\Library\Library.Roslyn3.8.csproj -tp repo\Library.Tests\Library.Roslyn3.8.Tests.csproj -tp repo\MoreTests\MoreTests.Roslyn3.8.csproj` | works (screenshot below is for that) |
|:white_check_mark:| repo | `-p repo\ControlLibrary\ControlLibrary.csproj -tp repo\ControlLibrary.Tests\ControlLibrary.Tests.csproj -tp repo\MoreTests\MoreTests.Roslyn3.8.csproj` | works |
|:white_check_mark:| repo | `-p repo\ControlLibrary\ControlLibrary.csproj -tp repo\MoreTests\MoreTests.Roslyn3.8.csproj -tp repo\MoreTests\MoreTests.Roslyn4.0.csproj` | works (this is the edge case mentioned in one of the comments) |

<img width="804" alt="image" src="https://user-images.githubusercontent.com/5451366/155340937-45eb3d82-8cfc-4657-a899-4b5ac3f8c32e.png">

See also my comments in the PR. With all these efforts you don't have an option to not merge this :P