### PR TITLE
fix(dashboard reporter): Actually print the hint in cyan

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
@@ -43,23 +43,16 @@ namespace Stryker.Core.Reporters
                 }
                 else
                 {
-                    _console.Write("[Cyan]Hint: by passing \"--open-report:dashboard or -o:dashboard\" the report will open automatically once Stryker is done.[/]");
+                    var aqua = new Style(Color.Aqua);
+                    _console.WriteLine("Hint: by passing \"--open-report:dashboard or -o:dashboard\" the report will open automatically once Stryker is done.", aqua);
                 }
 
+                var green = new Style(Color.Green);
                 _console.WriteLine();
-                _console.MarkupLine("[Green]Your report has been uploaded at:[/]");
-
-                if (_console.Profile.Capabilities.Links)
-                {
-                    // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
-                    _console.MarkupLine($"[Green][link={reportUri}]{reportUri}[/][/]");
-                }
-                else
-                {
-                    _console.MarkupLine($"[Green]{reportUri}[/]");
-                }
-
-                _console.MarkupLine("[Green]You can open it in your browser of choice.[/]");
+                _console.WriteLine("Your report has been uploaded at:", green);
+                // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
+                _console.WriteLine(reportUri, _console.Profile.Capabilities.Links ? green.Combine(new Style(link: reportUri)) : green);
+                _console.WriteLine("You can open it in your browser of choice.", green);
             }
             else
             {

--- a/src/Stryker.Core/Stryker.Core/Reporters/HtmlReporter/HtmlReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/HtmlReporter/HtmlReporter.cs
@@ -43,25 +43,27 @@ namespace Stryker.Core.Reporters.Html.reporter
             }
             else
             {
-                _console.MarkupLine("[Cyan]Hint: by passing \"--open-report or -o\" the report will open automatically once Stryker is done.[/]");
+                var aqua = new Style(Color.Aqua);
+                _console.WriteLine("Hint: by passing \"--open-report or -o\" the report will open automatically once Stryker is done.", aqua);
             }
 
             var reportUri = "file://" + reportPath.Replace("\\", "/").Replace(" ", "%20");
-            
+
+            var green = new Style(Color.Green);
             _console.WriteLine();
-            _console.MarkupLine("[Green]Your html report has been generated at:[/]");
+            _console.WriteLine("Your html report has been generated at:", green);
 
             if (_console.Profile.Capabilities.Links)
             {
                 // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
-                _console.MarkupLineInterpolated($"[Green][link={reportUri}]{reportPath}[/][/]");
+                _console.WriteLine(reportPath, green.Combine(new Style(link: reportUri)));
             }
             else
             {
-                _console.MarkupLineInterpolated($"[Green]{reportUri}[/]");
+                _console.WriteLine(reportUri, green);
             }
 
-            _console.MarkupLine("[Green]You can open it in your browser of choice.[/]");
+            _console.WriteLine("You can open it in your browser of choice.", green);
         }
 
         private void WriteHtmlReport(string filePath, string mutationReport)

--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReporter.cs
@@ -30,17 +30,18 @@ namespace Stryker.Core.Reporters.Json
 
             WriteReportToJsonFile(reportPath, mutationReport);
 
+            var green = new Style(Color.Green);
             _console.WriteLine();
-            _console.MarkupLine("[Green]Your json report has been generated at:[/]");
+            _console.WriteLine("Your json report has been generated at:", green);
 
             if (_console.Profile.Capabilities.Links)
             {
                 // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
-                _console.MarkupLineInterpolated($"[Green][link={reportUri}]{reportPath}[/][/]");
+                _console.WriteLine(reportPath, green.Combine(new Style(link: reportUri)));
             }
             else
             {
-                _console.MarkupLineInterpolated($"[Green]{reportUri}[/]");
+                _console.WriteLine(reportUri, green);
             }
         }
 


### PR DESCRIPTION
Also simplify writing text with Spectre.Console by using the WriteLine method directly with a style. This avoids unnecessary markup parsing.