### PR TITLE
fix(azure-baseline): Use full SAS token format instead of making assumptions and transformations on the token

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -552,7 +552,7 @@ Providing a subfolder is optional but allowed. In the case of a custom subfolder
 ### `azure-fileshare-sas` <`string`>
 
 Default: `null`  
-Command line: `--azure-fileshare-sas "adfdf34343242323rewfe323434"`  
+Command line: `--azure-fileshare-sas "se=2022-08-25T14%3A27Z&sp=rwdl&spr=https&sv=2021-06-08&sr=d&sdd=1&sig=XXXXXXXXXXXXX"`  
 Config file: `N/A`
 
 When using the azure file storage [provider](#baselineprovider-string) you must pass credentials for the fileshare to Stryker.

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/AzureFileShareBaselineProviderTests.cs
@@ -15,14 +15,16 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 {
     public class AzureFileShareBaselineProviderTests : TestBase
     {
-        [Fact]
-        public async Task Load_Calls_Correct_URL()
+        [Theory]
+        [InlineData("sv=AZURE_SAS_KEY")]
+        [InlineData("?sv=AZURE_SAS_KEY")]
+        public async Task Load_Calls_Correct_URL(string sas)
         {
             // Arrange
             var options = new StrykerOptions()
             {
                 AzureFileStorageUrl = "https://www.filestoragelocation.com",
-                AzureFileStorageSas = "AZURE_SAS_KEY",
+                AzureFileStorageSas = sas,
                 BaselineProvider = BaselineProvider.AzureFileStorage
             };
 
@@ -73,7 +75,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var options = new StrykerOptions()
             {
                 AzureFileStorageUrl = "https://www.filestoragelocation.com",
-                AzureFileStorageSas = "AZURE_SAS_KEY",
+                AzureFileStorageSas = "sv=AZURE_SAS_KEY",
                 BaselineProvider = BaselineProvider.AzureFileStorage
             };
 
@@ -82,14 +84,13 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var readonlyInputComponent = new Mock<IReadOnlyProjectComponent>(MockBehavior.Loose).Object;
 
             var jsonReport = JsonReport.Build(options, readonlyInputComponent);
-
             var expectedGetUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedCreateDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version?sv=AZURE_SAS_KEY&restype=directory");
 
             var expectedFileAllocationUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/project_version/stryker-report.json?sv=AZURE_SAS_KEY&comp=range");
 
             handlerMock
                 .Protected()
@@ -190,7 +191,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var options = new StrykerOptions
             {
                 AzureFileStorageUrl = "https://www.filestoragelocation.com",
-                AzureFileStorageSas = "AZURE_SAS_KEY",
+                AzureFileStorageSas = "sv=AZURE_SAS_KEY",
                 WithBaseline = false,
                 ProjectName = projectName
             };
@@ -203,14 +204,14 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var expectedGetUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedCreateOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateProjectOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateBaselinesDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/baseline/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/?sv=AZURE_SAS_KEY&restype=directory");
+            var expectedCreateProjectOutputDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/?sv=AZURE_SAS_KEY&restype=directory");
+            var expectedCreateBaselinesDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/baseline/?sv=AZURE_SAS_KEY&restype=directory");
+            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/?sv=AZURE_SAS_KEY&restype=directory");
 
             var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{projectName}/{projectVersion}/stryker-report.json?sv=AZURE_SAS_KEY&comp=range");
 
             handlerMock
                 .Protected()
@@ -314,7 +315,7 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
             var options = new StrykerOptions()
             {
                 AzureFileStorageUrl = "https://www.filestoragelocation.com",
-                AzureFileStorageSas = "AZURE_SAS_KEY",
+                AzureFileStorageSas = "sv=AZURE_SAS_KEY",
                 BaselineProvider = BaselineProvider.AzureFileStorage
             };
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
@@ -325,13 +326,13 @@ namespace Stryker.Core.UnitTest.Baseline.Providers
 
             var expectedGetUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedCreateStrykerOutputDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateBaselinesDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/?restype=directory&sv=AZURE_SAS_KEY");
-            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/?restype=directory&sv=AZURE_SAS_KEY");
+            var expectedCreateStrykerOutputDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/?sv=AZURE_SAS_KEY&restype=directory");
+            var expectedCreateBaselinesDirectoryUri = new Uri("https://www.filestoragelocation.com/StrykerOutput/baseline/?sv=AZURE_SAS_KEY&restype=directory");
+            var expectedCreateVersionDirectoryUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/?sv=AZURE_SAS_KEY&restype=directory");
 
             var expectedFileAllocationUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?sv=AZURE_SAS_KEY");
 
-            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?comp=range&sv=AZURE_SAS_KEY");
+            var expectedUploadContentUri = new Uri($"https://www.filestoragelocation.com/StrykerOutput/{version}/stryker-report.json?sv=AZURE_SAS_KEY&comp=range");
 
             handlerMock
                 .Protected()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/AzureFileStorageSasInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/AzureFileStorageSasInputTests.cs
@@ -16,13 +16,25 @@ namespace Stryker.Core.UnitTest.Options.Inputs
         }
 
         [Fact]
-        public void Should_Normalize_SAS()
+        public void Should_Accept_Valid_SAS()
         {
-            var target = new AzureFileStorageSasInput { SuppliedInput = "?sv=SAS" };
+            var target = new AzureFileStorageSasInput { SuppliedInput = "se=2022-08-27T09%3A26%3A07Z&sp=rwdl&spr=https&sv=2018-11-09&sr=s&sig=fzEyru3OpOpzkTpLfFjuI6TEhShY/dsad%3D" };
 
             var validatedSas = target.Validate(BaselineProvider.AzureFileStorage);
 
-            validatedSas.ShouldBe("SAS");
+            validatedSas.ShouldBe("se=2022-08-27T09%3A26%3A07Z&sp=rwdl&spr=https&sv=2018-11-09&sr=s&sig=fzEyru3OpOpzkTpLfFjuI6TEhShY/dsad%3D");
+        }
+
+        [Theory]
+        [InlineData("se=2022-08-27T09%3A26%3A07Z&sp=rwdl&spr=https&sr=s&sig=4324234")]
+        [InlineData("se=2022-08-27T09%3A26%3A07Z&sp=rwdl&spr=https&sr=s&sv=4324234")]
+        public void Should_Throw_Exception_When_Missing_Important_Keys(string input)
+        {
+            var target = new AzureFileStorageSasInput { SuppliedInput = input };
+
+            var exception = Should.Throw<InputException>(() => target.Validate(BaselineProvider.AzureFileStorage));
+
+            exception.Message.ShouldBe("The azure file storage shared access signature is not in the correct format");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -3,11 +3,13 @@ using Stryker.Core.Logging;
 using Stryker.Core.Options;
 using Stryker.Core.Reporters.Json;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace Stryker.Core.Baseline.Providers
 {
@@ -32,7 +34,8 @@ namespace Stryker.Core.Baseline.Providers
         public async Task<JsonReport> Load(string version)
         {
             var fileUrl = $"{_options.AzureFileStorageUrl}/{_outputPath}/{version}/stryker-report.json";
-            var url = new Uri($"{fileUrl}?sv={_options.AzureFileStorageSas}");
+
+            var url = GenerateUri(fileUrl, _options.AzureFileStorageSas).ToString();
 
             using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
 
@@ -53,14 +56,15 @@ namespace Stryker.Core.Baseline.Providers
 
         public async Task Save(JsonReport report, string version)
         {
-            var fileUrl = $"{_options.AzureFileStorageUrl}/{_outputPath}/{version}/stryker-report.json";
-            var url = new Uri($"{fileUrl}?comp=range&sv={_options.AzureFileStorageSas}");
-
             var existingReport = await Load(version);
 
             var reportJson = report.ToJson();
 
             int byteSize = Encoding.UTF8.GetByteCount(report.ToJson());
+
+            var fileUrl = $"{_options.AzureFileStorageUrl}/{_outputPath}/{version}/stryker-report.json";
+
+            var url = GenerateUri(fileUrl, _options.AzureFileStorageSas, new Dictionary<string, string> { { "comp", "range" } }).Uri;
 
             if (existingReport == null)
             {
@@ -112,7 +116,7 @@ namespace Stryker.Core.Baseline.Providers
         {
             _logger.LogDebug("Creating directory {0}", fileUrl);
 
-            var url = new Uri($"{fileUrl}?restype=directory&sv={_options.AzureFileStorageSas}");
+            var url = GenerateUri(fileUrl, _options.AzureFileStorageSas, new Dictionary<string, string> { { "restype", "directory" } }).ToString();
 
             using var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
@@ -137,7 +141,10 @@ namespace Stryker.Core.Baseline.Providers
         {
             _logger.LogDebug("Allocating storage for file {0}", fileUrl);
 
-            var url = new Uri($"{fileUrl}?sv={_options.AzureFileStorageSas}");
+            var uriBuilder = new UriBuilder(fileUrl);
+            var query = HttpUtility.ParseQueryString(_options.AzureFileStorageSas);
+            uriBuilder.Query = query.ToString();
+            var url = uriBuilder.ToString();
 
             using var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
@@ -185,5 +192,21 @@ namespace Stryker.Core.Baseline.Providers
 
         private string ToSafeResponseMessage(string responseMessage) =>
             responseMessage.Replace(_options.AzureFileStorageUrl, "xxxxxxxxxx").Replace(_options.AzureFileStorageSas, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+
+        private static UriBuilder GenerateUri(string fileUrl, string sasToken, Dictionary<string, string> queryParameters = default)
+        {
+            var uriBuilder = new UriBuilder(fileUrl);
+            var query = HttpUtility.ParseQueryString(sasToken);
+            if (queryParameters != default)
+            {
+                foreach (var para in queryParameters)
+                {
+                    query.Add(para.Key, para.Value);
+                }
+            }
+
+            uriBuilder.Query = query.ToString();
+            return uriBuilder;
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/AzureFileShareBaselineProvider.cs
@@ -140,12 +140,8 @@ namespace Stryker.Core.Baseline.Providers
         private async Task<bool> AllocateFileLocationAsync(int byteSize, string fileUrl)
         {
             _logger.LogDebug("Allocating storage for file {0}", fileUrl);
-
-            var uriBuilder = new UriBuilder(fileUrl);
-            var query = HttpUtility.ParseQueryString(_options.AzureFileStorageSas);
-            uriBuilder.Query = query.ToString();
-            var url = uriBuilder.ToString();
-
+            var url = GenerateUri(fileUrl, _options.AzureFileStorageSas).ToString();
+            
             using var requestMessage = new HttpRequestMessage(HttpMethod.Put, url);
 
             requestMessage.Headers.Add("x-ms-type", "file");

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/AzureFileStorageSasInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/AzureFileStorageSasInput.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Web;
 using Stryker.Core.Baseline.Providers;
 using Stryker.Core.Exceptions;
 
@@ -18,8 +20,16 @@ namespace Stryker.Core.Options.Inputs
                     throw new InputException("The azure file storage shared access signature is required when azure file storage is used for dashboard compare.");
                 }
 
-                // Normalize the SAS
-                return SuppliedInput.Replace("?sv=", "");
+                var query = HttpUtility.ParseQueryString(SuppliedInput);
+
+                var hasImportantKey = query.AllKeys.Where(x => x.Equals("sv", System.StringComparison.InvariantCultureIgnoreCase) || x.Equals("sig", System.StringComparison.InvariantCultureIgnoreCase));
+
+                if (hasImportantKey.Count() < 2)
+                {
+                    throw new InputException("The azure file storage shared access signature is not in the correct format");
+                }
+
+                return SuppliedInput;
             }
             return Default;
         }


### PR DESCRIPTION
This PR stops Stryker from making the assumption that the SAS Token is in a specific format.

It will now take the SAS token that has been provided, do some basic validation to ensure that it has the correct parameters (SV & Sig) and will then pass it along to the file share operations.

One thing to note, the order of the query parameters has changed, but the outcome is still the same.

Fixes #2148 