### PR TITLE
deps(html report): Update mutation-testing-elements to 1.7.11

### DIFF
--- a/src/Stryker.Core/Stryker.Core/libman.json
+++ b/src/Stryker.Core/Stryker.Core/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "jsdelivr",
   "libraries": [
     {
-      "library": "mutation-testing-elements@1.7.10",
+      "library": "mutation-testing-elements@1.7.11",
       "files": [
         "dist/mutation-test-elements.js"
       ],


### PR DESCRIPTION
Fixes theme color for Ignored mutants.
Hides unnecessary mutant id from mutant drawer.