### PR TITLE
fix(reporting): Correctly show whitespace in report

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/SourceFiles/JsonMutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/SourceFiles/JsonMutant.cs
@@ -31,7 +31,7 @@ namespace Stryker.Core.Reporters.Json.SourceFiles
             MutatorName = mutant.Mutation.DisplayName;
             Description = mutant.Mutation.Description;
 
-            Replacement = mutant.Mutation.ReplacementNode.ToFullString();
+            Replacement = mutant.Mutation.ReplacementNode.ToString();
             Location = new Location(mutant.Mutation.OriginalNode.GetLocation().GetMappedLineSpan());
 
             Status = mutant.ResultStatus.ToString();


### PR DESCRIPTION
Now using `SyntaxNode.ToString()` instead of `SyntaxNode.ToFullString()` in the `JsonMutant` class. [`SyntaxNode.ToFullString()`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.syntaxnode.tofullstring?view=roslyn-dotnet-4.3.0) also includes leading and trailing trivia. Leading trivia should not be necessary as the location is already set here:

https://github.com/stryker-mutator/stryker-net/blob/085a0b7837370b709b00285ba4efe5ad55718a0a/src/Stryker.Core/Stryker.Core/Reporters/Json/SourceFiles/JsonMutant.cs#L35

This change renders the report correctly: 
<img width="261" alt="image" src="https://user-images.githubusercontent.com/24809068/198847726-1c1b4d38-8d6b-4a22-813b-551359b60c54.png">


Q: Should trailing trivia be included?

Fixes #2270 