### PR TITLE
fix(exception logging): Log vstest exceptions instead of swallowing

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Exceptions/GeneralStrykerException.cs
+++ b/src/Stryker.Core/Stryker.Core/Exceptions/GeneralStrykerException.cs
@@ -28,12 +28,14 @@ namespace Stryker.Core.Exceptions
             builder.AppendLine();
             builder.AppendLine(Message);
             builder.AppendLine();
-            if (!string.IsNullOrEmpty(Details))
+            if (Details is not null)
             {
                 builder.AppendLine(Details);
             }
             else if (InnerException is not null)
             {
+                builder.AppendLine();
+                builder.AppendLine("Inner Exception: ");
                 builder.AppendLine(InnerException.Message);
                 builder.AppendLine(InnerException.StackTrace);
             }

--- a/src/Stryker.Core/Stryker.Core/Exceptions/GeneralStrykerException.cs
+++ b/src/Stryker.Core/Stryker.Core/Exceptions/GeneralStrykerException.cs
@@ -19,10 +19,7 @@ namespace Stryker.Core.Exceptions
         {
         }
 
-        public GeneralStrykerException(string message, string details) : base(message)
-        {
-            Details = details;
-        }
+        public GeneralStrykerException(string message, string details) : base(message) => Details = details;
 
         public override string ToString()
         {
@@ -35,9 +32,10 @@ namespace Stryker.Core.Exceptions
             {
                 builder.AppendLine(Details);
             }
-            else if (InnerException != null)
+            else if (InnerException is not null)
             {
-                builder.AppendLine(Details);
+                builder.AppendLine(InnerException.Message);
+                builder.AppendLine(InnerException.StackTrace);
             }
             return builder.ToString();
         }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
@@ -120,6 +120,7 @@ namespace Stryker.Core.TestRunners.VsTest
             }
             catch (Exception e)
             {
+                _logger.LogError("Stryker failed to connect to vstest.console with error: {error}", e.Message);
                 throw new GeneralStrykerException("Stryker failed to connect to vstest.console", e);
             }
             return vsTestConsole;
@@ -298,10 +299,14 @@ namespace Stryker.Core.TestRunners.VsTest
                 : string.Empty;
 
             if (_testFramework.HasFlag(TestFramework.NUnit))
+            {
                 settingsForCoverage = "<CollectDataForEachTestSeparately>true</CollectDataForEachTestSeparately>";
+            }
 
             if (_testFramework.HasFlag(TestFramework.xUnit))
+            {
                 settingsForCoverage += "<DisableParallelization>true</DisableParallelization>";
+            }
 
             var timeoutSettings = timeout is > 0
                 ? $"<TestSessionTimeout>{timeout}</TestSessionTimeout>" + Environment.NewLine


### PR DESCRIPTION
Related to #2117 