### PR TITLE
chore: Rename IProjectAndTest + other minor code clean ups

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
@@ -42,9 +42,9 @@ namespace Stryker.Core.UnitTest.Initialisation
             }
             var ranTests = new TestGuidsList(testList);
             var failedTests = new TestGuidsList(test1);
-            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTest>())).Returns(new TestRunResult(Enumerable.Empty<VsTestDescription>(), ranTests, failedTests, TestGuidsList.NoTest(), string.Empty, Enumerable.Empty<string>(), TimeSpan.Zero) );
+            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTests>())).Returns(new TestRunResult(Enumerable.Empty<VsTestDescription>(), ranTests, failedTests, TestGuidsList.NoTest(), string.Empty, Enumerable.Empty<string>(), TimeSpan.Zero) );
             testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
-            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTest>())).Returns(new TestSet());
+            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
 
             _target.InitialTest(_options, null, testRunnerMock.Object);
         }
@@ -53,9 +53,9 @@ namespace Stryker.Core.UnitTest.Initialisation
         public void InitialTestProcess_ShouldCalculateTestTimeout()
         {
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
-            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTest>())).Callback(() => Thread.Sleep(2)).Returns(new TestRunResult(true));
+            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTests>())).Callback(() => Thread.Sleep(2)).Returns(new TestRunResult(true));
             testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
-            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTest>())).Returns(new TestSet());
+            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
             var result = _target.InitialTest( _options, null, testRunnerMock.Object);
 
             result.TimeoutValueCalculator.DefaultTimeout.ShouldBeInRange(1, 200, "This test contains a Thread.Sleep to simulate time passing as this test is testing that a stopwatch is used correctly to measure time.\n If this test is failing for unclear reasons, perhaps the computer running the test is too slow causing the time estimation to be off");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -75,9 +75,9 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             inputFileResolverMock.SetupGet( x => x.FileSystem).Returns(new FileSystem());
             initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), null));
-            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTest>())).Returns(new TestSet());
+            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTests>())).Returns(new TestSet());
             testRunnerMock.Setup(x => x.DiscoverTests( It.IsAny<string>())).Returns(true);
-            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(),It.IsAny<ITestRunner>())).Throws(new InputException("")); // failing test
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(),It.IsAny<ITestRunner>())).Throws(new InputException("")); // failing test
 
             var target = new InitialisationProcess(inputFileResolverMock.Object,
                 initialBuildProcessMock.Object,
@@ -91,7 +91,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var projects = target.GetMutableProjectsInfo(options);
             target.BuildProjects(options, projects);
             Assert.Throws<InputException>(() => target.GetMutationTestInputs(options, projects, testRunnerMock.Object));
-            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(), testRunnerMock.Object), Times.Once);
+            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), testRunnerMock.Object), Times.Once);
         }
 
         [Fact]
@@ -120,9 +120,9 @@ namespace Stryker.Core.UnitTest.Initialisation
                 testSet.RegisterTest(new TestDescription(ranTest, "test", "test.cpp"));
             }
             testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
-            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTest>())).Returns(testSet);
+            testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(testSet);
             var failedTests = new TestGuidsList(failedTest);
-            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(),It.IsAny<ITestRunner>())).Returns(
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(),It.IsAny<ITestRunner>())).Returns(
                 new InitialTestRun(
                 new TestRunResult(Array.Empty<VsTestDescription>() ,ranTests, failedTests, TestGuidsList.NoTest(), string.Empty, Enumerable.Empty<string>(),TimeSpan.Zero), new TimeoutValueCalculator(0) )); // failing test
 
@@ -138,7 +138,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             target.BuildProjects(options, projects);
             Assert.Throws<InputException>(() => target.GetMutationTestInputs(options, projects, testRunnerMock.Object));
             inputFileResolverMock.Verify(x => x.ResolveSourceProjectInfos(It.IsAny<StrykerOptions>()), Times.Once);
-            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(), testRunnerMock.Object), Times.Once);
+            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), testRunnerMock.Object), Times.Once);
         }
 
         [Theory]
@@ -172,9 +172,9 @@ namespace Stryker.Core.UnitTest.Initialisation
                 testSet.RegisterTest(new TestDescription(ranTest, "test", "test.cpp"));
             }
             testRunnerMock.Setup(x => x.DiscoverTests( It.IsAny<string>())).Returns(true);
-            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTest>())).Returns(testSet);
+            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTests>())).Returns(testSet);
             var failedTests = new TestGuidsList(failedTest);
-            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(),It.IsAny<ITestRunner>())).Returns( new InitialTestRun(
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(),It.IsAny<ITestRunner>())).Returns( new InitialTestRun(
                 new TestRunResult(Array.Empty<VsTestDescription>() ,ranTests, failedTests, TestGuidsList.NoTest(), string.Empty, Enumerable.Empty<string>(), TimeSpan.Zero), new TimeoutValueCalculator(0) )); // failing test
 
             var target = new InitialisationProcess(inputFileResolverMock.Object,
@@ -221,8 +221,8 @@ namespace Stryker.Core.UnitTest.Initialisation
             var testSet = new TestSet();
             testSet.RegisterTest(new TestDescription(Guid.Empty, "test", "test.cs"));
             testRunnerMock.Setup(x => x.DiscoverTests( It.IsAny<string>())).Returns(true);
-            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTest>())).Returns(testSet);
-            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(),It.IsAny<ITestRunner>()))
+            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTests>())).Returns(testSet);
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(),It.IsAny<ITestRunner>()))
                 .Returns(new InitialTestRun(new TestRunResult(true), null)); // failing test
 
             var target = new InitialisationProcess(inputFileResolverMock.Object,
@@ -239,7 +239,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var input = target.GetMutationTestInputs(options, projects, testRunnerMock.Object).First();
  
             inputFileResolverMock.Verify(x => x.ResolveSourceProjectInfos(It.IsAny<StrykerOptions>()), Times.Once);
-            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTest>(), testRunnerMock.Object), Times.Once);
+            initialTestProcessMock.Verify(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), testRunnerMock.Object), Times.Once);
         }
 
 
@@ -276,8 +276,8 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), null));
             testRunnerMock.Setup(x => x.DiscoverTests( It.IsAny<string>())).Returns(false);
-            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTest>())).Returns(new TestSet());
-            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(),  It.IsAny<IProjectAndTest>(),It.IsAny<ITestRunner>()))
+            testRunnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTests>())).Returns(new TestSet());
+            initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(),  It.IsAny<IProjectAndTests>(),It.IsAny<ITestRunner>()))
                 .Returns(new InitialTestRun(new TestRunResult(Array.Empty<VsTestDescription>(),  TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), string.Empty, Enumerable.Empty<string>(), TimeSpan.Zero), null)); // failing test
 
             var target = new InitialisationProcess(inputFileResolverMock.Object,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
@@ -148,8 +148,8 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var mockRunner = new Mock<ITestRunner>();
             mockRunner.Setup(r => r.DiscoverTests(It.IsAny<string>())).Returns(true);
-            mockRunner.Setup(r => r.GetTests(It.IsAny<IProjectAndTest>())).Returns(new TestSet());
-            mockRunner.Setup(r => r.InitialTest(It.IsAny<IProjectAndTest>())).Returns(new TestRunResult(true));
+            mockRunner.Setup(r => r.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
+            mockRunner.Setup(r => r.InitialTest(It.IsAny<IProjectAndTests>())).Returns(new TestRunResult(true));
 
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/FullRunScenario.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/FullRunScenario.cs
@@ -168,9 +168,9 @@ namespace Stryker.Core.UnitTest.MutationTest
                 Enumerable.Empty<string>(),
                 TimeSpan.Zero);
             runnerMock.Setup(x => x.DiscoverTests( It.IsAny<string>())).Returns(true);
-            runnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTest>())).Returns(TestSet);
-            runnerMock.Setup(x => x.InitialTest( It.IsAny<IProjectAndTest>())).Returns(GetRunResult(InitialRunId));
-            runnerMock.Setup(x => x.CaptureCoverage( It.IsAny<IProjectAndTest>()))
+            runnerMock.Setup(x => x.GetTests( It.IsAny<IProjectAndTests>())).Returns(TestSet);
+            runnerMock.Setup(x => x.InitialTest( It.IsAny<IProjectAndTests>())).Returns(GetRunResult(InitialRunId));
+            runnerMock.Setup(x => x.CaptureCoverage( It.IsAny<IProjectAndTests>()))
                 .Returns(() =>
                 {
                     var result = new List<CoverageRunResult>(_tests.Count);
@@ -183,9 +183,9 @@ namespace Stryker.Core.UnitTest.MutationTest
                     }
                     return result;
                 });
-            runnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(), It.IsAny<ITimeoutValueCalculator>(),
+            runnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(), It.IsAny<ITimeoutValueCalculator>(),
                     It.IsAny<IReadOnlyList<Mutant>>(), It.IsAny<TestUpdateHandler>())).
-                Callback((Action<IProjectAndTest, ITimeoutValueCalculator, IReadOnlyList<Mutant>, TestUpdateHandler>)((_, test1, list,
+                Callback((Action<IProjectAndTests, ITimeoutValueCalculator, IReadOnlyList<Mutant>, TestUpdateHandler>)((_, test1, list,
                     update) =>
                 {
                     foreach (var m in list)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
@@ -19,14 +19,14 @@ namespace Stryker.Core.UnitTest.MutationTest
         {
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
             var mutant = new Mutant { Id = 1 };
-            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).Returns(new TestRunResult(true));
+            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).Returns(new TestRunResult(true));
 
             var target = new MutationTestExecutor(testRunnerMock.Object);
 
             target.Test(null, new List<Mutant> { mutant }, null, null);
 
             mutant.ResultStatus.ShouldBe(MutantStatus.Survived);
-            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
+            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
         }
 
         [Fact]
@@ -34,14 +34,14 @@ namespace Stryker.Core.UnitTest.MutationTest
         {
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
             var mutant = new Mutant { Id = 1, CoveringTests = TestGuidsList.EveryTest() };
-            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),null, It.IsAny<IReadOnlyList<Mutant>>(), null)).Returns(new TestRunResult(false));
+            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),null, It.IsAny<IReadOnlyList<Mutant>>(), null)).Returns(new TestRunResult(false));
 
             var target = new MutationTestExecutor(testRunnerMock.Object);
 
             target.Test(null,new List<Mutant> { mutant }, null, null);
 
             mutant.ResultStatus.ShouldBe(MutantStatus.Killed);
-            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),null, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
+            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),null, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Stryker.Core.UnitTest.MutationTest
         {
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
             var mutant = new Mutant { Id = 1, CoveringTests = TestGuidsList.EveryTest() };
-            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).
+            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).
                 Returns(TestRunResult.TimedOut(new List<VsTestDescription>(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.EveryTest(), "", Enumerable.Empty<string>(), TimeSpan.Zero));
 
             var target = new MutationTestExecutor(testRunnerMock.Object);
@@ -58,7 +58,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             target.Test(null, new List<Mutant> { mutant }, timeoutValueCalculator, null);
 
             mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
-            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(), timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
+            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(), timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Once);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Stryker.Core.UnitTest.MutationTest
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
             var mutant1 = new Mutant { Id = 1, CoveringTests = TestGuidsList.EveryTest() };
             var mutant2 = new Mutant { Id = 2, CoveringTests = TestGuidsList.EveryTest() };
-            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).
+            testRunnerMock.Setup(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<Mutant>>(), null)).
                 Returns(TestRunResult.TimedOut(new List<VsTestDescription>(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), "", Enumerable.Empty<string>(), TimeSpan.Zero));
 
             var target = new MutationTestExecutor(testRunnerMock.Object);
@@ -77,7 +77,7 @@ namespace Stryker.Core.UnitTest.MutationTest
 
             mutant1.ResultStatus.ShouldBe(MutantStatus.Timeout);
             mutant2.ResultStatus.ShouldBe(MutantStatus.Timeout);
-            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTest>(),timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Exactly(3));
+            testRunnerMock.Verify(x => x.TestMultipleMutants( It.IsAny<IProjectAndTests>(),timeoutValueCalculator, It.IsAny<IReadOnlyList<Mutant>>(), null), Times.Exactly(3));
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
+++ b/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
@@ -21,7 +21,7 @@ namespace Stryker.Core.CoverageAnalysis
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<CoverageAnalyser>();
         }
 
-        public void DetermineTestCoverage(IProjectAndTest project, ITestRunner runner, IEnumerable<Mutant> mutants, ITestGuids resultFailingTests)
+        public void DetermineTestCoverage(IProjectAndTests project, ITestRunner runner, IEnumerable<Mutant> mutants, ITestGuids resultFailingTests)
         {
             if (!_options.OptimizationMode.HasFlag(OptimizationModes.SkipUncoveredMutants) &&
                 !_options.OptimizationMode.HasFlag(OptimizationModes.CoverageBasedTest))

--- a/src/Stryker.Core/Stryker.Core/CoverageAnalysis/ICoverageAnalyser.cs
+++ b/src/Stryker.Core/Stryker.Core/CoverageAnalysis/ICoverageAnalyser.cs
@@ -7,6 +7,6 @@ namespace Stryker.Core.CoverageAnalysis
 {
     public interface ICoverageAnalyser
     {
-        void DetermineTestCoverage(IProjectAndTest project, ITestRunner runner, IEnumerable<Mutant> mutants, ITestGuids resultFailingTests);
+        void DetermineTestCoverage(IProjectAndTests project, ITestRunner runner, IEnumerable<Mutant> mutants, ITestGuids resultFailingTests);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/IProjectAndTests.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/IProjectAndTests.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Stryker.Core.Initialisation;
 
-public interface IProjectAndTest
+public interface IProjectAndTests
 {
     bool IsFullFramework { get; }
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
@@ -8,7 +8,7 @@ namespace Stryker.Core.Initialisation
 {
     public interface IInitialTestProcess
     {
-        InitialTestRun InitialTest(StrykerOptions options, IProjectAndTest project, ITestRunner testRunner);
+        InitialTestRun InitialTest(StrykerOptions options, IProjectAndTests project, ITestRunner testRunner);
     }
 
     public class InitialTestProcess : IInitialTestProcess
@@ -26,7 +26,7 @@ namespace Stryker.Core.Initialisation
         /// <param name="testRunner"></param>
         /// <param name="options">Stryker options</param>
         /// <returns>The duration of the initial test run</returns>
-        public InitialTestRun InitialTest(StrykerOptions options, IProjectAndTest project, ITestRunner testRunner)
+        public InitialTestRun InitialTest(StrykerOptions options, IProjectAndTests project, ITestRunner testRunner)
         {
             // Setup a stopwatch to record the initial test duration
             var stopwatch = new Stopwatch();

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.Compiling;
-using Stryker.Core.Initialisation;
 using Stryker.Core.Initialisation.Buildalyzer;
 using Stryker.Core.Logging;
 using Stryker.Core.MutantFilters;
@@ -13,7 +12,6 @@ using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.TestProjects;
-using static Microsoft.FSharp.Core.ByRefKinds;
 
 namespace Stryker.Core.MutationTest
 {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
@@ -15,7 +15,7 @@ namespace Stryker.Core.MutationTest
     public interface IMutationTestExecutor
     {
         ITestRunner TestRunner { get; }
-        void Test(IProjectAndTest project, IList<Mutant> mutantsToTest, ITimeoutValueCalculator timeoutMs, TestUpdateHandler updateHandler);
+        void Test(IProjectAndTests project, IList<Mutant> mutantsToTest, ITimeoutValueCalculator timeoutMs, TestUpdateHandler updateHandler);
     }
 
     public class MutationTestExecutor : IMutationTestExecutor
@@ -29,7 +29,7 @@ namespace Stryker.Core.MutationTest
             Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationTestProcess>();
         }
 
-        public void Test(IProjectAndTest project, IList<Mutant> mutantsToTest, ITimeoutValueCalculator timeoutMs, TestUpdateHandler updateHandler)
+        public void Test(IProjectAndTests project, IList<Mutant> mutantsToTest, ITimeoutValueCalculator timeoutMs, TestUpdateHandler updateHandler)
         {
             var forceSingle = false;
             while (mutantsToTest.Any())
@@ -76,7 +76,7 @@ namespace Stryker.Core.MutationTest
             }
         }
 
-        private TestRunResult RunTestSession(IProjectAndTest projectAndTest, ICollection<Mutant> mutantsToTest,
+        private TestRunResult RunTestSession(IProjectAndTests projectAndTests, ICollection<Mutant> mutantsToTest,
             ITimeoutValueCalculator timeoutMs,
             TestUpdateHandler updateHandler, bool forceSingle)
         {
@@ -85,7 +85,7 @@ namespace Stryker.Core.MutationTest
             {
                 foreach (var mutant in mutantsToTest)
                 {
-                    var localResult = TestRunner.TestMultipleMutants(projectAndTest, timeoutMs, new[] { mutant }, updateHandler);
+                    var localResult = TestRunner.TestMultipleMutants(projectAndTests, timeoutMs, new[] { mutant }, updateHandler);
                     if (updateHandler == null || localResult.SessionTimedOut)
                     {
                         mutant.AnalyzeTestRun(localResult.FailingTests, localResult.ExecutedTests, localResult.TimedOutTests, localResult.SessionTimedOut);
@@ -95,7 +95,7 @@ namespace Stryker.Core.MutationTest
                 return new TestRunResult(true);
             }
 
-            var result = TestRunner.TestMultipleMutants(projectAndTest, timeoutMs, mutantsToTest.ToList(), updateHandler);
+            var result = TestRunner.TestMultipleMutants(projectAndTests, timeoutMs, mutantsToTest.ToList(), updateHandler);
             if (updateHandler != null && !result.SessionTimedOut)
             {
                 return result;

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
@@ -8,7 +8,7 @@ using Stryker.Core.ProjectComponents.TestProjects;
 
 namespace Stryker.Core.ProjectComponents.SourceProjects
 {
-    public class SourceProjectInfo : IProjectAndTest
+    public class SourceProjectInfo : IProjectAndTests
     {
         private readonly List<string> _warnings = new();
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/ITestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/ITestRunner.cs
@@ -14,12 +14,12 @@ namespace Stryker.Core.TestRunners
     {
         bool DiscoverTests(string assembly);
 
-        TestSet GetTests(IProjectAndTest project);
+        TestSet GetTests(IProjectAndTests project);
 
-        TestRunResult InitialTest(IProjectAndTest project);
+        TestRunResult InitialTest(IProjectAndTests project);
 
-        IEnumerable<CoverageRunResult> CaptureCoverage(IProjectAndTest project);
+        IEnumerable<CoverageRunResult> CaptureCoverage(IProjectAndTests project);
 
-        TestRunResult TestMultipleMutants(IProjectAndTest project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update);
+        TestRunResult TestMultipleMutants(IProjectAndTests project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -38,7 +38,7 @@ namespace Stryker.Core.TestRunners.VsTest
             _vsTestConsole = _context.BuildVsTestWrapper(RunnerId);
         }
 
-        public TestRunResult InitialTest(IProjectAndTest project)
+        public TestRunResult InitialTest(IProjectAndTests project)
         {
             var testResults = RunTestSession(TestGuidsList.EveryTest(), project);
             foreach (var test in _context.VsTests.Keys)
@@ -65,7 +65,7 @@ namespace Stryker.Core.TestRunners.VsTest
             return BuildTestRunResult(testResults, totalCountOfTests, totalCountOfTests,false);
         }
 
-        public TestRunResult TestMultipleMutants(IProjectAndTest project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update)
+        public TestRunResult TestMultipleMutants(IProjectAndTests project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update)
         {
             var mutantTestsMap = new Dictionary<int, ITestGuids>();
             var timeOutMs = timeoutCalc?.DefaultTimeout;
@@ -181,7 +181,7 @@ namespace Stryker.Core.TestRunners.VsTest
                 : new TestRunResult(_context.VsTests.Values, ranTests, failedTestsDescription, timedOutTests, message, messages, duration);
         }
 
-        public IRunResults RunTestSession(ITestGuids testsToRun, IProjectAndTest project, int? timeout = null, Dictionary<int, ITestGuids> mutantTestsMap= null, Action<IRunResults> updateHandler = null) =>
+        public IRunResults RunTestSession(ITestGuids testsToRun, IProjectAndTests project, int? timeout = null, Dictionary<int, ITestGuids> mutantTestsMap= null, Action<IRunResults> updateHandler = null) =>
             RunTestSession(testsToRun, project.GetTestAssemblies(),
                 _context.GenerateRunSettings(timeout, false, mutantTestsMap, project.HelperNamespace, project.IsFullFramework), timeout, updateHandler).GetResults();
 
@@ -216,7 +216,7 @@ namespace Stryker.Core.TestRunners.VsTest
 
             _aborted = false;
             var options = new TestPlatformOptions { TestCaseFilter = string.IsNullOrWhiteSpace(_context.Options.TestCaseFilter) ? null : _context.Options.TestCaseFilter };
-            Task session = null;
+            Task session;
             if (tests.IsEveryTest)
             {
                 session = _vsTestConsole.RunTestsWithCustomTestHostAsync(sources, runSettings, options, eventHandler, strykerVsTestHostLauncher);

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunnerPool.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunnerPool.cs
@@ -53,15 +53,15 @@ namespace Stryker.Core.TestRunners.VsTest
 
         public bool DiscoverTests(string assembly) => Context.AddTestSource(assembly);
 
-        public TestSet GetTests(IProjectAndTest project) => Context.GetTestsForSources(project.GetTestAssemblies());
+        public TestSet GetTests(IProjectAndTests project) => Context.GetTestsForSources(project.GetTestAssemblies());
 
-        public TestRunResult TestMultipleMutants(IProjectAndTest project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update)
+        public TestRunResult TestMultipleMutants(IProjectAndTests project, ITimeoutValueCalculator timeoutCalc, IReadOnlyList<Mutant> mutants, TestUpdateHandler update)
             => RunThis(runner => runner.TestMultipleMutants(project, timeoutCalc, mutants, update));
 
-        public TestRunResult InitialTest(IProjectAndTest project)
+        public TestRunResult InitialTest(IProjectAndTests project)
             => RunThis(runner => runner.InitialTest(project));
 
-        public IEnumerable<CoverageRunResult> CaptureCoverage(IProjectAndTest project) => Context.Options.OptimizationMode.HasFlag(OptimizationModes.CaptureCoveragePerTest) ? CaptureCoverageTestByTest(project) : CaptureCoverageInOneGo(project);
+        public IEnumerable<CoverageRunResult> CaptureCoverage(IProjectAndTests project) => Context.Options.OptimizationMode.HasFlag(OptimizationModes.CaptureCoveragePerTest) ? CaptureCoverageTestByTest(project) : CaptureCoverageInOneGo(project);
 
         private void Initialize(Func<VsTestContextInformation, int, VsTestRunner> runnerBuilder = null)
         {
@@ -74,11 +74,11 @@ namespace Stryker.Core.TestRunners.VsTest
                 }));
         }
 
-        private IEnumerable<CoverageRunResult> CaptureCoverageInOneGo(IProjectAndTest project) => ConvertCoverageResult(RunThis(runner => runner.RunCoverageSession(TestGuidsList.EveryTest(), project.GetTestAssemblies(), project.HelperNamespace, project.IsFullFramework).TestResults), false);
+        private IEnumerable<CoverageRunResult> CaptureCoverageInOneGo(IProjectAndTests project) => ConvertCoverageResult(RunThis(runner => runner.RunCoverageSession(TestGuidsList.EveryTest(), project.GetTestAssemblies(), project.HelperNamespace, project.IsFullFramework).TestResults), false);
 
-        private IEnumerable<CoverageRunResult> CaptureCoverageTestByTest(IProjectAndTest project) => ConvertCoverageResult(CaptureCoveragePerIsolatedTests(project, Context.VsTests.Keys).TestResults, true);
+        private IEnumerable<CoverageRunResult> CaptureCoverageTestByTest(IProjectAndTests project) => ConvertCoverageResult(CaptureCoveragePerIsolatedTests(project, Context.VsTests.Keys).TestResults, true);
 
-        private IRunResults CaptureCoveragePerIsolatedTests(IProjectAndTest project, IEnumerable<Guid> tests)
+        private IRunResults CaptureCoveragePerIsolatedTests(IProjectAndTests project, IEnumerable<Guid> tests)
         {
             var options = new ParallelOptions { MaxDegreeOfParallelism = _countOfRunners };
             var result = new SimpleRunResults();


### PR DESCRIPTION
Address remarks from #2400 review. Mainly the renaming of IProjectAndTest to IProjectAndTests