### PR TITLE
fix(NullCoalescingExpressionMutator): Don't generate certain mutants when right hand side is ThrowExpression (#2387)

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/NullCoalescingExpressionMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/NullCoalescingExpressionMutatorTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Shouldly;
@@ -36,6 +35,22 @@ namespace Stryker.Core.UnitTest.Mutators
             {
                 expectedExpressionStrings.ShouldContain(mutant.ReplacementNode.ToString());
             }
+        }
+
+        [Fact]
+        public void ShouldMutateThrowExpression()
+        {
+            // Arrange
+            var target = new NullCoalescingExpressionMutator();
+            var originalExpressionString = "a ?? throw new ArgumentException(nameof(a))";
+            var originalExpression = SyntaxFactory.ParseExpression(originalExpressionString);
+
+            // Act
+            var result = target.ApplyMutations(originalExpression as BinaryExpressionSyntax);
+
+            // Assert
+            var mutant = result.ShouldHaveSingleItem();
+            mutant.ReplacementNode.ToString().ShouldBe("a");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/NullCoalescingExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/NullCoalescingExpressionMutator.cs
@@ -19,8 +19,8 @@ namespace Stryker.Core.Mutators
 
                 // Do not create "left to right", or "remove right" mutants when the right
                 // hand side is a throw expression, as they result in invalid code.
-                // I.E. myVar = throw new ArgumentNullExpression ?? a;
-                // and  myVar = throw new ArgumentNullExpression;
+                // I.E. myVar = throw new ArgumentNullException() ?? a;
+                // and  myVar = throw new ArgumentNullException();
                 if (!node.Right.IsKind(SyntaxKind.ThrowExpression))
                 {
                     yield return new Mutation


### PR DESCRIPTION
As discussed in the linked issue, certain mutations from `NullCoalescingExpressionMutator` will generate invalid code if the right hand side of the expression is a `throw`.

These are simple to filter out by checking if `node.Right` is of type `SyntaxKind.ThrowExpression`.

Fixed #2387