### PR TITLE
fix(dashboard reporter): fix dashboard publishing when the project name is computed

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerOptionsTests.cs
@@ -51,6 +51,27 @@ namespace Stryker.Core.UnitTest.Options
             result.AdditionalTimeout.ShouldBe(1);
             result.ProjectPath.ShouldBe("C://Dev//Test");
             result.WorkingDirectory.ShouldBe("C://Dev");
+            result.ProjectName.ShouldBe("name");
+            result.ProjectVersion.ShouldBe("version");
+        }
+
+        [Fact]
+        public void ShouldFlowProjectNameAndProjectVersionToParentOptions()
+        {
+            var target = new StrykerOptions
+            {
+                ProjectName = "",
+                ProjectVersion = "",
+            };
+
+            var copy = target.Copy("C://Dev//Test", "C://Dev", "test", new[] { "project1" });
+            copy.ProjectName = "project-name";
+            copy.ProjectVersion = "project-version";
+
+            // We need this because Stryker.Core.Initialisation.InitialisationProcess.InitializeDashboardProjectInformation operates
+            // on a copy of the StrykerOptions that were passed to the Stryker.Core.Clients.DashboardClient constructor.
+            target.ProjectName.ShouldBe("project-name");
+            target.ProjectVersion.ShouldBe("project-version");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -52,7 +52,7 @@ namespace Stryker.Core.Clients
             }
             catch(Exception exception)
             {
-                _logger.LogError(exception, "Failed to upload report to the dashboard");
+                _logger.LogError(exception, "Failed to upload report to the dashboard at {DashboardUrl}", url);
                 return null;
             }
         }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -191,7 +191,7 @@ namespace Stryker.Core.Options
         public IEnumerable<LinqExpression> ExcludedLinqExpressions { get; init; } = Enumerable.Empty<LinqExpression>();
 
         /// <summary>
-        /// The optimization mode for coverage analysis for the current run. 
+        /// The optimization mode for coverage analysis for the current run.
         /// </summary>
         public OptimizationModes OptimizationMode { get; init; }
 
@@ -199,21 +199,50 @@ namespace Stryker.Core.Options
         /// This name is used in the dashboard report
         /// Is settable because this version can be detected by using DotNet.ReproducibleBuilds and thus can be overridden by stryker internally
         /// </summary>
-        public string ProjectName { get; set; }
+        public string ProjectName
+        {
+            get => _projectName;
+            set
+            {
+                _projectName = value;
+                if (_parentOptions is not null)
+                {
+                    _parentOptions.ProjectName = value;
+                }
+            }
+        }
 
         /// <summary>
         /// This projectversion is used in the dashboard report
         /// Is settable because this version can be detected by using DotNet.ReproducibleBuilds and thus can be overridden by stryker internally
         /// </summary>
-        public string ProjectVersion { get; set; }
+        public string ProjectVersion
+        {
+            get => _projectVersion;
+            set
+            {
+                _projectVersion = value;
+                if (_parentOptions is not null)
+                {
+                    _parentOptions.ProjectVersion = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Instruct Stryker to break execution when at least one test failed on initial run.
         /// </summary>
         public bool BreakOnInitialTestFailure { get; set; }
 
+        // Keep a reference on the parent instance in order to flow get/set properties (ProjectName and ProjectVersion) up to the parent
+        // This is required for the dashboard reporter to work properly
+        private StrykerOptions _parentOptions;
+        private string _projectName;
+        private string _projectVersion;
+
         public StrykerOptions Copy(string projectPath, string workingDirectory, string projectUnderTest, IEnumerable<string> testProjects) => new()
         {
+            _parentOptions = this,
             AdditionalTimeout = AdditionalTimeout,
             AzureFileStorageSas = AzureFileStorageSas,
             AzureFileStorageUrl = AzureFileStorageUrl,


### PR DESCRIPTION
Pull request #2055 (fix(Reporting): Fix issue with relative paths that miss the root folder) broke pull request #1710 (fix: Dashboard baseline project name and version are not set).

I have added a new test to ensure that this does not regress in the future.

Before this commit, an HTTP 404 error would occur because the dashboard URL was not correct:

```
[12:46:37 ERR] Failed to upload report to the dashboard
System.Net.Http.HttpRequestException: Response status code does not indicate success: 404 (Not Found).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at Stryker.Core.Clients.DashboardClient.PublishReport(JsonReport report, String version)
[12:46:37 ERR] Uploading to stryker dashboard failed...
```