### PR TITLE
Adding TFM command line option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,7 @@ Valid language versions:
 ### `target-framework` <`string`>
 
 Default: randomly selected
-Command line: `N/A`  
+Command line: `target-framework`  
 Config file: `"target-framework": "netcoreapp3.1"`
 
 If the project targets multiple frameworks, this way you can specify the particular framework to build against. If you specify a non-existent target, Stryker will build the project against a random one (or the only one if so).

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -453,5 +453,16 @@ Options:";
             _inputs.BreakOnInitialTestFailureInput.SuppliedInput.HasValue.ShouldBeTrue();
             _inputs.BreakOnInitialTestFailureInput.SuppliedInput.Value.ShouldBeTrue();
         }
+
+        [Theory]
+        [InlineData("--target-framework", "net7.0")]
+        public void ShouldSupplyTargetFrameworkWhenPassed(params string[] argName)
+        {
+            _target.Run(argName);
+
+            _strykerRunnerMock.VerifyAll();
+
+            _inputs.TargetFrameworkInput.SuppliedInput.ShouldBe("net7.0");
+        }
     }
 }

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigReader.cs
@@ -123,7 +123,7 @@ namespace Stryker.CLI
             AddCliInput(inputs.ProjectUnderTestNameInput, "project", "p", argumentHint: "project-name.csproj", category: InputCategory.Build);
             AddCliInput(inputs.TestProjectsInput, "test-project", "tp", CommandOptionType.MultipleValue, InputCategory.Build);
             AddCliInput(inputs.MsBuildPathInput, "msbuild-path", null, category: InputCategory.Build);
-
+            AddCliInput(inputs.TargetFrameworkInput, "target-framework", null, optionType: CommandOptionType.SingleValue, category: InputCategory.Build);
 
             AddCliInput(inputs.MutateInput, "mutate", "m", optionType: CommandOptionType.MultipleValue, argumentHint: "glob-pattern", category: InputCategory.Mutation);
             AddCliInput(inputs.MutationLevelInput, "mutation-level", "l", category: InputCategory.Mutation);


### PR DESCRIPTION
So this adds an option to specify TFM in the command line in addition to the config file.

Some context: in our repo, we are now changing the way we execute mutation testing. Instead of having one TFM value in the config and hoping that random selection works wherever this TFM is not available, we are going to have the information about the desired TFM elsewhere and use it when running Stryker for every particular project. 

This will save some time and make mutation testing results more deterministic.

I checked this manually for a little repro also :)