### PR TITLE
fix(options): Stryker silently runs with default config if custom config file is set but not found

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigReaderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigReaderTests.cs
@@ -1,0 +1,135 @@
+using System.IO;
+using McMaster.Extensions.CommandLineUtils;
+using Moq;
+using Shouldly;
+using Stryker.Core.Exceptions;
+using Stryker.Core.Options;
+using Stryker.Core.Options.Inputs;
+using Xunit;
+
+namespace Stryker.CLI.UnitTest
+{
+    public class ConfigReaderTests
+    {
+        private readonly Mock<IStrykerInputs> _inputs;
+        private readonly CommandLineApplication _app;
+        private readonly CommandLineConfigHandler _cmdConfigHandler;
+
+        public ConfigReaderTests()
+        {
+            _inputs = GetMockInputs();
+            _app = GetCommandLineApplication();
+
+            _cmdConfigHandler = new CommandLineConfigHandler();
+            _cmdConfigHandler.RegisterCommandLineOptions(_app, _inputs.Object);
+        }
+
+        [Fact]
+        public void InvalidConfigFile_ShouldThrowInputException()
+        {
+            var args = new[] { "-f", "invalidconfig.json" };
+
+            var reader = new ConfigReader();
+
+            var exception = Assert.Throws<InputException>(() => reader.Build(_inputs.Object, args, _app, _cmdConfigHandler));
+            exception.Message.ShouldStartWith("Config file not found");
+        }
+
+        [Fact]
+        public void InvalidDefaultConfigFile_ShouldNotThrowInputExceptionAndNotParseConfigFile()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory($"..{Path.DirectorySeparatorChar}");
+
+            var args = new string[] { };
+
+            var reader = new ConfigReader();
+
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Never());
+
+            Directory.SetCurrentDirectory(currentDirectory);
+        }
+        
+        [Fact]
+        public void ValidDefaultConfigFile_ShouldParseConfigFile()
+        {
+            var args = new string[] { };
+
+            var reader = new ConfigReader();
+
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+        }
+
+        private void VerifyConfigFileDeserialized(Times time)
+        {
+            _inputs.VerifyGet(x => x.BaselineProviderInput, time);
+        }
+
+        private static CommandLineApplication GetCommandLineApplication()
+        {
+            var app = new CommandLineApplication
+            {
+                Name = "Stryker",
+                FullName = "Stryker: Stryker mutator for .Net",
+                Description = "Stryker mutator for .Net",
+                ExtendedHelpText = "Welcome to Stryker for .Net! Run dotnet stryker to kick off a mutation test run",
+                HelpTextGenerator = new GroupedHelpTextGenerator()
+            };
+            return app;
+        }
+
+        private static Mock<IStrykerInputs> GetMockInputs()
+        {
+            var inputs = new Mock<IStrykerInputs>();
+            inputs.Setup(x => x.BasePathInput).Returns(new BasePathInput());
+
+            inputs.Setup(x => x.ThresholdBreakInput).Returns(new ThresholdBreakInput());
+            inputs.Setup(x => x.ThresholdHighInput).Returns(new ThresholdHighInput());
+            inputs.Setup(x => x.ThresholdLowInput).Returns(new ThresholdLowInput());
+            inputs.Setup(x => x.LogToFileInput).Returns(new LogToFileInput());
+            inputs.Setup(x => x.VerbosityInput).Returns(new VerbosityInput());
+            inputs.Setup(x => x.ConcurrencyInput).Returns(new ConcurrencyInput());
+            inputs.Setup(x => x.SolutionInput).Returns(new SolutionInput());
+            inputs.Setup(x => x.ProjectUnderTestNameInput).Returns(new ProjectUnderTestNameInput());
+            inputs.Setup(x => x.TestProjectsInput).Returns(new TestProjectsInput());
+            inputs.Setup(x => x.MsBuildPathInput).Returns(new MsBuildPathInput());
+            inputs.Setup(x => x.MutateInput).Returns(new MutateInput());
+            inputs.Setup(x => x.MutationLevelInput).Returns(new MutationLevelInput());
+            inputs.Setup(x => x.SinceInput).Returns(new SinceInput());
+            inputs.Setup(x => x.WithBaselineInput).Returns(new WithBaselineInput());
+            inputs.Setup(x => x.OpenReportInput).Returns(new OpenReportInput());
+            inputs.Setup(x => x.ReportersInput).Returns(new ReportersInput());
+            inputs.Setup(x => x.ProjectVersionInput).Returns(new ProjectVersionInput());
+            inputs.Setup(x => x.DashboardApiKeyInput).Returns(new DashboardApiKeyInput());
+            inputs.Setup(x => x.AzureFileStorageSasInput).Returns(new AzureFileStorageSasInput());
+            inputs.Setup(x => x.DevModeInput).Returns(new DevModeInput());
+
+            inputs.Setup(x => x.SinceInput).Returns(new SinceInput());
+            inputs.Setup(x => x.BaselineProviderInput).Returns(new BaselineProviderInput());
+            inputs.Setup(x => x.DiffIgnoreChangesInput).Returns(new DiffIgnoreChangesInput());
+            inputs.Setup(x => x.FallbackVersionInput).Returns(new FallbackVersionInput());
+            inputs.Setup(x => x.AzureFileStorageUrlInput).Returns(new AzureFileStorageUrlInput());
+            inputs.Setup(x => x.CoverageAnalysisInput).Returns(new CoverageAnalysisInput());
+            inputs.Setup(x => x.DisableBailInput).Returns(new DisableBailInput());
+            inputs.Setup(x => x.DisableMixMutantsInput).Returns(new DisableMixMutantsInput());
+            inputs.Setup(x => x.AdditionalTimeoutInput).Returns(new AdditionalTimeoutInput());
+            inputs.Setup(x => x.ProjectNameInput).Returns(new ProjectNameInput());
+            inputs.Setup(x => x.ModuleNameInput).Returns(new ModuleNameInput());
+            inputs.Setup(x => x.ReportersInput).Returns(new ReportersInput());
+            inputs.Setup(x => x.SinceTargetInput).Returns(new SinceTargetInput());
+            inputs.Setup(x => x.TargetFrameworkInput).Returns(new TargetFrameworkInput());
+            inputs.Setup(x => x.LanguageVersionInput).Returns(new LanguageVersionInput());
+            inputs.Setup(x => x.TestCaseFilterInput).Returns(new TestCaseFilterInput());
+            inputs.Setup(x => x.DashboardUrlInput).Returns(new DashboardUrlInput());
+            inputs.Setup(x => x.IgnoreMutationsInput).Returns(new IgnoreMutationsInput());
+            inputs.Setup(x => x.IgnoredMethodsInput).Returns(new IgnoreMethodsInput());
+            inputs.Setup(x => x.ReportFileNameInput).Returns(new ReportFileNameInput());
+
+            return inputs;
+        }
+    }
+}

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigHandler.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigHandler.cs
@@ -24,11 +24,10 @@ namespace Stryker.CLI
             }
         }
 
-        public string GetConfigFilePath(string[] args, CommandLineApplication app)
+        public CommandOption GetConfigFileOption(string[] args, CommandLineApplication app)
         {
             var commands = app.Parse(args);
-            var option = commands.SelectedCommand.Options.SingleOrDefault(o => o.LongName == _configFileInput.ArgumentName);
-            return option?.Value() ?? "stryker-config.json";
+            return commands.SelectedCommand.Options.SingleOrDefault(o => o.LongName == _configFileInput.ArgumentName);
         }
 
         public void ReadCommandLineConfig(string[] args, CommandLineApplication app, IStrykerInputs inputs)

--- a/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using McMaster.Extensions.CommandLineUtils;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Options;
 
 namespace Stryker.CLI
@@ -24,12 +25,20 @@ namespace Stryker.CLI
             var basePath = Directory.GetCurrentDirectory();
             inputs.BasePathInput.SuppliedInput = basePath;
 
+            var configFileOption = cmdConfigHandler.GetConfigFileOption(args, app);
+
             // read config from json and commandline
-            var configFilePath = Path.Combine(basePath, cmdConfigHandler.GetConfigFilePath(args, app));
+            var configFilePath = Path.Combine(basePath, configFileOption?.Value() ?? "stryker-config.json");
             if (File.Exists(configFilePath))
             {
                 JsonConfigHandler.DeserializeConfig(configFilePath, inputs);
             }
+            else if (configFileOption.HasValue())
+            {
+                // only throw exception if the config file path provided by the user
+                throw new InputException($"Config file not found {configFilePath}");
+            }
+
             cmdConfigHandler.ReadCommandLineConfig(args, app, inputs);
         }
     }

--- a/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
@@ -35,7 +35,7 @@ namespace Stryker.CLI
             }
             else if (configFileOption.HasValue())
             {
-                // only throw exception if the config file path is provided by the user
+                // throw exception if the config file path is provided by the user yet it does not exist
                 throw new InputException($"Config file not found at {configFilePath}");
             }
 

--- a/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/ConfigReader.cs
@@ -35,8 +35,8 @@ namespace Stryker.CLI
             }
             else if (configFileOption.HasValue())
             {
-                // only throw exception if the config file path provided by the user
-                throw new InputException($"Config file not found {configFilePath}");
+                // only throw exception if the config file path is provided by the user
+                throw new InputException($"Config file not found at {configFilePath}");
             }
 
             cmdConfigHandler.ReadCommandLineConfig(args, app, inputs);


### PR DESCRIPTION
To fix this issue, I thought that an InputException should only be thrown if the invalid config was provided by the user.

If no config is provided and the default config is not present, do as before and silently continue.

Note: This is my first PR for the Stryker project, do not hesitate to suggest changes.