### PR TITLE
fix: Stryker not properly flagging mutant as TimedOut

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
@@ -41,20 +41,33 @@ namespace Stryker.Core.UnitTest.Mutants
         }
 
         [Fact]
-        public void ShouldSetTimedoutState()
+        public void ShouldSetTimedOutStateWhenSomeTestTimesOut()
         {
-            var failedTestsMock = new Mock<ITestGuids>();
-            var resultTestsMock = new Mock<ITestGuids>();
-            var timedoutTestsMock = new Mock<ITestGuids>();
-            var coveringTestsMock = new Mock<ITestGuids>();
+            var mutant = new Mutant
+            {
+                AssessingTests = TestGuidsList.EveryTest()
+            };
 
-            failedTestsMock.Setup(x => x.IsEmpty).Returns(true);
-            timedoutTestsMock.Setup(x => x.IsEmpty).Returns(false);
-            coveringTestsMock.Setup(x => x.IsEveryTest).Returns(true);
+            mutant.AnalyzeTestRun(TestGuidsList.NoTest(),
+                TestGuidsList.EveryTest(),
+                TestGuidsList.EveryTest(),
+                false);
 
-            var mutant = new Mutant();
+            mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
+        }
 
-            mutant.AnalyzeTestRun(failedTestsMock.Object, resultTestsMock.Object, timedoutTestsMock.Object);
+        [Fact]
+        public void ShouldSetTimedOutStateWhenSessionTimesOut()
+        {
+            var mutant = new Mutant
+            {
+                AssessingTests = TestGuidsList.EveryTest()
+            };
+
+            mutant.AnalyzeTestRun(TestGuidsList.NoTest(),
+                TestGuidsList.NoTest(),
+                TestGuidsList.NoTest(),
+                true);
 
             mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
@@ -58,5 +58,24 @@ namespace Stryker.Core.UnitTest.MutationTest
             mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
             testRunnerMock.Verify(x => x.TestMultipleMutants(timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
         }
+
+        [Fact]
+        public void MutationTestExecutor_ShouldSwitchToSingleModeOnDubiousTimeouts()
+        {
+            var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
+            var mutant1 = new Mutant { Id = 1, CoveringTests = TestGuidsList.EveryTest() };
+            var mutant2 = new Mutant { Id = 2, CoveringTests = TestGuidsList.EveryTest() };
+            testRunnerMock.Setup(x => x.TestMultipleMutants(It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).
+                Returns(TestRunResult.TimedOut(TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), "", TimeSpan.Zero));
+
+            var target = new MutationTestExecutor(testRunnerMock.Object);
+
+            var timeoutValueCalculator = new TimeoutValueCalculator(500);
+            target.Test(new List<Mutant> { mutant1, mutant2 }, timeoutValueCalculator, null);
+
+            mutant1.ResultStatus.ShouldBe(MutantStatus.Timeout);
+            mutant2.ResultStatus.ShouldBe(MutantStatus.Timeout);
+            testRunnerMock.Verify(x => x.TestMultipleMutants(timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Exactly(3));
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
@@ -44,19 +44,19 @@ namespace Stryker.Core.Mutants
 
         public int? Line => Mutation?.OriginalNode?.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
 
-        public void AnalyzeTestRun(ITestGuids failedTests, ITestGuids resultRanTests, ITestGuids timedOutTests)
+        public void AnalyzeTestRun(ITestGuids failedTests, ITestGuids resultRanTests, ITestGuids timedOutTests, bool sessionTimedOut)
         {
             if (AssessingTests.ContainsAny(failedTests))
             {
                 ResultStatus = MutantStatus.Killed;
             }
+            else if (AssessingTests.ContainsAny(timedOutTests) || sessionTimedOut)
+            {
+                ResultStatus = MutantStatus.Timeout;
+            }
             else if (resultRanTests.IsEveryTest || (resultRanTests.IsEveryTest is not true && AssessingTests.IsIncludedIn(resultRanTests)))
             {
                 ResultStatus = MutantStatus.Survived;
-            }
-            else if (AssessingTests.ContainsAny(timedOutTests))
-            {
-                ResultStatus = MutantStatus.Timeout;
             }
         }
     }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -158,7 +158,7 @@ namespace Stryker.Core.MutationTest
             }
             foreach (var mutant in testedMutants)
             {
-                mutant.AnalyzeTestRun(failedTests, ranTests, timedOutTest);
+                mutant.AnalyzeTestRun(failedTests, ranTests, timedOutTest, false);
 
                 if (mutant.ResultStatus == MutantStatus.NotRun)
                 {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/CoverageRunResult.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/CoverageRunResult.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 
 namespace Stryker.Core.TestRunners
 {
@@ -42,9 +40,6 @@ namespace Stryker.Core.TestRunners
             : MutationTestingRequirements.NotCovered;
 
         public CoverageConfidence Confidence { get; private set; }
-
-        public IReadOnlyCollection<int> LeakedMutations  => _mutationFlags
-            .Where(p => p.Value.HasFlag(MutationTestingRequirements.CoveredOutsideTest)).Select(p => p.Key).ToImmutableArray();
 
         public CoverageRunResult(Guid testId, CoverageConfidence confidence, IEnumerable<int> coveredMutations,
             IEnumerable<int> detectedStaticMutations, IEnumerable<int> leakedMutations)


### PR DESCRIPTION
I found circumstances where Stryker does not properly marks TimedOut mutants (while working on diagnose mode).
This PR fixes this issue.

Note: current design for TimeOut handling is insufficiently cohesive. This comes from the fact that Stryker must handle situations where it cannot identify which test timed out, which happens when this is the very first test to be executed by VsTest (apparently).
An improved refactoring will be provided with diagnose mode. I made this call to avoid a complex merge in the coming weeks 😄 .