### PR TITLE
fix(assignment statement mutator): Add trivia between operands

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/AssignmentStatementMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/AssignmentStatementMutatorTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Shouldly;
 using Stryker.Core.Mutators;
 using System.Linq;
@@ -54,6 +55,27 @@ namespace Stryker.Core.UnitTest.Mutators
                 mutation.Type.ShouldBe(Mutator.Assignment);
                 mutation.DisplayName.ShouldBe($"{input} to {mutation.ReplacementNode.Kind()} mutation");
             }
+        }
+
+        [Theory]
+        [InlineData("a += b", "a -= b")]
+        [InlineData("a +=  b", "a -=  b")]
+        [InlineData("a  += b", "a  -= b")]
+        [InlineData("a +=\nb", "a -=\nb")]
+        [InlineData("a\n+= b", "a\n-= b")]
+        public void ShouldKeepTrivia(string originalExpressionString, string expectedExpressionString)
+        {
+            // Arrange
+            var target = new AssignmentExpressionMutator();
+            var originalExpression = SyntaxFactory.ParseExpression(originalExpressionString);
+
+            // Act
+            var result = target.ApplyMutations(originalExpression as AssignmentExpressionSyntax);
+
+            // Assert
+            var mutation = result.ShouldHaveSingleItem();
+
+            mutation.ReplacementNode.ToString().ShouldBe(expectedExpressionString);
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
@@ -41,10 +41,12 @@ namespace Stryker.Core.Mutators
 
             foreach (var targetAssignmentKind in targetAssignmentKinds)
             {
+                var replacementNode = SyntaxFactory.AssignmentExpression(targetAssignmentKind, node.Left, node.Right);
+                replacementNode = replacementNode.WithOperatorToken(replacementNode.OperatorToken.WithTriviaFrom(node.OperatorToken));
                 yield return new Mutation
                 {
                     OriginalNode = node,
-                    ReplacementNode = SyntaxFactory.AssignmentExpression(targetAssignmentKind, node.Left, node.Right),
+                    ReplacementNode = replacementNode,
                     DisplayName = $"{assignmentKind} to {targetAssignmentKind} mutation",
                     Type = Mutator.Assignment
                 };


### PR DESCRIPTION
Fixed that the output of the AssignmentMutator is missing a space after the operator.