### PR TITLE
fix(baseline): json reports with testfiles are now correctly deserialized

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
@@ -10,15 +10,13 @@ namespace Stryker.Core.Reporters.Json
 {
     public class JsonReport
     {
-        public string SchemaVersion { get; init; } = "1";
+        public string SchemaVersion { get; init; } = "2";
         public IDictionary<string, int> Thresholds { get; init; } = new Dictionary<string, int>();
         public string ProjectRoot { get; init; }
         public IDictionary<string, SourceFile> Files { get; init; } = new Dictionary<string, SourceFile>();
         public IDictionary<string, JsonTestFile> TestFiles { get; set; } = null;
 
-        public JsonReport()
-        {
-        }
+        public JsonReport() { }
 
         private JsonReport(StrykerOptions options, IReadOnlyProjectComponent mutationReport, TestProjectsInfo testProjectsInfo)
         {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/SourceFiles/SourceFile.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/SourceFiles/SourceFile.cs
@@ -1,7 +1,7 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.Logging;
 using Stryker.Core.ProjectComponents;
-using System.Collections.Generic;
 
 namespace Stryker.Core.Reporters.Json.SourceFiles
 {
@@ -11,9 +11,7 @@ namespace Stryker.Core.Reporters.Json.SourceFiles
         public string Source { get; init; }
         public ISet<JsonMutant> Mutants { get; init; }
 
-        public SourceFile()
-        {
-        }
+        public SourceFile() { }
 
         public SourceFile(IReadOnlyFileLeaf file, ILogger logger = null)
         {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/TestFiles/JsonTestFile.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/TestFiles/JsonTestFile.cs
@@ -10,6 +10,8 @@ namespace Stryker.Core.Reporters.Json.TestFiles
         public string Source { get; init; }
         public ISet<Test> Tests { get; set; }
 
+        public JsonTestFile() { }
+
         public JsonTestFile(TestFile testFile)
         {
             Source = testFile?.Source;


### PR DESCRIPTION
fix #2497 