### PR TITLE
Fix: static mutants not marked as needing all tests

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -475,6 +475,25 @@ namespace Stryker.Core.UnitTest.TestRunners
             OtherMutant.CoveringTests.IsEveryTest.ShouldBe(true);
         }
 
+        // this verifies that static mutants are flagged as to be tested against all tests
+        [Fact]
+        public void StaticMutantsShouldBeTestedAgainstAllTests()
+        {
+            var options = new StrykerOptions
+            {
+                OptimizationMode = OptimizationModes.CoverageBasedTest
+            };
+            var staticMutant = new Mutant() { Id = 14, IsStaticValue = true };
+            var mockVsTest = BuildVsTestRunnerPool(options, out var runner);
+
+            SetupMockCoverageRun(mockVsTest, new Dictionary<string, string> { ["T0"] = "0;", ["T1"] = "1;" });
+            
+            var analyzer = new CoverageAnalyser(options);
+            analyzer.DetermineTestCoverage(runner, new[] { Mutant, OtherMutant, staticMutant }, TestGuidsList.NoTest());
+            // the suspicious mutant should be tested against all tests
+            staticMutant.CoveringTests.IsEveryTest.ShouldBe(true);
+        }
+
         // this verifies that mutant that are covered outside any tests are
         // flagged as to be tested against all tests (except failed ones)
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
+++ b/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
@@ -98,7 +98,7 @@ namespace Stryker.Core.CoverageAnalysis
                 _logger.LogDebug(
                     $"Mutant {mutant.Id} will be tested against all tests.");
             }
-            else if (resultTingRequirements.HasFlag(MutationTestingRequirements.Static))
+            else if (resultTingRequirements.HasFlag(MutationTestingRequirements.Static) || mutant.IsStaticValue)
             {
                 // static mutations will be tested against every tests, except the one that are trusted not to cover it
                 mutant.CoveringTests =allTestsGuidsExceptTrusted.Merge(testGuids);


### PR DESCRIPTION
Test runners and coverage analyzers refactoring introduced a regression in V2.1: mutations in field initializers where no longer flagged as needing full testing; this lead to some false survivors (see #2118).
This PR fixes that and add a regression test