### PR TITLE
fix(filters): ExcludeFromCodeCoverage not working when justification is given

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeFromCodeCoverageFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeFromCodeCoverageFilterTests.cs
@@ -66,7 +66,7 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
         {
             // Arrange
             var mutant = Create(@"
-[ExcludeFromCodeCoverage]
+[ExcludeFromCodeCoverage(""sowhat"")]
 public class IgnoredMethodMutantFilter_NestedMethodCalls
 {
     private void TestMethod()

--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -134,11 +134,6 @@ namespace Stryker.Core.Compiling
                 return new MutantInfo();
             }
 
-            if (info.Id == -1)
-            {
-                Logger.LogError("Mutation not found, this should not happen");
-            }
-
             Logger.LogDebug("Found mutant {id} of type '{type}' controlled by '{engine}'.", info.Id, info.Type, info.Engine);
 
             return info;
@@ -239,10 +234,7 @@ namespace Stryker.Core.Compiling
                         foreach (var mutant in scan.Where(x => x.Type == Mutator.Block.ToString() && !brokenMutations.Contains(x.Node)))
                         {
                             brokenMutations.Add(mutant.Node);
-                            if (mutant.Id != -1)
-                            {
-                                RolledBackIds.Add(mutant.Id.Value);
-                            }
+                            RolledBackIds.Add(mutant.Id.Value);
                         }
                     }
                     else

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/ExcludeFromCodeCoverageFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/ExcludeFromCodeCoverageFilter.cs
@@ -39,7 +39,7 @@ namespace Stryker.Core.MutantFilters
         {
             return m.AttributeLists
                 .SelectMany(attr => attr.Attributes)
-                .Any(attr => Regex.IsMatch(attr.ToString(),
+                .Any(attr => Regex.IsMatch(attr.Name.ToString(),
                     @"^(?:System\.Diagnostics\.CodeAnalysis\.)?ExcludeFromCodeCoverage(?:Attribute)?$"));
         }
     }


### PR DESCRIPTION
Fix ExcludeFromCodeCoverageFilter not ignoring code when a reason is used: #1963
Removes spurious logs: #1957 