### PR TITLE
docs(operating modes): Add operating modes page

### DIFF
--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -20,17 +20,11 @@ Just run
 dotnet stryker
 ```
 
-in your test project folder. Stryker will automatically detect the target project based on the project reference. If your test project has multiple project references, you need to specify the target project with `--project <filename>` ([docs here](https://stryker-mutator.io/docs/stryker-net/configuration/#project-file-name)). You can only specify one target project at the time.
+in your test project folder. Stryker will automatically detect the source project based on the project reference. If your test project has multiple project references, you need to specify the source project with `--project <filename>` ([docs here](https://stryker-mutator.io/docs/stryker-net/configuration/#project-file-name)). You can only specify one source project at the time.
 
-## Target project context
+## Source project context
 
-Run
-
-```bash
-dotnet stryker -tp "../Tests/Tests.csproj"
-```
-
-in your target project folder. If multiple test projects (ex unit tests, specs) target the same source project you need to specify each test project. You can include multiple test projects like this ([see docs](https://stryker-mutator.io/docs/stryker-net/configuration/#test-projects-string)):
+Run `dotnet stryker -tp "../Tests/Tests.csproj"` in your source project folder. If multiple test projects (ex unit tests, specs) target the same source project you need to specify each test project. You can include multiple test projects like this ([see docs](https://stryker-mutator.io/docs/stryker-net/configuration/#test-projects-string)):
 
 ```bash
 dotnet stryker -tp "../Tests/Tests.csproj" -tp "../MoreTests/MoreTests.csproj"

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -14,13 +14,8 @@ You will also be able to run Stryker from your solution context in the future.
 
 ## Test project context
 
-Just run
-
-```bash
-dotnet stryker
-```
-
-in your test project folder. Stryker will automatically detect the source project based on the project reference. If your test project has multiple project references, you need to specify the source project with `--project <filename>` ([docs here](https://stryker-mutator.io/docs/stryker-net/configuration/#project-file-name)). You can only specify one source project at the time.
+Just run `dotnet stryker` in your test project folder.  
+Stryker will automatically detect the source project based on the project reference. If your test project has multiple project references, you need to specify the source project with `--project <filename>` ([docs here](https://stryker-mutator.io/docs/stryker-net/configuration/#project-file-name)). You can only specify one source project at the time.
 
 ## Source project context
 

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -5,7 +5,7 @@ custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs
 ---
 # Operating modes
 
-There are currently two different ways to run Stryker:
+There are currently two ways to run Stryker:
 
 - From the test project context
 - From the source project context

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -30,7 +30,7 @@ Run
 dotnet stryker -tp "../Tests/Tests.csproj"
 ```
 
-in your target project folder. If your target project uses multiple test projects that you want to include in the Stryker run, you need to specify each test project. You can include multiple test projects like this ([see docs](https://stryker-mutator.io/docs/stryker-net/configuration/#test-projects-string)):
+in your target project folder. If multiple test projects (ex unit tests, specs) target the same source project you need to specify each test project. You can include multiple test projects like this ([see docs](https://stryker-mutator.io/docs/stryker-net/configuration/#test-projects-string)):
 
 ```bash
 dotnet stryker -tp "../Tests/Tests.csproj" -tp "../MoreTests/MoreTests.csproj"

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -8,7 +8,7 @@ custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs
 There are currently two different ways to run Stryker:
 
 - From the test project context
-- From the target project context
+- From the source project context
 
 You will also be able to run Stryker from your solution context in the future.
 

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -1,0 +1,41 @@
+---
+title: Operating modes
+sidebar_position: 25
+custom_edit_url: https://github.com/stryker-mutator/stryker-net/edit/master/docs/operating-modes.md
+---
+# Operating modes
+
+There are currently two different ways to run Stryker:
+
+- From the test project context
+- From the target project context
+
+You will also be able to run Stryker from your solution context in the future.
+
+## Test project context
+
+Just run
+
+```bash
+dotnet stryker
+```
+
+in your test project folder. Stryker will automatically detect the target project based on the project reference. If your test project has multiple project references, you need to specify the target project with `--project <filename>` ([docs here](https://stryker-mutator.io/docs/stryker-net/configuration/#project-file-name)). You can only specify one target project at the time.
+
+## Target project context
+
+Run
+
+```bash
+dotnet stryker -tp "../Tests/Tests.csproj"
+```
+
+in your target project folder. If your target project uses multiple test projects that you want to include in the Stryker run, you need to specify each test project. You can include multiple test projects like this ([see docs](https://stryker-mutator.io/docs/stryker-net/configuration/#test-projects-string)):
+
+```bash
+dotnet stryker -tp "../Tests/Tests.csproj" -tp "../MoreTests/MoreTests.csproj"
+```
+
+## Solution file context
+
+Coming soon!


### PR DESCRIPTION
Added a new page to the documentation to specify the different ways to run Stryker. I did not document the solution context way, as it's still in progress (right?).

Closes #2281 