### PR TITLE
chore: Refactor dependency injection

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -13,8 +13,6 @@ namespace Stryker.Core.UnitTest.Initialisation
 {
     public class ProjectMutatorTests : TestBase
     {
-        private readonly Mock<IInitialisationProcessProvider> _initialisationProcessProviderMock = new Mock<IInitialisationProcessProvider>(MockBehavior.Strict);
-        private readonly Mock<IMutationTestProcessProvider> _mutationTestProcessProviderMock = new Mock<IMutationTestProcessProvider>(MockBehavior.Strict);
         private readonly Mock<IMutationTestProcess> _mutationTestProcessMock = new Mock<IMutationTestProcess>(MockBehavior.Strict);
         private readonly Mock<IInitialisationProcess> _initialisationProcessMock = new Mock<IInitialisationProcess>(MockBehavior.Strict);
         private readonly Mock<IReporter> _reporterMock = new Mock<IReporter>(MockBehavior.Strict);
@@ -22,15 +20,6 @@ namespace Stryker.Core.UnitTest.Initialisation
 
         public ProjectMutatorTests()
         {
-            _initialisationProcessProviderMock.Setup(x => x.Provide()).Returns(_initialisationProcessMock.Object);
-
-            _mutationTestProcessProviderMock
-                .Setup(x => x.Provide(
-                    It.IsAny<MutationTestInput>(),
-                    It.IsAny<IReporter>(),
-                    It.IsAny<IMutationTestExecutor>(),
-                    It.IsAny<StrykerOptions>()))
-                .Returns(_mutationTestProcessMock.Object);
 
             _mutationTestProcessMock.Setup(x => x.Mutate());
 
@@ -49,7 +38,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         {
             // arrange
             var options = new StrykerOptions();
-            var target = new ProjectMutator(_initialisationProcessProviderMock.Object, _mutationTestProcessProviderMock.Object);
+            var target = new ProjectMutator(_initialisationProcessMock.Object, _mutationTestProcessMock.Object);
 
             _initialisationProcessMock.Setup(x => x.Initialize(It.IsAny<StrykerOptions>())).Returns(_mutationTestInput);
             _initialisationProcessMock.Setup(x => x.InitialTest(options))

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -500,8 +500,9 @@ public class VsTestMockingHelper : TestBase
             TestRunner = runner,
             InitialTestRun = new InitialTestRun(testRunResult, new TimeoutValueCalculator(500))
         };
-        return new MutationTestProcess(input, new Mock<IReporter>().Object, new MutationTestExecutor(input.TestRunner),
-            fileSystem: _fileSystem, options: options, mutantFilter: new Mock<IMutantFilter>(MockBehavior.Loose).Object);
+        var mutator = new CsharpMutationProcess(input, _fileSystem, options);
+
+        return new MutationTestProcess(input, options, null, new MutationTestExecutor(runner), mutator);
     }
 
     private class MockStrykerTestHostLauncher : IStrykerTestHostLauncher

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -18,16 +17,6 @@ using Stryker.Core.TestRunners.VsTest;
 namespace Stryker.Core.Initialisation
 {
     // For mocking purposes
-    public interface IInitialisationProcessProvider
-    {
-        IInitialisationProcess Provide();
-    }
-
-    [ExcludeFromCodeCoverage]
-    public class InitialisationProcessProvider : IInitialisationProcessProvider
-    {
-        public IInitialisationProcess Provide() => new InitialisationProcess();
-    }
 
     public interface IInitialisationProcess
     {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
 using Stryker.Core.Reporters;
@@ -12,28 +11,25 @@ namespace Stryker.Core.Initialisation
 
     public class ProjectMutator : IProjectMutator
     {
-        private readonly IInitialisationProcessProvider _initialisationProcessProvider;
-        private readonly IMutationTestProcessProvider _mutationTestProcessProvider;
+        private readonly IMutationTestProcess _injectedMutationtestProcess;
+        private readonly IInitialisationProcess _injectedInitialisationProcess;
 
-        public ProjectMutator(IInitialisationProcessProvider initialisationProcessProvider = null,
-            IMutationTestProcessProvider mutationTestProcessProvider = null)
+        public ProjectMutator(IInitialisationProcess initialisationProcess = null,
+            IMutationTestProcess mutationTestProcess = null)
         {
-            _initialisationProcessProvider = initialisationProcessProvider ?? new InitialisationProcessProvider();
-            _mutationTestProcessProvider = mutationTestProcessProvider ?? new MutationTestProcessProvider();
+            _injectedInitialisationProcess = initialisationProcess ;
+            _injectedMutationtestProcess = mutationTestProcess;
         }
 
         public IMutationTestProcess MutateProject(StrykerOptions options, IReporter reporters)
         {
             // get a new instance of InitialisationProcess for each project
-            var initialisationProcess = _initialisationProcessProvider.Provide();
+            var initialisationProcess = _injectedInitialisationProcess ?? new InitialisationProcess();
             // initialize
             var input = initialisationProcess.Initialize(options);
 
-            var process = _mutationTestProcessProvider.Provide(
-                mutationTestInput: input,
-                reporter: reporters,
-                mutationTestExecutor: new MutationTestExecutor(input.TestRunner),
-                options: options);
+            var process = _injectedMutationtestProcess ?? new MutationTestProcess(input, options, reporters,
+                new MutationTestExecutor(input.TestRunner));
 
             // initial test
             input.InitialTestRun = initialisationProcess.InitialTest(options);

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/FilePatternMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/FilePatternMutantFilter.cs
@@ -35,15 +35,15 @@ namespace Stryker.Core.MutantFilters
                 }
 
                 // Check if the mutant is excluded.
-                if (_excludePattern.Any(MatchesPattern))
-                {
-                    return false;
-                }
-
-                return true;
+                return !_excludePattern.Any(MatchesPattern);
 
                 bool MatchesPattern(FilePattern pattern)
                 {
+                    // if we do not have the original node, we cannot exclude the mutation according to its location
+                    if (mutant.Mutation.OriginalNode == null)
+                    {
+                        return false;
+                    }
                     // We check both the full and the relative path to allow for relative paths.
                     return pattern.IsMatch(file.FullPath, mutant.Mutation.OriginalNode.Span) ||
                            pattern.IsMatch(file.RelativePath, mutant.Mutation.OriginalNode.Span);

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -13,6 +13,7 @@ namespace Stryker.Core.MutantFilters
         private static IDiffProvider _diffProvider;
         private static IGitInfoProvider _gitInfoProvider;
         private static IBaselineProvider _baselineProvider;
+        private static MutationTestInput _input;
 
         public static IMutantFilter Create(StrykerOptions options, MutationTestInput mutationTestInput,
             IDiffProvider diffProvider = null, IBaselineProvider baselineProvider = null,
@@ -23,9 +24,10 @@ namespace Stryker.Core.MutantFilters
                 throw new ArgumentNullException(nameof(options));
             }
 
-            _diffProvider = diffProvider ?? new GitDiffProvider(options, mutationTestInput.TestRunner.DiscoverTests());
-            _baselineProvider = baselineProvider ?? BaselineProviderFactory.Create(options);
-            _gitInfoProvider = gitInfoProvider ?? new GitInfoProvider(options);
+            _input = mutationTestInput;
+            _diffProvider = diffProvider ;
+            _baselineProvider = baselineProvider;
+            _gitInfoProvider = gitInfoProvider;
 
             return new BroadcastMutantFilter(DetermineEnabledMutantFilters(options));
         }
@@ -41,11 +43,12 @@ namespace Stryker.Core.MutantFilters
 
             if (options.WithBaseline)
             {
-                enabledFilters.Add(new BaselineMutantFilter(options, _baselineProvider, _gitInfoProvider));
+                enabledFilters.Add(new BaselineMutantFilter(options,
+                    _baselineProvider ?? BaselineProviderFactory.Create(options), _gitInfoProvider ?? new GitInfoProvider(options)));
             }
             if (options.Since || options.WithBaseline)
             {
-                enabledFilters.Add(new SinceMutantFilter(_diffProvider));
+                enabledFilters.Add(new SinceMutantFilter(_diffProvider ?? new GitDiffProvider(options, _input.TestRunner.DiscoverTests())));
             }
             if (options.ExcludedLinqExpressions.Any())
             {
@@ -57,7 +60,7 @@ namespace Stryker.Core.MutantFilters
 
         private sealed class ByMutantFilterType : IComparer<IMutantFilter>
         {
-            public int Compare(IMutantFilter x, IMutantFilter y) => x.Type.CompareTo(y.Type);
+            public int Compare(IMutantFilter x, IMutantFilter y) => x?.Type.CompareTo(y?.Type) ?? -1; 
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -23,9 +23,16 @@ namespace Stryker.Core.MutationTest
         private readonly IFileSystem _fileSystem;
         private readonly MutationTestInput _input;
         private readonly BaseMutantOrchestrator<SyntaxNode> _orchestrator;
-
         private readonly IMutantFilter _mutantFilter;
 
+        /// <summary>
+        /// This constructor is for tests
+        /// </summary>
+        /// <param name="mutationTestInput"></param>
+        /// <param name="fileSystem"></param>
+        /// <param name="options"></param>
+        /// <param name="mutantFilter"></param>
+        /// <param name="orchestrator"></param>
         public CsharpMutationProcess(MutationTestInput mutationTestInput,
             IFileSystem fileSystem = null,
             StrykerOptions options = null,
@@ -42,6 +49,14 @@ namespace Stryker.Core.MutationTest
 
             _mutantFilter = mutantFilter ?? MutantFilterFactory.Create(options, _input);
         }
+
+        /// <summary>
+        /// This constructor is used by the <see cref="MutationTestProcess"/> initialization logic.
+        /// </summary>
+        /// <param name="mutationTestInput"></param>
+        /// <param name="options"></param>
+        public CsharpMutationProcess(MutationTestInput mutationTestInput, StrykerOptions options) : this(mutationTestInput, null, options, null, null)
+        {}
 
         public void Mutate()
         {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/FsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/FsharpMutationProcess.cs
@@ -2,11 +2,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.FSharp.Collections;
 using Stryker.Core.Compiling;
 using Stryker.Core.Logging;
-using Stryker.Core.MutantFilters;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
-using Stryker.Core.Reporters;
 using System;
 using System.IO;
 using System.IO.Abstractions;
@@ -15,7 +13,8 @@ using static FSharp.Compiler.SyntaxTree;
 
 namespace Stryker.Core.MutationTest
 {
-    class FsharpMutationProcess : IMutationProcess
+
+    public class FsharpMutationProcess : IMutationProcess
     {
         private readonly ProjectComponent<ParsedInput> _projectInfo;
         private readonly ILogger _logger;
@@ -23,12 +22,19 @@ namespace Stryker.Core.MutationTest
         private readonly FsharpCompilingProcess _compilingProcess;
         private readonly BaseMutantOrchestrator<FSharpList<SynModuleOrNamespace>> _orchestrator;
 
+        /// <summary>
+        /// This constructor is for tests
+        /// </summary>
+        /// <param name="mutationTestInput"></param>
+        /// <param name="fileSystem"></param>
+        /// <param name="options"></param>
+        /// <param name="orchestrator"></param>
         public FsharpMutationProcess(MutationTestInput mutationTestInput,
-            BaseMutantOrchestrator<FSharpList<SynModuleOrNamespace>> orchestrator = null,
-            IFileSystem fileSystem = null,
-            StrykerOptions options = null)
+            IFileSystem fileSystem,
+            StrykerOptions options,
+            BaseMutantOrchestrator<FSharpList<SynModuleOrNamespace>> orchestrator)
         {
-            MutationTestInput input = mutationTestInput;
+            var input = mutationTestInput;
             _projectInfo = (ProjectComponent<ParsedInput>)input.ProjectInfo.ProjectContents;
 
             _options = options;
@@ -37,6 +43,14 @@ namespace Stryker.Core.MutationTest
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();
         }
 
+        /// <summary>
+        /// This constructor is used by the <see cref="MutationTestProcess"/> initialization logic.
+        /// </summary>
+        /// <param name="mutationTestInput"></param>
+        /// <param name="options"></param>
+        public FsharpMutationProcess(MutationTestInput mutationTestInput,
+            StrykerOptions options): this(mutationTestInput, null, options, null){}
+
         public void Mutate()
         {
             // Mutate source files
@@ -44,15 +58,15 @@ namespace Stryker.Core.MutationTest
             {
                 _logger.LogDebug($"Mutating {file.RelativePath}");
                 // Mutate the syntax tree
-                var treeroot = ((ParsedInput.ImplFile)file.SyntaxTree).Item.modules;
-                var mutatedSyntaxTree = _orchestrator.Mutate(treeroot);
+                var treeRoot = ((ParsedInput.ImplFile)file.SyntaxTree).Item.modules;
+                var mutatedSyntaxTree = _orchestrator.Mutate(treeRoot);
                 // Add the mutated syntax tree for compilation
                 var tree = (ParsedInput.ImplFile)file.SyntaxTree;
                 var item = tree.Item;
                 //we hardcode the lastcompiled flag to make the compile pass
-                //this needs to be fixed in the FSharp.Compiler.SourceCodeServices package, or made dynamic as it now assumes the bottom of Program.fs is the entrypoint
-                var lastcompiled = item.fileName.Equals("Program.fs") ? new Tuple<bool, bool>(true, true) : item.isLastCompiland;
-                file.MutatedSyntaxTree = ParsedInput.NewImplFile(ParsedImplFileInput.NewParsedImplFileInput(item.fileName, item.isScript, item.qualifiedNameOfFile, item.scopedPragmas, item.hashDirectives, mutatedSyntaxTree, lastcompiled));
+                //this needs to be fixed in the FSharp.Compiler.SourceCodeServices package, or made dynamic as it now assumes the bottom of Program.fs is the entry point
+                var lastCompile = item.fileName.Equals("Program.fs") ? new Tuple<bool, bool>(true, true) : item.isLastCompiland;
+                file.MutatedSyntaxTree = ParsedInput.NewImplFile(ParsedImplFileInput.NewParsedImplFileInput(item.fileName, item.isScript, item.qualifiedNameOfFile, item.scopedPragmas, item.hashDirectives, mutatedSyntaxTree, lastCompile));
                 if (_options.DevMode)
                 {
                     _logger.LogTrace($"Mutated {file.RelativePath}:{Environment.NewLine}{mutatedSyntaxTree}");
@@ -92,10 +106,8 @@ namespace Stryker.Core.MutationTest
             }
         }
 
-        public void FilterMutants()
-        {
+        public void FilterMutants() => throw
             //fsharp implementation is work in progress
-            throw new NotImplementedException();
-        }
+            new NotImplementedException();
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/IMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/IMutationProcess.cs
@@ -1,6 +1,6 @@
-﻿namespace Stryker.Core.MutationTest
+namespace Stryker.Core.MutationTest
 {
-    interface IMutationProcess
+    public interface IMutationProcess
     {
         void Mutate();
 

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -1,39 +1,20 @@
 using System;
 using System.Collections.Generic;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
-using Microsoft.FSharp.Collections;
 using Stryker.Core.CoverageAnalysis;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Initialisation.Buildalyzer;
 using Stryker.Core.Logging;
-using Stryker.Core.MutantFilters;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.Reporters;
-using static FSharp.Compiler.SyntaxTree;
 
 namespace Stryker.Core.MutationTest
 {
-    public interface IMutationTestProcessProvider
-    {
-        IMutationTestProcess Provide(MutationTestInput mutationTestInput, IReporter reporter, IMutationTestExecutor mutationTestExecutor, StrykerOptions options);
-    }
-
-    public class MutationTestProcessProvider : IMutationTestProcessProvider
-    {
-        public IMutationTestProcess Provide(MutationTestInput mutationTestInput,
-            IReporter reporter,
-            IMutationTestExecutor mutationTestExecutor,
-            StrykerOptions options) =>
-            new MutationTestProcess(mutationTestInput, reporter, mutationTestExecutor, options: options);
-    }
-
     public interface IMutationTestProcess
     {
         MutationTestInput Input { get; }
@@ -46,62 +27,61 @@ namespace Stryker.Core.MutationTest
 
     public class MutationTestProcess : IMutationTestProcess
     {
-        public MutationTestInput Input { get; }
+        private static readonly ILogger Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();;
         private readonly IProjectComponent _projectContents;
-        private readonly ILogger _logger;
         private readonly IMutationTestExecutor _mutationTestExecutor;
-        private readonly IFileSystem _fileSystem;
-        private readonly BaseMutantOrchestrator _orchestrator;
         private readonly IReporter _reporter;
         private readonly ICoverageAnalyser _coverageAnalyser;
         private readonly StrykerOptions _options;
-        private readonly Language _language;
-        private IMutationProcess _mutationProcess;
+        private readonly IMutationProcess _mutationProcess;
+        private static readonly Dictionary<Language, Func<MutationTestInput, StrykerOptions, IMutationProcess>> LanguageMap = new();
 
-        public MutationTestProcess(MutationTestInput mutationTestInput,
-            IReporter reporter,
-            IMutationTestExecutor mutationTestExecutor,
-            BaseMutantOrchestrator<SyntaxNode> cSharpOrchestrator = null,
-            BaseMutantOrchestrator<FSharpList<SynModuleOrNamespace>> fSharpOrchestrator = null,
-            IFileSystem fileSystem = null,
-            IMutantFilter mutantFilter = null,
-            ICoverageAnalyser coverageAnalyser = null,
-            StrykerOptions options = null)
+        static MutationTestProcess()
         {
-            Input = mutationTestInput;
-            _projectContents = mutationTestInput.ProjectInfo.ProjectContents;
-            _reporter = reporter;
-            _options = options;
-            _mutationTestExecutor = mutationTestExecutor;
-            _fileSystem = fileSystem ?? new FileSystem();
-            _logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();
-            _coverageAnalyser = coverageAnalyser ?? new CoverageAnalyser(_options);
-            _language = Input.ProjectInfo.ProjectUnderTestAnalyzerResult.GetLanguage();
-            _orchestrator = cSharpOrchestrator ?? fSharpOrchestrator ?? ChooseOrchestrator(_options);
-
-            SetupMutationTestProcess(mutantFilter);
+            DeclareMutationProcessForLanguage<CsharpMutationProcess>(Language.Csharp);
+            DeclareMutationProcessForLanguage<FsharpMutationProcess>(Language.Fsharp);
         }
 
-        private BaseMutantOrchestrator ChooseOrchestrator(StrykerOptions options)
+        public static void DeclareMutationProcessForLanguage<T>(Language language) where T:IMutationProcess
         {
-            if (_language == Language.Fsharp)
+            var constructor = typeof(T).GetConstructor(new[]
+                { typeof(MutationTestInput), typeof(StrykerOptions) });
+            if (constructor == null)
             {
-                return new FsharpMutantOrchestrator(options: options);
+                throw new NotSupportedException(
+                    $"Failed to find a constructor with the appropriate signature for type {typeof(T)}");
             }
 
-            return new CsharpMutantOrchestrator(options: options);
+            LanguageMap[language] = (x, y) => (IMutationProcess)constructor.Invoke(new object[] { x, y });
         }
 
-        private void SetupMutationTestProcess(IMutantFilter mutantFilter) =>
-            _mutationProcess = _language switch
+        public MutationTestProcess(MutationTestInput input,
+            StrykerOptions options,
+            IReporter reporter,
+            IMutationTestExecutor executor,
+            IMutationProcess mutationProcess = null,
+            ICoverageAnalyser coverageAnalyzer = null)
+        {
+            Input = input;
+            _reporter = reporter;
+            _options = options;
+            _mutationTestExecutor = executor;
+            _mutationProcess = mutationProcess ?? BuildMutationProcess();
+            _coverageAnalyser = coverageAnalyzer ?? new CoverageAnalyser(_options);
+            _projectContents = input.ProjectInfo.ProjectContents;
+        }
+
+        public MutationTestInput Input { get; }
+
+        private IMutationProcess BuildMutationProcess()
+        {
+            if (!LanguageMap.ContainsKey(Input.ProjectInfo.ProjectUnderTestAnalyzerResult.GetLanguage()))
             {
-                Language.Csharp => new CsharpMutationProcess(Input, _fileSystem, _options, mutantFilter,
-                    (BaseMutantOrchestrator<SyntaxNode>)_orchestrator),
-                Language.Fsharp => new FsharpMutationProcess(Input,
-                    (BaseMutantOrchestrator<FSharpList<SynModuleOrNamespace>>)_orchestrator, _fileSystem, _options),
-                _ => throw new GeneralStrykerException(
-                    "no valid language detected || no valid csproj or fsproj was given")
-            };
+                throw new GeneralStrykerException(
+                    "no valid language detected || no valid csproj or fsproj was given.");
+            }
+            return LanguageMap[Input.ProjectInfo.ProjectUnderTestAnalyzerResult.GetLanguage()](Input, _options);
+        }
 
         public void Mutate()
         {
@@ -177,7 +157,7 @@ namespace Stryker.Core.MutationTest
             {
                 if (mutant.ResultStatus == MutantStatus.NotRun)
                 {
-                    _logger.LogWarning($"Mutation {mutant.Id} was not fully tested.");
+                    Logger.LogWarning($"Mutation {mutant.Id} was not fully tested.");
                 }
 
                 OnMutantTested(mutant, reportedMutants);
@@ -240,6 +220,7 @@ namespace Stryker.Core.MutationTest
                     {
                         break;
                     }
+
                     if (nextSet.ContainsAny(usedTests))
                     {
                         continue;
@@ -256,7 +237,7 @@ namespace Stryker.Core.MutationTest
                 blocks.Add(nextBlock);
             }
             
-            _logger.LogDebug(
+            Logger.LogDebug(
                 $"Mutations will be tested in {blocks.Count} test runs" +
                 (mutantsNotRun.Count > blocks.Count ? $", instead of {mutantsNotRun.Count}." : "."));
 

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -27,7 +27,7 @@ namespace Stryker.Core.MutationTest
 
     public class MutationTestProcess : IMutationTestProcess
     {
-        private static readonly ILogger Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();;
+        private static readonly ILogger Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();
         private readonly IProjectComponent _projectContents;
         private readonly IMutationTestExecutor _mutationTestExecutor;
         private readonly IReporter _reporter;

--- a/src/Stryker.DataCollector/Stryker.DataCollector/CoverageCollector.cs
+++ b/src/Stryker.DataCollector/Stryker.DataCollector/CoverageCollector.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using System.Xml;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector;


### PR DESCRIPTION
Refactor process classes to simplify design. Get rid of some intermediate factory classes.
Reduce coupling with C# and F# coupling, giving the opportunity to move the incomplete F# support to a dedicated project, or at least branch