### PR TITLE
Guard against `ProcessorCount` reporting values lower then `1`

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/ConcurrencyInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/ConcurrencyInput.cs
@@ -15,14 +15,19 @@ Reasons you might want to lower this setting:
     - You're running on a shared server
     - You are running stryker in the background while doing other work";
 
-        public override int? Default => Environment.ProcessorCount / 2;
+        public override int? Default => Math.Max(Environment.ProcessorCount / 2, 1);
 
         public int Validate(ILogger<ConcurrencyInput> logger = null)
         {
             logger ??= ApplicationLogging.LoggerFactory.CreateLogger<ConcurrencyInput>();
 
-            if (SuppliedInput == null)
+            if (SuppliedInput is null)
             {
+                if (Environment.ProcessorCount < 1)
+                {
+                    logger.LogWarning("Processor count is not reported by the system, using concurrency of 1. Set a concurrency to remove this warning.");
+                }
+
                 return Default.Value;
             }
 


### PR DESCRIPTION
Should fix #1927

I have seen reports online about the method also reporting `-1`, so wanted to be safe and did check on any value lower then `1`.

Added a warning and a message that the user can get rid of the warning by supplying a value themselves, they probably know the amount of processors that would make sense.

Can't think of an easy way of adding unit test coverage for this.