### PR TITLE
fix(mutating): Better support for mutating local function

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -145,8 +145,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
 void SomeMethod()  => (true && SomeOtherMethod(out var x)) ? x : 5;
 }";
             string expected = @"void TestMethod(){if(StrykerNamespace.MutantControl.IsActive(0)){}else{
-void SomeMethod()  {if(StrykerNamespace.MutantControl.IsActive(1)){!((true && SomeOtherMethod(out var x)) )? x : 5;}else{if(StrykerNamespace.MutantControl.IsActive(2)){(true || SomeOtherMethod(out var x)) ? x : 5;}else{((StrykerNamespace.MutantControl.IsActive(3)?false:true )&& SomeOtherMethod(out var x)) ? x : 5;}}};
-}}";
+void SomeMethod()  {if(StrykerNamespace.MutantControl.IsActive(1)){return!((true && SomeOtherMethod(out var x)) )? x : 5;}else{if(StrykerNamespace.MutantControl.IsActive(2)){return(true || SomeOtherMethod(out var x)) ? x : 5;}else{((StrykerNamespace.MutantControl.IsActive(3)?false:true )&& SomeOtherMethod(out var x)) ? x : 5;}}};}}";
 
             ShouldMutateSourceInClassToExpected(source, expected);
         }
@@ -1444,6 +1443,45 @@ string Value => Generator(out var x) ? """" :""test"";
             var expected = @"class Test {
 int GetId(string input) {if(StrykerNamespace.MutantControl.IsActive(0)){return!(int.TryParse(input, out var result) )? result : 0;}else{return int.TryParse(input, out var result) ? result : 0;}}
 string Value {get{if(StrykerNamespace.MutantControl.IsActive(1)){return!(Generator(out var x) )? """" :""test"";}else{return Generator(out var x) ? (StrykerNamespace.MutantControl.IsActive(2)?""Stryker was here!"":"""" ):(StrykerNamespace.MutantControl.IsActive(3)?"""":""test"");}}}}}}";
+            ShouldMutateSourceInClassToExpected(source, expected);
+        }
+
+        [Fact]
+        // test for issue #1386
+        public void ShouldHandleLocalFunctions()
+        {
+            var source = @"
+        public string DoStuff(char myChar, int myInt)
+        {
+            if (TryGet(myChar, out int i))
+            {}
+            string makeString(char c, int i) => new string(c, i);
+            return getString;
+        }
+        private bool TryGet(char myChar, out int i)
+        {
+            i = 0;
+            return true;
+        }";
+
+            var expected = @"public string DoStuff(char myChar, int myInt)
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{if(StrykerNamespace.MutantControl.IsActive(1))        {
+            if (!(TryGet(myChar, out int i)))
+            {}
+            string makeString(char c, int i) => new string(c, i);
+            return getString;
+        }
+else        {
+            if (TryGet(myChar, out int i))
+            {}
+            string makeString(char c, int i) => new string(c, i);
+            return getString;
+        }
+}return default(string);}        private bool TryGet(char myChar, out int i)
+{{i= default(int);}if(StrykerNamespace.MutantControl.IsActive(2)){}else        {
+            i = 0;
+            return (StrykerNamespace.MutantControl.IsActive(3)?false:true);
+        }return default(bool);}}}}";
             ShouldMutateSourceInClassToExpected(source, expected);
         }
     }

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/AnonymousFunctionExpressionToBodyEngine.cs
@@ -24,7 +24,7 @@ namespace Stryker.Core.Instrumentation
                 // no need to convert
                 return method;
             }
-            var  statementLine = SyntaxFactory.ReturnStatement(method.ExpressionBody.WithLeadingTrivia(SyntaxFactory.Space));
+            var statementLine = SyntaxFactory.ReturnStatement(method.ExpressionBody.WithLeadingTrivia(SyntaxFactory.Space));
 
             // do we need add return to the expression body?
             return method.WithBody(SyntaxFactory.Block(statementLine)).WithAdditionalAnnotations(Marker) as T;

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/LocalFunctionExpressionToBodyEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/LocalFunctionExpressionToBodyEngine.cs
@@ -37,7 +37,6 @@ namespace Stryker.Core.Instrumentation
             }
             // do we need add return to the expression body?
             return function.WithBody(SyntaxFactory.Block(statementLine)).WithExpressionBody(null).WithAdditionalAnnotations(Marker);
-
         }
 
         protected override SyntaxNode Revert(LocalFunctionStatementSyntax node)

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseMethodDeclarationOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseMethodDeclarationOrchestrator.cs
@@ -13,12 +13,13 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
     internal class BaseMethodDeclarationOrchestrator<T> : NodeSpecificOrchestrator<T, BaseMethodDeclarationSyntax> where T : BaseMethodDeclarationSyntax
     {
         protected override MutationContext PrepareContext(T node, MutationContext context)
-        {
-            context.Enter(MutationControl.Block);
-            return base.PrepareContext(node, context);
-        }
+            => base.PrepareContext(node, context.Enter(MutationControl.Block));
 
-        protected override void RestoreContext(MutationContext context) => context.Leave(MutationControl.Block);
+        protected override void RestoreContext(MutationContext context)
+        {
+            context.Leave(MutationControl.Block);
+            base.RestoreContext(context);
+        }
 
         /// <inheritdoc/>
         /// Inject mutations and convert expression body to block body if required.

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/LocalFunctionStatementOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/LocalFunctionStatementOrchestrator.cs
@@ -2,40 +2,59 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Stryker.Core.Helpers;
 
 namespace Stryker.Core.Mutants.CsharpNodeOrchestrators
 {
     internal class LocalFunctionStatementOrchestrator : NodeSpecificOrchestrator<LocalFunctionStatementSyntax, LocalFunctionStatementSyntax>
     {
+        /// <summary>
+        /// Mutate the children, except the arrow expression body that may require conversion.
+        /// </summary>
+        protected override LocalFunctionStatementSyntax OrchestrateChildrenMutation(LocalFunctionStatementSyntax node,
+            MutationContext context) =>
+            node.ReplaceNodes(node.ChildNodes().Where(child => child != node.ExpressionBody),
+                (original, _) => MutateSingleNode(original, context));
+
         protected override LocalFunctionStatementSyntax InjectMutations(LocalFunctionStatementSyntax sourceNode, LocalFunctionStatementSyntax targetNode,
             MutationContext context)
         {
-            // find out parameters
             targetNode = base.InjectMutations(sourceNode, targetNode, context);
 
             var fullTargetBody = targetNode.Body;
             var sourceNodeParameterList = sourceNode.ParameterList;
 
-            if (fullTargetBody != null)
+            if (fullTargetBody == null)
             {
-                // the function is in the body form
-                // inject initialization to default for all out parameters
-                targetNode = sourceNode.WithBody(MutantPlacer.AddDefaultInitializers(fullTargetBody,
-                    sourceNodeParameterList.Parameters.Where(p =>
-                        p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword)))));
-                // add a return in case we changed the control flow
-                return MutantPlacer.AddEndingReturn(targetNode);
-            }
-            // nothing to do if there is now pending statement mutations
-            if (!context.HasStatementLevelMutant)
-            {
-                return targetNode;
-            }
+                // we will now mutate the expression body
+                var localContext = context.Enter(MutationControl.Block);
+                targetNode = targetNode.ReplaceNode(targetNode.ExpressionBody!,
+                    MutateSingleNode(sourceNode.ExpressionBody, localContext));
+                if (localContext.HasStatementLevelMutant)
+                {
+                    // this is an expression body method
+                    // we need to convert it to expression body form
+                    targetNode = MutantPlacer.ConvertExpressionToBody(targetNode);
+                    // we need to inject pending block (and statement) level mutations
+                    targetNode = targetNode.WithBody(SyntaxFactory.Block(
+                        localContext.InjectBlockLevelExpressionMutation(targetNode.Body,
+                            sourceNode.ExpressionBody!.Expression, true)));
+                }
+                localContext.Leave(MutationControl.Block);
+                if (targetNode.Body == null)
+                {
+                    // we did not perform any conversion
+                    return targetNode;
+                }
 
-            // we need to move to a body version of the function to inject pending mutations
-            targetNode = MutantPlacer.ConvertExpressionToBody(targetNode);
-            return targetNode.WithBody(SyntaxFactory.Block(context.InjectBlockLevelExpressionMutation(targetNode.Body, sourceNode.ExpressionBody.Expression, sourceNode.NeedsReturn())));
+            }
+            
+            // the function is in the body form
+            // inject initialization to default for all out parameters
+            targetNode = targetNode.WithBody(MutantPlacer.AddDefaultInitializers(targetNode.Body,
+                sourceNodeParameterList.Parameters.Where(p =>
+                    p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword)))));
+            // add a return in case we changed the control flow
+            return MutantPlacer.AddEndingReturn(targetNode);
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -20,9 +20,9 @@ namespace Stryker.Core.Mutants
     public class MutationStore
     {
         private static readonly ILogger Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationStore>();
-        protected List<Mutant> _expressionMutants = new();
-        protected Stack<List<Mutant>> _statementMutants = new();
-        protected Stack<List<Mutant>> _blockMutants = new();
+        private readonly List<Mutant> _expressionMutants = new();
+        private readonly Stack<List<Mutant>> _statementMutants = new();
+        private readonly Stack<List<Mutant>> _blockMutants = new();
 
         public bool HasBlockLevel => _blockMutants.Count > 0 && _blockMutants.Peek().Count > 0;
         public bool HasStatementLevel => (_statementMutants.Count > 0 && _statementMutants.Peek().Count > 0) || HasBlockLevel;


### PR DESCRIPTION
Prevent migration of mutations from a method to a locally defined function as those lead to errors. 
Significant rewrite for 'LocalFunctionStatementOrchestrator' and 'AnonymousFunctionExpressionOrchestrator'.
Isolated the migration of the expression body (if present) to ensure a proper handling of the mutation context which prevents mutation migrating to other places.
Should also resolve some compile error mutant (see `CsharpMutantOrchestratorTests`: previous version of the test shows that the generated code will not compile)

Fix #1986 