### PR TITLE
fix(since): correctly classify changed files as source or test files

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
@@ -597,5 +597,92 @@ namespace Stryker.Core.UnitTest.DiffProviders
             res.ChangedTestFiles.Count().ShouldBe(2);
             res.ChangedSourceFiles.Count().ShouldBe(3);
         }
+        [Fact]
+        public void ScanDiffReturnsListOfFiles_WithoutTestProjects_ShouldCorrectlyAssignTestAndSourceFiles()
+        {
+            // Arrange
+            var basePath = FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests1");
+            var options = new StrykerOptions()
+            {
+                ProjectPath = basePath,
+                SinceTarget = "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            };
+            var gitInfoMock = new Mock<IGitInfoProvider>();
+            var repositoryMock = new Mock<IRepository>(MockBehavior.Loose);
+            var commitMock = new Mock<Commit>(MockBehavior.Loose);
+            var branchMock = new Mock<Branch>(MockBehavior.Strict);
+            var patchMock = new Mock<Patch>(MockBehavior.Strict);
+            var patchEntrySourceFile1Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntrySourceFile2Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntrySourceFile3Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntryTestFile1Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntryTestFile2Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+
+            // Setup of mocks
+            commitMock
+                .SetupGet(x => x.Tree)
+                .Returns(new Mock<Tree>(MockBehavior.Loose).Object);
+
+            branchMock
+                .SetupGet(x => x.Tip)
+                .Returns(commitMock.Object);
+
+            branchMock.SetupGet(x => x.UpstreamBranchCanonicalName).Returns("origin/branch");
+            branchMock.SetupGet(x => x.CanonicalName).Returns("refs/heads/branch");
+            branchMock.SetupGet(x => x.FriendlyName).Returns("branch");
+
+            repositoryMock
+                .Setup(x => x.Branches.GetEnumerator())
+                .Returns(new List<Branch> { branchMock.Object }.GetEnumerator())
+                .Verifiable();
+
+            patchEntrySourceFile1Mock
+                .SetupGet(x => x.Path)
+                .Returns("file.cs");
+            patchEntrySourceFile2Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Source/Category/Source1.cs"));
+            patchEntrySourceFile3Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/RootFile.cs"));
+
+            patchEntryTestFile1Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests1/Test.cs"));
+            patchEntryTestFile2Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests2/CategoryA/Test2.cs"));
+
+            patchMock
+                .Setup(x => x.GetEnumerator())
+                .Returns(((IEnumerable<PatchEntryChanges>)new List<PatchEntryChanges>
+                {
+                    patchEntrySourceFile1Mock.Object,
+                    patchEntrySourceFile2Mock.Object,
+                    patchEntrySourceFile3Mock.Object,
+                    patchEntryTestFile1Mock.Object,
+                    patchEntryTestFile2Mock.Object
+                }).GetEnumerator());
+
+            repositoryMock
+                .Setup(x => x.Diff.Compare<Patch>(It.IsAny<Tree>(), DiffTargets.WorkingDirectory))
+                .Returns(patchMock.Object);
+
+            repositoryMock
+                .Setup(x => x.Lookup(It.IsAny<ObjectId>())).Returns(commitMock.Object);
+
+            gitInfoMock.Setup(x => x.DetermineCommit()).Returns(commitMock.Object);
+
+            gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
+            gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
+            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+
+            // Act
+            var res = target.ScanDiff();
+
+            // Assert
+            res.ChangedTestFiles.Count().ShouldBe(1);
+            res.ChangedSourceFiles.Count().ShouldBe(4);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
@@ -506,5 +506,96 @@ namespace Stryker.Core.UnitTest.DiffProviders
             // Assert
             res.ChangedSourceFiles.Count().ShouldBe(0);
         }
+
+        [Fact]
+        public void ScanDiffReturnsListOfFiles_ShouldCorrectlyAssignTestAndSourceFiles()
+        {
+            // Arrange
+            var basePath = FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Source");
+            var test1Path = FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests1");
+            var test2Path = FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests2");
+            var options = new StrykerOptions()
+            {
+                ProjectPath = basePath,
+                TestProjects = new[] { test1Path, test2Path },
+                SinceTarget = "d670460b4b4aece5915caf5c68d12f560a9fe3e4",
+            };
+            var gitInfoMock = new Mock<IGitInfoProvider>();
+            var repositoryMock = new Mock<IRepository>(MockBehavior.Loose);
+            var commitMock = new Mock<Commit>(MockBehavior.Loose);
+            var branchMock = new Mock<Branch>(MockBehavior.Strict);
+            var patchMock = new Mock<Patch>(MockBehavior.Strict);
+            var patchEntrySourceFile1Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntrySourceFile2Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntrySourceFile3Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntryTestFile1Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+            var patchEntryTestFile2Mock = new Mock<PatchEntryChanges>(MockBehavior.Strict);
+
+            // Setup of mocks
+            commitMock
+                .SetupGet(x => x.Tree)
+                .Returns(new Mock<Tree>(MockBehavior.Loose).Object);
+
+            branchMock
+                .SetupGet(x => x.Tip)
+                .Returns(commitMock.Object);
+
+            branchMock.SetupGet(x => x.UpstreamBranchCanonicalName).Returns("origin/branch");
+            branchMock.SetupGet(x => x.CanonicalName).Returns("refs/heads/branch");
+            branchMock.SetupGet(x => x.FriendlyName).Returns("branch");
+
+            repositoryMock
+                .Setup(x => x.Branches.GetEnumerator())
+                .Returns(new List<Branch> { branchMock.Object }.GetEnumerator())
+                .Verifiable();
+
+            patchEntrySourceFile1Mock
+                .SetupGet(x => x.Path)
+                .Returns("file.cs");
+            patchEntrySourceFile2Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Source/Category/Source1.cs"));
+            patchEntrySourceFile3Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/RootFile.cs"));
+
+            patchEntryTestFile1Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests1/Test.cs"));
+            patchEntryTestFile2Mock
+                .SetupGet(x => x.Path)
+                .Returns(FilePathUtils.NormalizePathSeparators("/c/Users/JohnDoe/Project/Tests/Tests2/CategoryA/Test2.cs"));
+
+            patchMock
+                .Setup(x => x.GetEnumerator())
+                .Returns(((IEnumerable<PatchEntryChanges>)new List<PatchEntryChanges>
+                {
+                    patchEntrySourceFile1Mock.Object,
+                    patchEntrySourceFile2Mock.Object,
+                    patchEntrySourceFile3Mock.Object,
+                    patchEntryTestFile1Mock.Object,
+                    patchEntryTestFile2Mock.Object
+                }).GetEnumerator());
+
+            repositoryMock
+                .Setup(x => x.Diff.Compare<Patch>(It.IsAny<Tree>(), DiffTargets.WorkingDirectory))
+                .Returns(patchMock.Object);
+
+            repositoryMock
+                .Setup(x => x.Lookup(It.IsAny<ObjectId>())).Returns(commitMock.Object);
+
+            gitInfoMock.Setup(x => x.DetermineCommit()).Returns(commitMock.Object);
+
+            gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
+            gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
+            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+
+            // Act
+            var res = target.ScanDiff();
+
+            // Assert
+            res.ChangedTestFiles.Count().ShouldBe(2);
+            res.ChangedSourceFiles.Count().ShouldBe(3);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
@@ -39,7 +39,13 @@ namespace Stryker.Core.DiffProviders
                 throw new InputException("Could not determine a commit to check for diff. Please check you have provided the correct value for --git-source");
             }
 
-            var testPaths = _options.TestProjects
+            var testProjects = _options.TestProjects.ToList();
+            if (!testProjects.Any())
+            {
+                testProjects.Add(_options.ProjectPath);
+            }
+
+            var testPaths = testProjects
                 .Select(testProject => testProject.EndsWith(Path.DirectorySeparatorChar)
                         ? testProject
                         : testProject + Path.DirectorySeparatorChar)

--- a/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
@@ -39,6 +39,12 @@ namespace Stryker.Core.DiffProviders
                 throw new InputException("Could not determine a commit to check for diff. Please check you have provided the correct value for --git-source");
             }
 
+            var testPaths = _options.TestProjects
+                .Select(testProject => testProject.EndsWith(Path.DirectorySeparatorChar)
+                        ? testProject
+                        : testProject + Path.DirectorySeparatorChar)
+                .ToArray();
+
             foreach (var patchChanges in repository.Diff.Compare<Patch>(commit.Tree, DiffTargets.WorkingDirectory))
             {
                 string diffPath = FilePathUtils.NormalizePathSeparators(Path.Combine(_gitInfoProvider.RepositoryPath, patchChanges.Path));
@@ -47,12 +53,8 @@ namespace Stryker.Core.DiffProviders
                 {
                     continue;
                 }
-
-                var fullName = _options.ProjectPath.EndsWith(Path.DirectorySeparatorChar)
-                    ? _options.ProjectPath
-                    : _options.ProjectPath + Path.DirectorySeparatorChar;
-
-                if (diffPath.StartsWith(fullName))
+                
+                if (testPaths.Any(testPath => diffPath.StartsWith(testPath)))
                 {
                     diffResult.ChangedTestFiles.Add(diffPath);
                 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
@@ -29,7 +29,7 @@ namespace Stryker.Core.MutantFilters
 
             if (_diffResult != null)
             {
-                _logger.LogInformation("{0} files changed", _diffResult.ChangedSourceFiles?.Count ?? 0 + _diffResult.ChangedTestFiles?.Count ?? 0);
+                _logger.LogInformation("{0} files changed", (_diffResult.ChangedSourceFiles?.Count ?? 0) + (_diffResult.ChangedTestFiles?.Count ?? 0));
 
                 if (_diffResult.ChangedSourceFiles != null)
                 {


### PR DESCRIPTION
Correct the classification of changed files in GIT as source or test files in `GitDiffProvider` when using the `SinceMutantFilter`.
fix #2255 

Also correct the displayed number of total changed files in the Log when using the `SinceMutantFilter`.