### PR TITLE
feat(nugetrestore): use MsBuild option during nuget restore

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Fsharp/FsharpFileDetectionTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Fsharp/FsharpFileDetectionTests.cs
@@ -1,14 +1,13 @@
-using Xunit;
-using Moq;
-using Stryker.Core.Initialisation;
 using System.Collections.Generic;
-using System.Linq;
-using Shouldly;
-using Stryker.Core.Options;
-using System.IO.Abstractions.TestingHelpers;
 using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Moq;
+using Shouldly;
+using Stryker.Core.Initialisation;
+using Stryker.Core.Options;
 
 namespace Stryker.Core.UnitTest.Fsharp
 {
@@ -60,13 +59,13 @@ namespace Stryker.Core.UnitTest.Fsharp
                     { Path.Combine(_filesystemRoot, "ExampleProject", "node_modules", "Some package"), new MockFileData("bla") }, // node_modules should be excluded
                 });
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(_testProjectPath, null, "fsharp", null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(_testProjectPath, null, "fsharp", null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>() { _projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: _testProjectPath,
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(_projectUnderTestPath, null, "fsharp", null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(_projectUnderTestPath, null, "fsharp", null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>() { _projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -1,9 +1,9 @@
+using System;
+using System.Collections.Generic;
 using Moq;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Testing;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.Initialisation
@@ -56,7 +56,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         }
 
         [Fact]
-        public void InitialBuildProcess_ShoulduseCustomMsbuildIfNotNull()
+        public void InitialBuildProcess_ShouldUseCustomMsbuildIfNotNull()
         {
             var processMock = new Mock<IProcessExecutor>(MockBehavior.Strict);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -124,13 +124,13 @@ namespace Stryker.Core.UnitTest.Initialisation
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
                 projectFilePath: testProjectPath,
                 references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -161,13 +161,13 @@ namespace Stryker.Core.UnitTest.Initialisation
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
                 projectFilePath: testProjectPath,
                 references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
@@ -201,13 +201,13 @@ namespace Stryker.Core.UnitTest.Initialisation
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
                 projectFilePath: testProjectPath,
                 references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -256,13 +256,13 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
                 projectFilePath: testProjectPath,
                 references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -300,13 +300,13 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                 projectReferences: new List<string> { projectUnderTestPath },
                 targetFramework: "netcoreapp2.1",
                 projectFilePath: testProjectPath,
                 references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -361,14 +361,14 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -413,14 +413,14 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -490,14 +490,14 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -544,14 +544,14 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -601,14 +601,14 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -663,12 +663,12 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, null, null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -697,7 +697,7 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
@@ -721,7 +721,7 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>() { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
@@ -743,7 +743,7 @@ using System.Reflection;
                 });
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
@@ -868,13 +868,13 @@ Please specify a test project name filter that results in one project.
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
 
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>() { { "Language", "C#" } },
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     projectFilePath: projectUnderTestPath,
@@ -902,7 +902,7 @@ Please specify a test project name filter that results in one project.
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
 
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
@@ -935,14 +935,14 @@ Please specify a test project name filter that results in one project.
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
 
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(testProjectPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: testProjectPath,
                     properties: new Dictionary<string, string>(),
                     references: new string[] { "" }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>(),
                     targetFramework: "netcoreapp2.1",
@@ -970,13 +970,13 @@ Please specify a test project name filter that results in one project.
 
             var projectFileReaderMock = new Mock<IProjectFileReader>(MockBehavior.Strict);
 
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(It.IsAny<string>(), null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string> { projectUnderTestPath },
                     targetFramework: "netcoreapp2.1",
                     projectFilePath: Path.Combine(_filesystemRoot, "TestProject1", "ExampleProject.csproj"),
                     properties: new Dictionary<string, string>() { { "Language", "C#" } }).Object);
-            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>()))
+            projectFileReaderMock.Setup(x => x.AnalyzeProject(projectUnderTestPath, null, null, It.IsAny<IEnumerable<IAnalyzerResult>>(), null))
                 .Returns(TestHelper.SetupProjectAnalyzerResult(
                     projectReferences: new List<string>() { "" },
                     targetFramework: "netcoreapp2.1",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/NugetRestoreProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/NugetRestoreProcessTests.cs
@@ -1,10 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using Moq;
 using Shouldly;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Testing;
-using System;
-using System.IO;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.Initialisation
@@ -63,6 +64,69 @@ namespace Stryker.Core.UnitTest.Initialisation
             var target = new NugetRestoreProcess(processExecutorMock.Object);
 
             target.RestorePackages(solutionPath);
+        }
+
+        [Fact]
+        public void NugetIsUsingSuppliedMsBuild()
+        {
+            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "DotnetFramework does not run on Unix");
+
+            string nugetPath = @"C:\choco\bin\NuGet.exe";
+            string msBuildVersion = "16.0.0";
+            string msbuildPath = @$"{CProgramFilesX86MicrosoftVisualStudio}\2019\MSBuild\16.0\Bin\MSBuild.exe";
+
+            string capturedMsBuildPath = "";
+
+            var processExecutorMock = new Mock<IProcessExecutor>(MockBehavior.Strict);
+            processExecutorMock.Setup(x => x.Start(solutionDir, It.Is<string>((p) => p.EndsWith("where.exe")), "nuget.exe", null, It.IsAny<int>()))
+                .Returns(new ProcessResult()
+                {
+                    ExitCode = 0,
+                    Output = nugetPath
+                });
+
+            processExecutorMock.Setup(x => x.Start(CProgramFilesX86MicrosoftVisualStudio, It.Is<string>((p) => p.EndsWith("where.exe")),
+                    "-latest -requires Microsoft.Component.MSBuild -products * -find MSBuild\\**\\Bin\\MSBuild.exe", null, It.IsAny<int>()))
+                .Returns(new ProcessResult()
+                {
+                    ExitCode = 0,
+                    Output = CProgramFilesX86MicrosoftVisualStudio
+                });
+            processExecutorMock.Setup(x => x.Start(solutionDir, It.IsAny<string>(), "-version /nologo", null, It.IsAny<int>()))
+                .Callback<string, string, string, IEnumerable<KeyValuePair<string, string>>, int>((
+                    path, application, arguments, environmentVariables, timeoutMs) =>
+                {
+                    capturedMsBuildPath = application;
+                })
+                .Returns(new ProcessResult()
+                {
+                    ExitCode = 0,
+                    Output = msBuildVersion
+                });
+
+            processExecutorMock.Setup(x => x.Start(solutionDir, nugetPath, string.Format("restore \"{0}\" -MsBuildVersion \"{1}\"", Path.GetFullPath(solutionPath), msBuildVersion), null, It.IsAny<int>()))
+                .Returns(new ProcessResult()
+                {
+                    ExitCode = 0,
+                    Output = "Packages restored"
+                });
+
+            processExecutorMock.Setup(x => x.Start(It.Is<string>(s => s.Contains("Microsoft Visual Studio")), It.Is<string>(s => s.Contains("vswhere.exe")), @"-latest -requires Microsoft.Component.MSBuild -products * -find MSBuild\**\Bin\MSBuild.exe", null, It.IsAny<int>()))
+                .Returns(new ProcessResult()
+                {
+                    ExitCode = 0,
+                    Output = "Msbuild executable path found at "
+                });
+
+            var target = new NugetRestoreProcess(processExecutorMock.Object);
+
+            target.RestorePackages(solutionPath, msbuildPath);
+            processExecutorMock.Verify(x => x.Start(CProgramFilesX86MicrosoftVisualStudio, It.Is<string>((p) => p.EndsWith("where.exe")),
+                "-latest -requires Microsoft.Component.MSBuild -products * -find MSBuild\\**\\Bin\\MSBuild.exe", null, It.IsAny<int>()), Times.Never);
+            processExecutorMock.Verify(x => x.Start(solutionDir, It.IsAny<string>(), "-version /nologo", null, It.IsAny<int>()), Times.Once);
+            processExecutorMock.Verify(x => x.Start(solutionDir, nugetPath, string.Format("restore \"{0}\" -MsBuildVersion \"{1}\"", Path.GetFullPath(solutionPath), msBuildVersion), null, It.IsAny<int>()), Times.Once);
+            processExecutorMock.Verify(x => x.Start(It.Is<string>(s => s.Contains("Microsoft Visual Studio")), It.Is<string>(s => s.Contains("vswhere.exe")), @"-latest -requires Microsoft.Component.MSBuild -products * -find MSBuild\**\Bin\MSBuild.exe", null, It.IsAny<int>()), Times.Never);
+            Assert.Equal(msbuildPath, capturedMsBuildPath);
         }
 
         [SkippableFact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/NugetRestoreProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/NugetRestoreProcessTests.cs
@@ -66,7 +66,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             target.RestorePackages(solutionPath);
         }
 
-        [Fact]
+        [SkippableFact]
         public void NugetIsUsingSuppliedMsBuild()
         {
             Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "DotnetFramework does not run on Unix");

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -60,7 +60,7 @@ namespace Stryker.Core.Initialisation
             foreach (var testProjectFile in testProjectFiles)
             {
                 // Analyze the test project
-                testProjectAnalyzerResults.Add(_projectFileReader.AnalyzeProject(testProjectFile, options.SolutionPath, options.TargetFramework, solutionProjects));
+                testProjectAnalyzerResults.Add(_projectFileReader.AnalyzeProject(testProjectFile, options.SolutionPath, options.TargetFramework, solutionProjects, options.MsBuildPath));
             }
             projectInfo.TestProjectAnalyzerResults = testProjectAnalyzerResults;
 
@@ -70,7 +70,7 @@ namespace Stryker.Core.Initialisation
             _logger.LogInformation("The project {0} will be mutated.", projectUnderTest);
 
             // Analyze project under test
-            projectInfo.ProjectUnderTestAnalyzerResult = _projectFileReader.AnalyzeProject(projectUnderTest, options.SolutionPath, options.TargetFramework, solutionProjects);
+            projectInfo.ProjectUnderTestAnalyzerResult = _projectFileReader.AnalyzeProject(projectUnderTest, options.SolutionPath, options.TargetFramework, solutionProjects, options.MsBuildPath);
 
             var language = projectInfo.ProjectUnderTestAnalyzerResult.GetLanguage();
             if (language == Language.Fsharp)

--- a/src/Stryker.Core/Stryker.Core/Initialisation/NugetRestoreProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/NugetRestoreProcess.cs
@@ -1,17 +1,17 @@
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Logging;
 using Stryker.Core.Testing;
 using Stryker.Core.ToolHelpers;
-using System;
-using System.IO;
-using System.Linq;
 
 namespace Stryker.Core.Initialisation
 {
     public interface INugetRestoreProcess
     {
-        void RestorePackages(string solutionPath);
+        void RestorePackages(string solutionPath, string msbuildPath = null);
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ namespace Stryker.Core.Initialisation
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<NugetRestoreProcess>();
         }
 
-        public void RestorePackages(string solutionPath)
+        public void RestorePackages(string solutionPath, string msbuildPath = null)
         {
             _logger.LogInformation("Restoring nuget packages using {0}", "nuget.exe");
             if (string.IsNullOrWhiteSpace(solutionPath))
@@ -48,7 +48,7 @@ namespace Stryker.Core.Initialisation
             var nugetPath = nugetWhereExeResult.Output.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault().Trim();
 
             // Locate MSBuild.exe
-            var msbuildPath = new MsBuildHelper().GetMsBuildPath(_processExecutor);
+            msbuildPath ??= new MsBuildHelper().GetMsBuildPath(_processExecutor);
             var msBuildVersionOutput = _processExecutor.Start(solutionDir, msbuildPath, "-version /nologo");
             if (msBuildVersionOutput.ExitCode != ExitCodes.Success)
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -16,7 +16,8 @@ namespace Stryker.Core.Initialisation
             string projectFilePath,
             string solutionFilePath,
             string targetFramework,
-            IEnumerable<IAnalyzerResult> solutionProjects);
+            IEnumerable<IAnalyzerResult> solutionProjects,
+            string msBuildPath = null);
     }
 
     /// <summary>
@@ -42,7 +43,8 @@ namespace Stryker.Core.Initialisation
             string projectFilePath,
             string solutionFilePath,
             string targetFramework,
-            IEnumerable<IAnalyzerResult> solutionProjects)
+            IEnumerable<IAnalyzerResult> solutionProjects,
+            string msBuildPath = null)
         {
 
             _logger.LogDebug("Analyzing project file {0}", projectFilePath);
@@ -55,7 +57,7 @@ namespace Stryker.Core.Initialisation
                 {
                     // buildalyzer failed to find restored packages, retry after nuget restore
                     _logger.LogDebug("Project analyzer result not successful, restoring packages");
-                    _nugetRestoreProcess.RestorePackages(solutionFilePath);
+                    _nugetRestoreProcess.RestorePackages(solutionFilePath, msBuildPath);
                     analyzerResult = GetProjectInfo(projectFilePath, targetFramework, solutionProjects);
                 }
                 else

--- a/src/Stryker.Core/Stryker.Core/ToolHelpers/MsBuildHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/ToolHelpers/MsBuildHelper.cs
@@ -1,9 +1,9 @@
-using Microsoft.Extensions.Logging;
-using Stryker.Core.Logging;
-using Stryker.Core.Testing;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+using Stryker.Core.Logging;
+using Stryker.Core.Testing;
 
 namespace Stryker.Core.ToolHelpers
 {
@@ -30,10 +30,6 @@ namespace Stryker.Core.ToolHelpers
 
         public string GetMsBuildPath(IProcessExecutor _processExecutor)
         {
-            if (File.Exists(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"))
-            {
-                return @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe";
-            }
             // See if any MSBuild.exe can be found in visual studio installation folder
             foreach (string drive in Directory.GetLogicalDrives())
             {
@@ -58,7 +54,10 @@ namespace Stryker.Core.ToolHelpers
                     }
                 }
             }
-
+            if (File.Exists(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"))
+            {
+                return @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe";
+            }
             // Else, find in default locations
             _logger.LogDebug("Unable to find msbuild using vswhere, using fallback locations");
 

--- a/src/Stryker.Core/Stryker.Core/ToolHelpers/MsBuildHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/ToolHelpers/MsBuildHelper.cs
@@ -19,6 +19,7 @@ namespace Stryker.Core.ToolHelpers
             _logger = logger ?? ApplicationLogging.LoggerFactory.CreateLogger<MsBuildHelper>();
             fallbackLocations = new List<string>
             {
+                @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe",
                 @"C:\Windows\Microsoft.Net\Framework64\v4.0.30319\MSBuild.exe",
                 @"C:\Windows\Microsoft.Net\Framework64\v3.5\MSBuild.exe",
                 @"C:\Windows\Microsoft.Net\Framework64\v2.0.50727\MSBuild.exe",
@@ -53,10 +54,6 @@ namespace Stryker.Core.ToolHelpers
                         }
                     }
                 }
-            }
-            if (File.Exists(@"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"))
-            {
-                return @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe";
             }
             // Else, find in default locations
             _logger.LogDebug("Unable to find msbuild using vswhere, using fallback locations");


### PR DESCRIPTION
Code to implement feature request https://github.com/stryker-mutator/stryker-net/issues/2356 (When setting the --msbuildPath option, the nuget restore should also use this msbuild to restore all the nuget packages)

Added 2 commits, 
one to implement the use of the msbuildPath cli option for the nuget restore 
the other one to change the default return of the MsBuildHelper to first look for the highest version of Visual Studio, only then trying to give Visual Studio 2017 Enterprise MsBuild path .