### PR TITLE
Adding break-on-initial-test-failure option to the config file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -640,6 +640,6 @@ By default stryker tries to autodiscover msbuild on your system. If stryker fail
 
 Default: `false`  
 Command line: `--break-on-initial-test-failure`  
-Config file: `N/A`
+Config file: `break-on-initial-test-failure`
 
 Instruct Stryker to break execution when at least one test failed on initial test run.

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/FileConfigReaderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/FileConfigReaderTests.cs
@@ -84,6 +84,7 @@ namespace Stryker.CLI.UnitTest
             actualInputs.IgnoredMethodsInput.SuppliedInput.ShouldContain("Log*");
             actualInputs.TestCaseFilterInput.SuppliedInput.ShouldBe("(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1");
             actualInputs.DashboardUrlInput.SuppliedInput.ShouldBe("https://alternative-stryker-dashboard.io");
+            actualInputs.BreakOnInitialTestFailureInput.SuppliedInput.ShouldNotBeNull().ShouldBeFalse();
         }
 
         [Fact]
@@ -130,6 +131,7 @@ namespace Stryker.CLI.UnitTest
             actualInputs.IgnoredMethodsInput.SuppliedInput.ShouldContain("Log*");
             actualInputs.TestCaseFilterInput.SuppliedInput.ShouldBe("(FullyQualifiedName~UnitTest1&TestCategory=CategoryA)|Priority=1");
             actualInputs.DashboardUrlInput.SuppliedInput.ShouldBe("https://alternative-stryker-dashboard.io");
+            actualInputs.BreakOnInitialTestFailureInput.SuppliedInput.ShouldNotBeNull().ShouldBeTrue();
         }
     }
 }

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.json
@@ -16,6 +16,7 @@
     "concurrency": 1,
     "solution": "",
     "mutation-level": "",
+    "break-on-initial-test-failure": false,
     "since": {
       "enabled": false,
       "target": "main",

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.yaml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/filled-stryker-config.yaml
@@ -14,6 +14,7 @@ stryker-config:
   concurrency: 1
   solution: ''
   mutation-level: ''
+  break-on-initial-test-failure: true
   since:
     enabled: false
     target: main

--- a/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
@@ -88,6 +88,9 @@ namespace Stryker.CLI
         [JsonPropertyName("report-file-name")]
         public string ReportFileName { get; init; }
 
+        [JsonPropertyName("break-on-initial-test-failure")]
+        public bool? BreakOnInitialTestFailure { get; init; }
+
         [JsonExtensionData]
         public Dictionary<string, JsonElement> ExtraData { get; init; }
     }

--- a/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
@@ -61,6 +61,7 @@ namespace Stryker.CLI
             inputs.IgnoredMethodsInput.SuppliedInput = config.IgnoreMethods;
 
             inputs.ReportFileNameInput.SuppliedInput = config.ReportFileName;
+            inputs.BreakOnInitialTestFailureInput.SuppliedInput = config.BreakOnInitialTestFailure;
         }
 
         private static FileBasedInput LoadConfig(string configFilePath)


### PR DESCRIPTION
As per discussion here: https://github.com/stryker-mutator/stryker-net/pull/2151#issuecomment-1406919865
This PR basically borrows from the initial commits in the PR above. I also tested this manually.