### PR TITLE
fix(ignore-mutations): Support mutator names as well as descriptions

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMutationsInputTests.cs
@@ -54,14 +54,14 @@ namespace Stryker.Core.UnitTest.Options.Inputs
         {
             var target = new IgnoreMutationsInput { SuppliedInput = new[] {
                 Mutator.String.ToString(),
-                Mutator.Logical.ToString()
+                Mutator.Regex.ToString(),
             } };
 
             var result = target.Validate();
 
             result.Count().ShouldBe(2);
             result.First().ShouldBe(Mutator.String);
-            result.Last().ShouldBe(Mutator.Logical);
+            result.ElementAt(1).ShouldBe(Mutator.Regex);
         }
 
 

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreMutationsInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreMutationsInput.cs
@@ -28,7 +28,7 @@ namespace Stryker.Core.Options.Inputs
                 {
                     // Find any mutatorType that matches the name passed by the user
                     var mutatorDescriptor = typeDescriptions.FirstOrDefault(
-                        x => x.Value.ToString().ToLower().Contains(mutatorToExclude.ToLower()));
+                        x => string.Equals(x.Key.ToString(), mutatorToExclude, StringComparison.CurrentCultureIgnoreCase) || x.Value.ToString().ToLower().Contains(mutatorToExclude.ToLower()));
                     if (mutatorDescriptor.Value is { })
                     {
                         excludedMutators.Add(mutatorDescriptor.Key);


### PR DESCRIPTION
Support internal name  on top of description. More specifically accept `Regex` as a valid value.

fix #2001 