### PR TITLE
fix(baseline): potential InvalidOperationException: Sequence contains no elements

### DIFF
--- a/src/Stryker.Core/Stryker.Core/MutantFilters/BaselineMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/BaselineMutantFilter.cs
@@ -93,8 +93,9 @@ namespace Stryker.Core.MutantFilters
         {
             if (matchingMutants.Count() == 1)
             {
-                matchingMutants.First().ResultStatus = (MutantStatus)Enum.Parse(typeof(MutantStatus), baselineMutant.Status);
-                matchingMutants.First().ResultStatusReason = "Result based on previous run";
+                var matchingMutant = matchingMutants.First();
+                matchingMutant.ResultStatus = (MutantStatus)Enum.Parse(typeof(MutantStatus), baselineMutant.Status);
+                matchingMutant.ResultStatusReason = "Result based on previous run";
             }
             else
             {


### PR DESCRIPTION
Since the `matchingMutants` is an IEnumerable<Mutant> it will be evaluated twice. But the `ResultStatus` is changed between the two calls to `First()` making it possible that the second evaluation returns no matches.

Full stack trace:
```
Unhandled exception. System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at Stryker.Core.MutantFilters.BaselineMutantFilter.SetMutantStatusToBaselineMutantStatus(JsonMutant baselineMutant, IEnumerable`1 matchingMutants)
   at Stryker.Core.MutantFilters.BaselineMutantFilter.UpdateMutantsWithBaselineStatus(IEnumerable`1 mutants, IReadOnlyFileLeaf file)
   at Stryker.Core.MutantFilters.BaselineMutantFilter.FilterMutants(IEnumerable`1 mutants, IReadOnlyFileLeaf file, StrykerOptions options)
   at Stryker.Core.MutantFilters.BroadcastMutantFilter.FilterMutants(IEnumerable`1 mutants, IReadOnlyFileLeaf file, StrykerOptions options)
   at Stryker.Core.MutationTest.CsharpMutationProcess.FilterMutants()
   at Stryker.Core.MutationTest.MutationTestProcess.FilterMutants()
   at Stryker.Core.StrykerRunner.RunMutationTest(IStrykerInputs inputs, ILoggerFactory loggerFactory, IProjectOrchestrator projectOrchestrator)
   at Stryker.CLI.StrykerCli.RunStryker(IStrykerInputs inputs) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 93
   at Stryker.CLI.StrykerCli.<>c__DisplayClass10_0.<Run>b__0() in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 68
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass143_0.<OnExecute>b__0(CancellationToken _)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Stryker.CLI.StrykerCli.Run(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 74
   at Stryker.CLI.Program.Main(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/Program.cs:line 14
```