### PR TITLE
Safe mode now works properly in constructors

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/RollbackProcess.cs
@@ -143,13 +143,13 @@ namespace Stryker.Core.Compiling
         {
             for (var currentNode = node; currentNode != null; currentNode = currentNode.Parent)
             {
-                if (currentNode.IsKind(SyntaxKind.MethodDeclaration) || currentNode.IsKind(SyntaxKind.GetAccessorDeclaration) || currentNode.IsKind(SyntaxKind.SetAccessorDeclaration))
+                if (currentNode.IsKind(SyntaxKind.MethodDeclaration) || currentNode.IsKind(SyntaxKind.GetAccessorDeclaration) || currentNode.IsKind(SyntaxKind.SetAccessorDeclaration) || currentNode.IsKind(SyntaxKind.ConstructorDeclaration))
                 {
                     return currentNode;
                 }
             }
-
-            return null;
+            // return the all file if not found
+            return node.SyntaxTree.GetRoot();
         }
 
         private void ScanAllMutationsIfsAndIds(SyntaxNode node, IList<MutantInfo> scan)
@@ -226,7 +226,7 @@ namespace Stryker.Core.Compiling
                     }
 
                     var scan = new List<MutantInfo>();
-                    var initNode = FindEnclosingMember(brokenMutation) ?? brokenMutation;
+                    var initNode = FindEnclosingMember(brokenMutation);
                     ScanAllMutationsIfsAndIds(initNode, scan);
 
                     if (scan.Any(x => x.Type == Mutator.Block.ToString()))


### PR DESCRIPTION
Ensure Stryker identifies properly Constructor as an appropriate scope for safe mode.
Ensure Stryker rolls back every mutation in the concerned source file when it fails to find the error enclosing scope. Previous versions of Stryker used the offending syntax node as the scope, leading to internal compilation errors when triggered.

Note that I have not been able to devise a unit test for that, as I did not find any way to trigger this condition with correct code.
The alternative to this could be to raise an exception when no scope is found, but it means blocking users when this happens.