### PR TITLE
Document 6.0 SDK requirement for app under test

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,9 +9,9 @@ custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs
 
 Stryker is installed using the dotnet cli as a [dotnet tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools)
 
-Stryker requires the dotnet 6.0 runtime or newer: [Install dotnet](https://dotnet.microsoft.com/download)
+Stryker requires the dotnet 6.0 SDK or newer: [Install dotnet](https://dotnet.microsoft.com/download)
 
-\* Note: Your application does not need to target dotnet 6.0 or newer. You only need the runtime installed so stryker can run.
+\* Note: Your application does not need to target dotnet 6.0 or newer. However, it must be able to build successfully using the dotnet 6.0 SDK.
 
 ## Dotnet framework specific
 Nuget is required for dotnet framework. Follow the instructions at [Install nuget](https://docs.microsoft.com/en-us/nuget/install-nuget-client-tools#windows) including adding nuget to the path. Otherwise stryker will not be able to find and use nuget.


### PR DESCRIPTION
Existing applications which are built using an SDK prior to 6.0 may not build under 6.0, which will prevent Stryker from analyzing them. For example, an SDK project which still explicitly includes assembly info attributes in its source and does not explicitly define the "GenerateAssemblyInfo" MSBuild property may build successfully using the 3.1 SDK, but will fail with the 6.0 SDK with "Duplicate attribute" errors.