### PR TITLE
fix(tests report): Correctly parse test files with preprocessor symbols

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -7,6 +7,7 @@
     <Compile Remove="TestResources\ExampleSourceFile.cs" />
     <Compile Remove="TestResources\ExampleTestFileA.cs" />
     <Compile Remove="TestResources\ExampleTestFileB.cs" />
+    <Compile Remove="TestResources\ExampleTestFilePreprocessorSymbols.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="TestResources\StrongNameKeyFile.snk" />
@@ -15,6 +16,9 @@
     <None Remove="TestResources\FsharpExampleSourceFile.fs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="TestResources\ExampleTestFilePreprocessorSymbols.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestResources\ExampleTestFileB.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
@@ -12,7 +12,9 @@ namespace Stryker.Core.UnitTest
             IEnumerable<string> projectReferences = null,
             string targetFramework = null,
             IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> packageReferences = null,
-            string[] references = null)
+            string[] references = null,
+            string[] preprocessorSymbols = null
+            )
         {
             var analyzerResultMock = new Mock<IAnalyzerResult>();
 
@@ -43,6 +45,10 @@ namespace Stryker.Core.UnitTest
             if (references != null)
             {
                 analyzerResultMock.Setup(x => x.References).Returns(references);
+            }
+            if (preprocessorSymbols is not null)
+            {
+                analyzerResultMock.Setup(x => x.PreprocessorSymbols).Returns(preprocessorSymbols);
             }
 
             return analyzerResultMock;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestResources/ExampleTestFilePreprocessorSymbols.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestResources/ExampleTestFilePreprocessorSymbols.cs
@@ -1,0 +1,45 @@
+namespace ExampleProject
+{
+    public class TestClass
+    {
+
+#if NET6_0_OR_GREATER
+            
+        [Fact]
+        public int Fibinacci(int len)
+        {
+            return Fibonacci(0, 1, 1, len);
+        }
+
+        [Fact]
+        public int Fibonacci(int a, int b, int counter, int len)
+        {
+            if (counter <= len)
+            {
+                Console.Write("{0}", a);
+                return Fibonacci(b, a + b, counter + 1, len);
+            }
+            return 0;
+        }
+
+        [Fact]
+        public string LoremIpsum()
+        {
+            return @"Lorem Ipsum
+                    Dolor Sit Amet
+                    Lorem Dolor Sit";
+        }
+
+        [Fact]
+        public void StringSplit()
+        {
+            var testString = "";
+
+            testString.Split("\n");
+
+
+        }
+        
+#endif
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
@@ -60,8 +60,8 @@ namespace Stryker.Core.Initialisation
                 if (testFile is not null)
                 {
                     var lineSpan = testFile.SyntaxTree.GetText().Lines[unitTest.LineNumber - 1].Span;
-                    var node = testFile.SyntaxTree.GetRoot().DescendantNodes(lineSpan)
-                        .First(n => n is MethodDeclarationSyntax);
+                    var nodesInSpan = testFile.SyntaxTree.GetRoot().DescendantNodes(lineSpan);
+                    var node = nodesInSpan.First(n => n is MethodDeclarationSyntax);
                     testFile.AddTest(unitTest.Id, unitTest.FullyQualifiedName, node);
                 }
                 else

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -32,7 +32,7 @@ namespace Stryker.Core.ProjectComponents.TestProjects
                 var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode,
                     path: file,
                     encoding: Encoding.UTF32,
-                    options: new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.None));
+                    options: new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.None, preprocessorSymbols: testProjectAnalyzerResult.PreprocessorSymbols));
 
                 if (!syntaxTree.IsGenerated())
                 {


### PR DESCRIPTION
fix #2501 