### PR TITLE
Use null instead of empty string for TestCaseFilter parameter

### DIFF
--- a/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
+++ b/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
@@ -112,25 +112,26 @@ namespace Stryker.Core.CoverageAnalysis
             {
                 mutant.CoveringTests = testGuids.Merge(dubiousTests);
                 mutant.AssessingTests = testGuids.Merge(dubiousTests).Excluding(failedTest);
-                if (mutant.CoveringTests.IsEmpty && mutant.ResultStatus == MutantStatus.NotRun)
-                {
-                    mutant.ResultStatus = MutantStatus.NoCoverage;
-                    mutant.ResultStatusReason = "Not covered by any test.";
-                    _logger.LogInformation(
-                        $"Mutant {mutant.Id} is not covered by any test.");
-                }
-                else if (mutant.AssessingTests.IsEmpty && mutant.ResultStatus == MutantStatus.NotRun)
-                {
-                    mutant.ResultStatus = MutantStatus.Survived;
-                    mutant.ResultStatusReason = "Only covered by already failing tests.";
-                    _logger.LogInformation(
-                        $"Mutant {mutant.Id} is only covered by failing tests.");
-                }
-                else
-                {
-                    _logger.LogDebug(
-                        $"Mutant {mutant.Id} will be tested against ({mutant.AssessingTests.Count}) tests.");
-                }
+            }
+            // assess status according to actual coverage
+            if (mutant.CoveringTests.IsEmpty && mutant.ResultStatus == MutantStatus.NotRun)
+            {
+                mutant.ResultStatus = MutantStatus.NoCoverage;
+                mutant.ResultStatusReason = "Not covered by any test.";
+                _logger.LogInformation(
+                    $"Mutant {mutant.Id} is not covered by any test.");
+            }
+            else if (mutant.AssessingTests.IsEmpty && mutant.ResultStatus == MutantStatus.NotRun)
+            {
+                mutant.ResultStatus = MutantStatus.Survived;
+                mutant.ResultStatusReason = "Only covered by already failing tests.";
+                _logger.LogInformation(
+                    $"Mutant {mutant.Id} is only covered by failing tests.");
+            }
+            else
+            {
+                _logger.LogDebug(
+                    $"Mutant {mutant.Id} will be tested against ({(mutant.AssessingTests.IsEveryTest ? "all" : mutant.AssessingTests.Count)}) tests.");
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -196,7 +196,7 @@ namespace Stryker.Core.TestRunners.VsTest
             eventHandler.ResultsUpdated += HandlerUpdate;
 
             _aborted = false;
-            var options = new TestPlatformOptions { TestCaseFilter = /*string.IsNullOrWhiteSpace(_context.Options.TestCaseFilter) ? null : */_context.Options.TestCaseFilter };
+            var options = new TestPlatformOptions { TestCaseFilter = string.IsNullOrWhiteSpace(_context.Options.TestCaseFilter) ? null : _context.Options.TestCaseFilter };
             if (tests.IsEveryTest)
             {
                 _vsTestConsole.RunTestsWithCustomTestHostAsync(_context.TestSources, runSettings, options, eventHandler,

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -196,7 +196,7 @@ namespace Stryker.Core.TestRunners.VsTest
             eventHandler.ResultsUpdated += HandlerUpdate;
 
             _aborted = false;
-            var options = new TestPlatformOptions { TestCaseFilter = _context.Options.TestCaseFilter };
+            var options = new TestPlatformOptions { TestCaseFilter = /*string.IsNullOrWhiteSpace(_context.Options.TestCaseFilter) ? null : */_context.Options.TestCaseFilter };
             if (tests.IsEveryTest)
             {
                 _vsTestConsole.RunTestsWithCustomTestHostAsync(_context.TestSources, runSettings, options, eventHandler,


### PR DESCRIPTION
fix #2251, workaround a potential bug in some xUnit versions