### PR TITLE
docs: add reference to integration test projects in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,22 +18,22 @@ New features are welcome! Either as requests or proposals.
 ## Adding a new mutator
 Please read the [dedicated document](adding_a_mutator.md).
 
-#### Setup Stryker.NET locally
+## Setup Stryker.NET locally
 While developing on Stryker.NET we advise to work in [the latest Visual Studio](https://www.visualstudio.com/downloads/) and to set Stryker up to run on a UnitTest project on your local disk.
 
-#### Example: Steps to run Stryker.NET on a local project
+### Example: Steps to run Stryker.NET on a local project
 *	Clone the repository `https://github.com/stryker-mutator/stryker-net.git`
 *	Open `Stryker.CLI.sln`
 *	On `Stryker.CLI` open `properties > Debug`
 *	Create a new Debug profile
-*	Set `Launch` as `Project` 
-*	Set `WorkingDirectory` as your local installation dir, pointing to a UnitTest project `example: (C:\Repos\MyProject\src\MyProject\MyProject.UnitTest)`
+*	Set `Launch` as `Project`
+*	Set `WorkingDirectory` as your local installation dir, pointing to a UnitTest project `example: (C:\Repos\MyProject\src\MyProject\MyProject.UnitTest)`. You can use the ready made projects in `.\integrationtest\TargetProjects` for this.
 *	Run the program with `Stryker.CLI` as the startup project with the newly created Debug profile
 
 \* Running Stryker on itself doesn't work as the assemblies will be in use by Visual Studio. You can clone Stryker another time to use as a test project.
 
 #### Compiler Platform SDK
-We advise to use the [.NET Compiler Platform SDK](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.NETCompilerPlatformSDK) during development. The `Syntax Visualizer` can help to understand Abstract Syntax Trees and find out types of `SyntaxNodes` you need to target for certain mutators. 
+We advise to use the [.NET Compiler Platform SDK](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.NETCompilerPlatformSDK) during development. The `Syntax Visualizer` can help to understand Abstract Syntax Trees and find out types of `SyntaxNodes` you need to target for certain mutators.
 
 ## Maintainers
 When merging pull requests or creating commits, please conform to [the angular commit message style](https://docs.google.com/document/d/1rk04jEuGfk9kYzfqCuOlPTSJw3hEDZJTBN5E5f1SALo), so our changelog will be updated.


### PR DESCRIPTION
In the CONTRIBUTING.MD, there are instructions for running Stryker locally. I added a reference to the existing integration test projects so that people don't need to setup their own dummy project.