### PR TITLE
fix(baseline): increase compatibility of azure file share provider with older SAS keys

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -116,10 +116,6 @@ namespace Stryker.Core.Baseline.Providers
 
             using var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
-            SetWritingHeaders(requestMessage);
-
-            requestMessage.Headers.Add("x-ms-file-last-write-time", "now");
-
             using var response = await _httpClient.SendAsync(requestMessage);
             if (response.StatusCode == HttpStatusCode.Created)
             {
@@ -145,9 +141,6 @@ namespace Stryker.Core.Baseline.Providers
 
             using var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
-            SetWritingHeaders(requestMessage);
-
-            requestMessage.Headers.Add("x-ms-file-last-write-time", "now");
             requestMessage.Headers.Add("x-ms-type", "file");
             requestMessage.Headers.Add("x-ms-content-length", byteSize.ToString());
 
@@ -175,8 +168,6 @@ namespace Stryker.Core.Baseline.Providers
                 Content = new StringContent(report, Encoding.UTF8, "application/json")
             };
 
-            SetWritingHeaders(requestMessage);
-
             requestMessage.Headers.Add("x-ms-range", $"bytes=0-{byteSize - 1}");
             requestMessage.Headers.Add("x-ms-write", "update");
 
@@ -190,13 +181,6 @@ namespace Stryker.Core.Baseline.Providers
             {
                 _logger.LogDebug("Uploaded report to azure file share");
             }
-        }
-
-        private void SetWritingHeaders(HttpRequestMessage requestMessage)
-        {
-            requestMessage.Headers.Add("x-ms-file-permission", "inherit");
-            requestMessage.Headers.Add("x-ms-file-attributes", "None");
-            requestMessage.Headers.Add("x-ms-file-creation-time", "now");
         }
 
         private string ToSafeResponseMessage(string responseMessage) =>


### PR DESCRIPTION
… Signed Version Compatibility

Removed a set of Headers that were beeing appended to http requests when using AzureFileShare as a
provider for Baseline. The headers `x-ms-file-permission`, `x-ms-file-attributes`,
`x-ms-file-creation-time` and `x-ms-file-last-write-time` are now deemed to be optional, and as a
result can be removed. By removing these headers, we are allowing ourselves to be able to use SAS
tokens that have been generated with a Signed Version that is lower than `2019-02-02`.

fix #2114