### PR TITLE
chore: initializermutator expressions cannot be less than 0

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
@@ -11,7 +11,7 @@ namespace Stryker.Core.Mutators
 
         public override IEnumerable<Mutation> ApplyMutations(InitializerExpressionSyntax node)
         {
-            if (node.Parent is ArrayCreationExpressionSyntax || node.Parent is ImplicitArrayCreationExpressionSyntax || node.Parent is StackAllocArrayCreationExpressionSyntax || node.Expressions.Count <= 0)
+            if (node.Parent is ArrayCreationExpressionSyntax || node.Parent is ImplicitArrayCreationExpressionSyntax || node.Parent is StackAllocArrayCreationExpressionSyntax || node.Expressions.Count == 0)
             {
                 yield break;
             }

--- a/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/InitializerMutator.cs
@@ -11,7 +11,7 @@ namespace Stryker.Core.Mutators
 
         public override IEnumerable<Mutation> ApplyMutations(InitializerExpressionSyntax node)
         {
-            if (node.Parent is ArrayCreationExpressionSyntax || node.Parent is ImplicitArrayCreationExpressionSyntax || node.Parent is StackAllocArrayCreationExpressionSyntax || node.Expressions.Count == 0)
+            if (node.Parent is ArrayCreationExpressionSyntax || node.Parent is ImplicitArrayCreationExpressionSyntax || node.Parent is StackAllocArrayCreationExpressionSyntax || !node.Expressions.Any())
             {
                 yield break;
             }


### PR DESCRIPTION
Based on [this](https://github.com/stryker-mutator/stryker-net/pull/2259#discussion_r1009704958) comment.