### PR TITLE
Add timeouts to workaround frozen VsTest

### DIFF
--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/DiscoveryEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/DiscoveryEventHandler.cs
@@ -39,14 +39,8 @@ namespace Stryker.Core.TestRunners.VsTest
             _waitHandle.Set();
         }
 
-        public void HandleRawMessage(string rawMessage)
-        {
-            _messages.Add("Test Discovery Raw Message: " + rawMessage);
-        }
+        public void HandleRawMessage(string rawMessage) => _messages.Add("Test Discovery Raw Message: " + rawMessage);
 
-        public void HandleLogMessage(TestMessageLevel level, string message)
-        {
-            _messages.Add("Test Discovery Message: " + message);
-        }
+        public void HandleLogMessage(TestMessageLevel level, string message) => _messages.Add("Test Discovery Message: " + message);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
@@ -10,26 +10,18 @@ namespace Stryker.Core.TestRunners.VsTest
 {
     public interface IStrykerTestHostLauncher : ITestHostLauncher
     {
-        bool WaitProcessExit();
+        bool WaitProcessExit(DateTime dateTime);
     }
 
-    public class StrykerVsTestHostLauncher : IStrykerTestHostLauncher
+    public class StrykerVsTestHostLauncher : ITestHostLauncher
     {
-        private Process _currentProcess;
-        private readonly object _lck = new object();
         private readonly int _id;
 
         private static ILogger Logger { get; }
 
-        static StrykerVsTestHostLauncher()
-        {
-            Logger = ApplicationLogging.LoggerFactory.CreateLogger<StrykerVsTestHostLauncher>();
-        }
+        static StrykerVsTestHostLauncher() => Logger = ApplicationLogging.LoggerFactory.CreateLogger<StrykerVsTestHostLauncher>();
 
-        public StrykerVsTestHostLauncher(int id)
-        {
-            _id = id;
-        }
+        public StrykerVsTestHostLauncher(int id) => _id = id;
 
         public bool IsDebug => false;
 
@@ -53,49 +45,20 @@ namespace Stryker.Core.TestRunners.VsTest
                     ["Verify_DisableClipboard"] = "true",
                 },
             };
-            _currentProcess = new Process { StartInfo = processInfo, EnableRaisingEvents = true };
+            var currentProcess = new Process { StartInfo = processInfo, EnableRaisingEvents = false };
 
-            _currentProcess.Exited += CurrentProcess_Exited;
+            currentProcess.OutputDataReceived += Process_OutputDataReceived;
+            currentProcess.ErrorDataReceived += Process_ErrorDataReceived;
 
-            _currentProcess.OutputDataReceived += Process_OutputDataReceived;
-            _currentProcess.ErrorDataReceived += Process_ErrorDataReceived;
-
-            if (!_currentProcess.Start())
+            if (!currentProcess.Start())
             {
-                Logger.LogError($"Runner {_id}: Failed to start process {processInfo.Arguments}.");
+                Logger.LogDebug($"Runner {_id}: Failed to start process {processInfo.Arguments}.");
             }
 
-            _currentProcess.BeginOutputReadLine();
-            _currentProcess.BeginErrorReadLine();
+            currentProcess.BeginOutputReadLine();
+            currentProcess.BeginErrorReadLine();
 
-            return _currentProcess.Id;
-        }
-
-        private void CurrentProcess_Exited(object sender, EventArgs e)
-        {
-            lock (_lck)
-            {
-                Monitor.Pulse(_lck);
-            }
-        }
-
-        public bool WaitProcessExit()
-        {
-            if (_currentProcess == null)
-            {
-                return false;
-            }
-
-            while (!_currentProcess.HasExited)
-            {
-                lock (_lck)
-                {
-                    Monitor.Wait(_lck, 500);
-                }
-            }
-
-            _currentProcess.Dispose();
-            return true;
+            return currentProcess.Id;
         }
 
         private void Process_ErrorDataReceived(object sender, DataReceivedEventArgs e)
@@ -114,9 +77,6 @@ namespace Stryker.Core.TestRunners.VsTest
             }
         }
 
-        public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo)
-        {
-            return LaunchTestHost(defaultTestHostStartInfo, CancellationToken.None);
-        }
+        public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo) => LaunchTestHost(defaultTestHostStartInfo, CancellationToken.None);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/TestRun.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/TestRun.cs
@@ -1,0 +1,59 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace Stryker.Core.TestRunners.VsTest
+{
+    internal class TestRun
+    {
+        private readonly VsTestDescription _testDescription;
+        private readonly IList<TestResult> _results;
+
+        public TestRun(VsTestDescription testDescription)
+        {
+            _testDescription = testDescription;
+            _results = new List<TestResult>(testDescription.NbSubCases);
+        }
+
+        public bool AddResult(TestResult result)
+        {
+            _results.Add(result);
+            return _results.Count >= _testDescription.NbSubCases;
+        }
+
+        public bool IsComplete() => _results.Count >= _testDescription.NbSubCases;
+
+        public TestResult Result()
+        {
+            var result = _results.Aggregate((TestResult)null, (acc, next) =>
+            {
+                if (acc == null)
+                {
+                    return next;
+                }
+                if (next.Outcome == TestOutcome.Failed || acc.Outcome == TestOutcome.None)
+                {
+                    acc.Outcome = next.Outcome;
+                }
+                if (acc.StartTime > next.StartTime)
+                {
+                    acc.StartTime = next.StartTime;
+                }
+                if (acc.EndTime < next.EndTime)
+                {
+                    acc.EndTime = next.EndTime;
+                }
+
+                foreach (var message in next.Messages)
+                {
+                    acc.Messages.Add(message);
+                }
+
+                acc.Duration = acc.EndTime - acc.StartTime;
+                return acc;
+            });
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Add Stryker controlled timeout for VsTest to detect frozen VsTest runs and retry them. Fix test runner frozen after test discovery.
May fix: #1665 , #1136 , 