### PR TITLE
fix(initial-build): add quotes around buildCommand when necessary

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -20,6 +20,21 @@ namespace Stryker.Core.UnitTest.Initialisation
             var target = new InitialBuildProcess(processMock.Object);
 
             var exception = Assert.Throws<InputException>(() => target.InitialBuild(false, "/", "/"));
+            Assert.Equal("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"dotnet build \"\"\"", exception.Details);
+        }
+
+        [Fact]
+        public void InitialBuildProcess_WithPathAsBuildCommand_ShouldThrowStrykerInputExceptionOnFailWithQuotes()
+        {
+            var processMock = new Mock<IProcessExecutor>(MockBehavior.Strict);
+
+            processMock.SetupProcessMockToReturn("", 1);
+
+            var target = new InitialBuildProcess(processMock.Object);
+
+            var exception = Assert.Throws<InputException>(() => target.InitialBuild(true, "/", "/", @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"));
+            Assert.Equal("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
+                         @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" \"C:\\\"\"", exception.Details);
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
@@ -60,9 +60,20 @@ namespace Stryker.Core.Initialisation
             if (result.ExitCode != ExitCodes.Success)
             {
                 // Initial build failed
-                throw new InputException(result.Output, $"Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"{buildCommand} {buildPath}\"");
+                throw new InputException(result.Output, FormatBuildResultErrorString(buildCommand, buildPath));
             }
             _logger.LogDebug("Initial build successful");
+        }
+
+        private static string FormatBuildResultErrorString(string buildCommand, string buildPath)
+        {
+            if (Path.IsPathRooted(buildCommand))
+            {
+                buildCommand = $"\"{buildCommand}\"";
+            }
+
+            return "Initial build of targeted project failed. Please make sure the targeted project is buildable." +
+                   $" You can reproduce this error yourself using: \"{buildCommand} {buildPath}\"";
         }
     }
 }


### PR DESCRIPTION
When building with MSBuild, extra quotes are necessary for the command to work when copying and pasting it in the CLI.

Note: this only adds these extra quotes when the buildcommand is a path.

fixes #2443