### PR TITLE
feat(testrunner): Diagnose failed test discovery and provide fix hints

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -41,7 +42,9 @@ namespace Stryker.Core.Initialisation
         private readonly IInitialTestProcess _initialTestProcess;
         private readonly IAssemblyReferenceResolver _assemblyReferenceResolver;
         private ITestRunner _testRunner;
+        private ProjectInfo _projectInfo;
         private readonly ILogger _logger;
+       
 
         public InitialisationProcess(
             IInputFileResolver inputFileResolver = null,
@@ -61,16 +64,16 @@ namespace Stryker.Core.Initialisation
         public MutationTestInput Initialize(StrykerOptions options)
         {
             // resolve project info
-            var projectInfo = _inputFileResolver.ResolveInput(options);
+             _projectInfo = _inputFileResolver.ResolveInput(options);
 
             // initial build
-            var testProjects = projectInfo.TestProjectAnalyzerResults.ToList();
+            var testProjects = _projectInfo.TestProjectAnalyzerResults.ToList();
             for (var i = 0; i < testProjects.Count; i++)
             {
                 _logger.LogInformation(
                     "Building test project {ProjectFilePath} ({CurrentTestProject}/{OfTotalTestProjects})",
                     testProjects[i].ProjectFilePath, i + 1,
-                    projectInfo.TestProjectAnalyzerResults.Count());
+                    _projectInfo.TestProjectAnalyzerResults.Count());
 
                 _initialBuildProcess.InitialBuild(
                     testProjects[i].TargetsFullFramework(),
@@ -79,26 +82,59 @@ namespace Stryker.Core.Initialisation
                     options.MsBuildPath);
             }
 
-            InitializeDashboardProjectInformation(options, projectInfo);
+            InitializeDashboardProjectInformation(options, _projectInfo);
 
             if (_testRunner == null)
             {
-                _testRunner = new VsTestRunnerPool(options, projectInfo);
+                _testRunner = new VsTestRunnerPool(options, _projectInfo);
             }
 
             var input = new MutationTestInput
             {
-                ProjectInfo = projectInfo,
-                AssemblyReferences = _assemblyReferenceResolver.LoadProjectReferences(projectInfo.ProjectUnderTestAnalyzerResult.References).ToList(),
+                ProjectInfo = _projectInfo,
+                AssemblyReferences = _assemblyReferenceResolver.LoadProjectReferences(_projectInfo.ProjectUnderTestAnalyzerResult.References).ToList(),
                 TestRunner = _testRunner,
             };
 
             return input;
         }
 
-        public InitialTestRun InitialTest(StrykerOptions options) =>
+        public InitialTestRun InitialTest(StrykerOptions options)
+        {
             // initial test
-            _initialTestProcess.InitialTest(options, _testRunner);
+            var result = _initialTestProcess.InitialTest(options, _testRunner);
+
+            if (_testRunner.DiscoverTests().Count == 0)
+            {
+                // no test have been discoverd, diagnose this
+                DiagnoseLackOfDetectedTest(_projectInfo);
+                _logger.LogError("No test has been found during initial test run. Stryker will stop.");
+            }
+            return result;
+        }
+
+        private static readonly Dictionary<string, string> _testFrameworks = new()
+        {
+            ["xunit.core"] = "xunit.runner.visualstudio",
+            ["nunit.framework"] = "NUnit3.TestAdapter",
+            ["Microsoft.VisualStudio.TestPlatform.TestFramework"] = "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter"
+        };
+
+        public static void DiagnoseLackOfDetectedTest(ProjectInfo projectInfo)
+        {
+            foreach (var testProject in projectInfo.TestProjectAnalyzerResults)
+            {
+                foreach (var (framework, adapter) in _testFrameworks)
+                {
+                    if (testProject.References.Any(r => r.Contains(framework)) && !testProject.References.Any(r => r.Contains(adapter)))
+                    {
+                        throw new InputException($"Project '{testProject.ProjectFilePath}' is not supported by VsTest because it is missing an appropriate VstTest adapter for '{framework}'. " +
+                            $"Adding '{adapter}' to this project references may resolve the issue.");
+                    }
+                }
+            }
+        }
+
 
         private void InitializeDashboardProjectInformation(StrykerOptions options, ProjectInfo projectInfo)
         {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -149,7 +149,7 @@ namespace Stryker.Core.Initialisation
             return projectUnderTestPath;
         }
 
-        private void ValidateTestProjectsCanBeExecuted(ProjectInfo projectInfo)
+        private static void ValidateTestProjectsCanBeExecuted(ProjectInfo projectInfo)
         {
             // if references contains Microsoft.VisualStudio.QualityTools.UnitTestFramework 
             // we have detected usage of mstest V1 and should exit

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectInfo.cs
@@ -13,12 +13,10 @@ namespace Stryker.Core.Initialisation
 
         public ProjectInfo() : this(null) { }
 
-        public ProjectInfo(IFileSystem fileSystem)
-        {
-            _fileSystem = fileSystem ?? new FileSystem();
-        }
+        public ProjectInfo(IFileSystem fileSystem) => _fileSystem = fileSystem ?? new FileSystem();
 
         public IEnumerable<IAnalyzerResult> TestProjectAnalyzerResults { get; set; }
+
         public IAnalyzerResult ProjectUnderTestAnalyzerResult { get; set; }
 
         /// <summary>
@@ -26,12 +24,9 @@ namespace Stryker.Core.Initialisation
         /// </summary>
         public IProjectComponent ProjectContents { get; set; }
 
-        public string GetInjectionFilePath(IAnalyzerResult analyzerResult)
-        {
-            return Path.Combine(
+        public string GetInjectionFilePath(IAnalyzerResult analyzerResult) => Path.Combine(
                 Path.GetDirectoryName(analyzerResult.GetAssemblyPath()),
                 Path.GetFileName(ProjectUnderTestAnalyzerResult.GetAssemblyPath()));
-        }
 
         public virtual void RestoreOriginalAssembly()
         {
@@ -41,6 +36,7 @@ namespace Stryker.Core.Initialisation
                 _fileSystem.File.Copy(GetBackupName(injectionPath), injectionPath, true);
             }
         }
+
         public virtual void BackupOriginalAssembly()
         {
             foreach (var testProject in TestProjectAnalyzerResults)


### PR DESCRIPTION
Implements #2126:
when no tests are detected Stryker verifies if there is a test runner present for each tes framework and stops on exception otherwise.

Limit: this only triggers if no test is detected in any test projects (if more than one is present).

_Note: the implementation is in a dedicated method and be run at another point in time if need arises._