### PR TITLE
fix(testrunner): fix scenario where vstest would hang if no tests were detected

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,7 +205,7 @@ stages:
       parameters:
         testName: 'windows-netcore'
         workingDirectory: 'integrationtest/TargetProjects'
-        strykerCommands: --solution '$(Agent.BuildDirectory)\s\integrationtest\TargetProjects\IntegrationTestApp.sln'
+        strykerCommands: --solution 'IntegrationTestApp.sln'
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,6 +197,10 @@ stages:
       parameters:
         testName: 'windows-netframework'
         workingDirectory: 'integrationtest/TargetProjects/NetFramework/FullFrameworkApp.Test'
+    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker
+      workingDirectory: 'integrationtest/TargetProjects/EmptyTestProject'
+      failOnStderr: false
+      continueOnError: true
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,9 +203,9 @@ stages:
       continueOnError: true
     - template: pipeline-templates/run-integration-test-steps.yml
       parameters:
-        testName: 'windows-solution'
+        testName: 'windows-netcore'
         workingDirectory: 'integrationtest/TargetProjects'
-        strykerCommands: --solution 'integrationtest/TargetProjects/IntegrationTestApp.sln'
+        strykerCommands: --solution '$(Agent.BuildDirectory)\s\integrationtest\TargetProjects\IntegrationTestApp.sln'
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,9 +203,9 @@ stages:
       continueOnError: true
     - template: pipeline-templates/run-integration-test-steps.yml
       parameters:
-        testName: 'linux-netcore'
+        testName: 'windows-solution'
         workingDirectory: 'integrationtest/TargetProjects'
-        strykerCommands: --solution '$(Agent.BuildDirectory)/s/integrationtest/TargetProjects/IntegrationTestApp.sln'
+        strykerCommands: --solution 'integrationtest/TargetProjects/IntegrationTestApp.sln'
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,10 +197,7 @@ stages:
       parameters:
         testName: 'windows-netframework'
         workingDirectory: 'integrationtest/TargetProjects/NetFramework/FullFrameworkApp.Test'
-    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker
-      workingDirectory: 'integrationtest/TargetProjects/EmptyTestProject'
-      failOnStderr: false
-      continueOnError: true
+
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:
@@ -225,6 +222,10 @@ stages:
         command: test
         projects: '**/Validation.csproj'
         arguments: --filter Category=Solution
+    - script: $(Agent.BuildDirectory)/tools/dotnet-stryker
+      workingDirectory: 'integrationtest/TargetProjects/EmptyTestProject'
+      failOnStderr: false
+      continueOnError: true
 
   - job: MacOsTests
     displayName: Run tests on Mac OS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,11 +201,6 @@ stages:
       workingDirectory: 'integrationtest/TargetProjects/EmptyTestProject'
       failOnStderr: false
       continueOnError: true
-    - template: pipeline-templates/run-integration-test-steps.yml
-      parameters:
-        testName: 'windows-netcore'
-        workingDirectory: 'integrationtest/TargetProjects'
-        strykerCommands: --solution 'IntegrationTestApp.sln'
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,6 +201,11 @@ stages:
       workingDirectory: 'integrationtest/TargetProjects/EmptyTestProject'
       failOnStderr: false
       continueOnError: true
+    - template: pipeline-templates/run-integration-test-steps.yml
+      parameters:
+        testName: 'linux-netcore'
+        workingDirectory: 'integrationtest/TargetProjects'
+        strykerCommands: --solution '$(Agent.BuildDirectory)/s/integrationtest/TargetProjects/IntegrationTestApp.sln'
     - task: DotNetCoreCLI@2
       displayName: 'Assert integration test results'
       inputs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Nuget is required for dotnet framework. Follow the instructions at [Install nuge
 
 Make sure NuGet targets and build tasks are installed. You can install them with visual studio by going to Tools > Get Tools and Features > Individual components > Code tools
 
-[NuGet targets and build tasks feature](./images/install-nuget-targets.png)
+![NuGet targets and build tasks feature](./images/install-nuget-targets.png)
 
 ## Migrating
 

--- a/integrationtest/IntegrationTest.sln
+++ b/integrationtest/IntegrationTest.sln
@@ -22,9 +22,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtraProject.XUnit", "TargetProjects\ExtraProject.XUnit\ExtraProject.XUnit.csproj", "{7322B3DF-7CD6-469D-A098-5A8A628C164D}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		TargetProjects\SharedProject\SharedProject.projitems*{ae33ceea-7eb1-438d-abd4-3208d032c5d3}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -68,5 +65,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2FEB055D-3A9A-4089-821D-F945309FCF74}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		TargetProjects\SharedProject\SharedProject.projitems*{ae33ceea-7eb1-438d-abd4-3208d032c5d3}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/integrationtest/TargetProjects/EmptyTestProject/EmptyTestProject.csproj
+++ b/integrationtest/TargetProjects/EmptyTestProject/EmptyTestProject.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TargetProject\TargetProject.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/integrationtest/TargetProjects/EmptyTestProject/UnitTest.cs
+++ b/integrationtest/TargetProjects/EmptyTestProject/UnitTest.cs
@@ -1,0 +1,7 @@
+namespace EmptyTestProject
+{
+    public class UnitTest
+    {
+
+    }
+}

--- a/integrationtest/TargetProjects/EmptyTestProject/Usings.cs
+++ b/integrationtest/TargetProjects/EmptyTestProject/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/integrationtest/TargetProjects/EmptyTestProject/packages.lock.json
+++ b/integrationtest/TargetProjects/EmptyTestProject/packages.lock.json
@@ -1,0 +1,1030 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.2.0, )",
+        "resolved": "3.2.0",
+        "contentHash": "xjY8xBigSeWIYs4I7DgUHqSNoGqnHi7Fv7/7RZD02rvZyG3hlsjnQKiVKVWKgr9kRKgmV+dEfu8KScvysiC0Wg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.5.0, )",
+        "resolved": "17.5.0",
+        "contentHash": "IJ4eSPcsRbwbAZehh1M9KgejSy0u3d0wAdkJytfCh67zOaCl5U3ltruUEe15MqirdRqGmm/ngbjeaVeGapSZxg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.5.0",
+          "Microsoft.TestPlatform.TestHost": "17.5.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, )",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, )",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.5.0",
+        "contentHash": "6FQo0O6LKDqbCiIgVQhJAf810HSjFlOj7FunWaeOGDKxy8DAbpHzPk4SfBTXz9ytaaceuIIeR6hZgplt09m+ig=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.5.0",
+        "contentHash": "QwiBJcC/oEA1kojOaB0uPWOIo4i6BYuTBBYJVhUvmXkyYqZ2Ut/VZfgi+enf8LF8J4sjO98oRRFt39MiRorcIw==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.5.0",
+        "contentHash": "X86aikwp9d4SDcBChwzQYZihTPGEtMdDk+9t64emAl7N0Tq+OmlLAoW+Rs+2FB2k6QdUicSlT4QLO2xABRokaw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.5.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.Win32.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "9ZQKCWxH7Ijp9BfahvL2Zyf1cJIk8XYLF6Yjzr2yi0b2cOut/HQ31qf1ThHAgCc3WiZMdnWcfJCgN82/0UunxA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "1.6.1",
+        "contentHash": "WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "HdSSp5MnJSsg08KMfZThpuLPJpPwE5hBXvHwoKWosyHHfe8Mh5WKT0ylEOf6yNzX6Ngjxe4Whkafh5q7Ymac4Q=="
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+yH1a49wJMy8Zt4yx5RhJrxO/DBDByAiCzNwiETI+1S4mPdCu0OY4djdciC7Vssk0l22wQaDLrXxXkp+3+7bVA=="
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "c3YNH1GQJbfIPJeCnr4avseugSqPrxwIqzthYyZDN6EuOyNOzq+y2KSUfRcXauya1sF4foESTgwM5e1A8arAKw=="
+      },
+      "runtime.native.System": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "c/qWt2LieNZIj1jGnVNsE2Kl23Ya2aSTBuXMD6V7k9KWr6l16Tqdwq+hJScEpWER9753NWC8h96PaVNY5Ld7Jw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZVuZJqnnegJhd2k/PtAbbIcZ3aZeITq3sj06oKfMBSfphW3HDmk/t4ObvbOk/JA/swGR0LNqMksAh/f7gpTROg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "NS1U+700m4KFRHR5o4vo9DSlTmlCKu/u7dtE5sUHVIPB+xpXxYQvgBgA6wEIeCz6Yfn0Z52/72WYsToCEPJnrw==",
+        "dependencies": {
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "b3pthNgxxFcD+Pc0WSEoC0+md3MyhRS6aCEeenvNE3Fdw1HyJ18ZhRFVJJzIeR/O/jpxPboB805Ho0T3Ul7w8A=="
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KeLz4HClKf+nFS7p/6Fi/CqyLXh81FpiGzcmuS8DGi9lUqSnZ6Es23/gv2O+1XVGfrbNmviF7CckBpavkBoIFQ=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ=="
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "X7IdhILzr4ROXd8mI1BUCQMSHSQwelUlBjF1JyTKCjXaOGn2fB4EKBxQbCK2VjO3WaWIdlXZL3W6TiIVnrhX4g=="
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "nyFNiCk/r+VOiIqreLix8yN+q3Wga9+SE8BCgkf+2BwEKiNx6DyvFjCgkfV743/grxv8jHJ8gUK4XEQw7yzRYg=="
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ytoewC6wGorL7KoCAvRfsgoJPJbNq+64k2SqW6JcOAebWsFUvCCYgfzQMrnpvPiEl4OrblUlhF2ji+Q1+SVLrQ=="
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "I8bKw2I8k58Wx7fMKQJn2R8lamboCAiHfHeV/pS65ScKWMMI0+wJkLYlEKvgW1D/XvSl/221clBoR2q9QNNM7A=="
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
+      },
+      "System.AppContext": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ratu44uTIHgeBeI0dE8DWvmXVBSo4u7ozRZZHOMmK/JPpYyo0dAfgSiHlpiObMQ5lEtEyIXA40sKRYg5J6A8uQ==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ztl69Xp0Y/UXCL+3v3tEU+lIy+bvjKNUmopn1wep/a291pVPK7dxBd6T7WnlQqRog+d1a/hSsgRsmFnIBKTPLQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Console": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tracing": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GUlBtdOWT4LTV3I+9/PJW+56AnnChTaOqqTLFtdmype/L500M2LIyXgmtd9X2P2VOkmJd5c67H5SaC2QcL1bFA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "FhKmdR6MPG+pxow6wGtNAWdZh7noIOpdD5TwQ3CprzgIE1bBBoim0vbR1+AWsWjQmU7zXHgQo4TWSP6lCeiWcQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "System.IO": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.Compression": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Buffers": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+        "dependencies": {
+          "System.Buffers": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Linq": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Net.Http": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Net.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "qOu+hDwFwoZPbzPvwut2qATe3ygjeQBDQj91xlsaqGFQUI5i4ZnZb8yyQuLGpDGivEPIt8EJkd1BVzVoP31FXA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Net.Sockets": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Reflection": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Reflection.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7u6ulLcZbyxB5Gq0nMkQttcdBTx57ibzw+4IOXEfR+sXYQoHvjW5LTLyNr8O22UIMrqYbchJQJnos4eooYzYJA==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0"
+        }
+      },
+      "System.Runtime.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "OKiSUN7DmTWeYb3l51A7EYaeNMnvxwE249YtZz7yooT4gOZhmTjIn48KgSsw2k2lYdLgTKNJw/ZIfSElwDRVgg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "uv1ynXqiMK8mp1GM3jDqPCFN66eJ5w5XNomaK2XD+TuCroNTLFGeZ+WCmBMcBDyTFKou3P6cR6J/QsaqDp7fGQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "System.Runtime.Numerics": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Cng": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "03idZOqFlsKRL4W+LuCpJ6dBYDUWReug6lZjBa3uJWnk5sPCUXckocevTaUA8iT/MFSrY/2HXkOt753xQ/cf8g==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Csp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "X4s/FCkEUnRGnwR3aSfVIkldBmtURMhmexALNTwpjklzxWU7yjMk7GHLKOZTNkgnWnE0q7+BCf9N2LVRWxewaA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.OpenSsl": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.3.0",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Text.Encoding": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "YVMK0Bt/A43RmwizJoZ22ei2nmrhobgeiYwFzC4YAN+nue8RF6djXDMog0UCn+brerQoYVyaS+ghy9P/MUVcmw==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.RegularExpressions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "npvJkVKl5rKXrtl1Kkm6OhOUaYGEiF9wFbppFRWSMoApKzt2PiPHT2Bb8a5sAWxprvdOAtvaARS9QYMznEUtug==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Timer": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0",
+          "Microsoft.NETCore.Targets": "1.1.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Xml.ReaderWriter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.3.0"
+        }
+      },
+      "System.Xml.XDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "library": {
+        "type": "Project"
+      },
+      "targetproject": {
+        "type": "Project",
+        "dependencies": {
+          "Library": "[1.0.0, )"
+        }
+      }
+    }
+  }
+}

--- a/integrationtest/TargetProjects/IntegrationTestApp.sln
+++ b/integrationtest/TargetProjects/IntegrationTestApp.sln
@@ -13,14 +13,13 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SharedProject", "SharedProj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TargetProject", "TargetProject\TargetProject.csproj", "{FD5B399F-F31D-4E95-824D-EF3FDC2F610C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraProject", "ExtraProject\ExtraProject.csproj", "{70462F5F-6EC9-43F9-B360-3F61C9636804}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtraProject", "ExtraProject\ExtraProject.csproj", "{70462F5F-6EC9-43F9-B360-3F61C9636804}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraProject.XUnit", "ExtraProject.XUnit\ExtraProject.XUnit.csproj", "{A862920A-7A81-4317-984E-2302A47B1792}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtraProject.XUnit", "ExtraProject.XUnit\ExtraProject.XUnit.csproj", "{A862920A-7A81-4317-984E-2302A47B1792}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmptyTestProject", "EmptyTestProject\EmptyTestProject.csproj", "{4EF7D9F7-8BEC-48B7-A336-0CD89EEBF627}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		SharedProject\SharedProject.projitems*{ae33ceea-7eb1-438d-abd4-3208d032c5d3}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -38,10 +37,6 @@ Global
 		{D2502C99-4676-4F4F-88F2-4F0384BF76EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2502C99-4676-4F4F-88F2-4F0384BF76EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2502C99-4676-4F4F-88F2-4F0384BF76EA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4F06AFF4-5AD9-41E4-9255-68E1B5A468AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4F06AFF4-5AD9-41E4-9255-68E1B5A468AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F06AFF4-5AD9-41E4-9255-68E1B5A468AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4F06AFF4-5AD9-41E4-9255-68E1B5A468AE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD5B399F-F31D-4E95-824D-EF3FDC2F610C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD5B399F-F31D-4E95-824D-EF3FDC2F610C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD5B399F-F31D-4E95-824D-EF3FDC2F610C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,11 +49,18 @@ Global
 		{A862920A-7A81-4317-984E-2302A47B1792}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A862920A-7A81-4317-984E-2302A47B1792}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A862920A-7A81-4317-984E-2302A47B1792}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EF7D9F7-8BEC-48B7-A336-0CD89EEBF627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF7D9F7-8BEC-48B7-A336-0CD89EEBF627}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF7D9F7-8BEC-48B7-A336-0CD89EEBF627}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF7D9F7-8BEC-48B7-A336-0CD89EEBF627}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0C29E1AA-5805-4524-8160-B0C28E4050D8}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		SharedProject\SharedProject.projitems*{ae33ceea-7eb1-438d-abd4-3208d032c5d3}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialTestProcessTests.cs
@@ -55,7 +55,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         public void InitialTestProcess_ShouldCalculateTestTimeout()
         {
             var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
-            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTests>())).Callback(() => Thread.Sleep(2)).Returns(new TestRunResult(true));
+            testRunnerMock.Setup(x => x.InitialTest(It.IsAny<IProjectAndTests>())).Callback(() => Thread.Sleep(10)).Returns(new TestRunResult(true));
             testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
             testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
             var result = _target.InitialTest( _options, null, testRunnerMock.Object);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
@@ -57,6 +57,8 @@ public class SseServerTest : TestBase
             eventReceived.Set();
         };
 
+        Task.Yield();
+
         Task.Run(() => sseClient.StartAsync());
         Thread.Sleep(100);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
@@ -34,7 +34,7 @@ public class SseServerTest : TestBase
         Thread.Sleep(100);
 
         _sut.SendEvent(new SseEvent<string> { Event = SseEventType.Finished, Data = "" });
-        eventReceived.WaitOne();
+        Assert.True(eventReceived.WaitOne(500), "SSEWait timeout. Please retry");
 
         @event.ShouldBeSemantically("finished");
         data.ShouldBeSemantically("\"\"");
@@ -65,7 +65,7 @@ public class SseServerTest : TestBase
             Event = SseEventType.MutantTested,
             Data = @object
         });
-        eventReceived.WaitOne();
+        Assert.True(eventReceived.WaitOne(500), "SSEWait timeout. Please retry");
 
         @event.ShouldBeSemantically("mutant-tested");
         data.ShouldBeSemantically("{\"id\":\"1\",\"status\":\"Survived\"}");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
@@ -15,7 +15,7 @@ public class SseServerTest : TestBase
     public SseServerTest() => _sut = new SseServer();
 
     [Fact]
-    public async Task ShouldSendFinishedEventCorrectlyAsync()
+    public void ShouldSendFinishedEventCorrectlyAsync()
     {
         _sut.OpenSseEndpoint();
 
@@ -41,7 +41,7 @@ public class SseServerTest : TestBase
     }
 
     [Fact]
-    public async Task ShouldSendMutantTestedEventCorrectlyAsync()
+    public void ShouldSendMutantTestedEventCorrectlyAsync()
     {
         _sut.OpenSseEndpoint();
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
@@ -7,8 +7,7 @@ using Shouldly;
 using Stryker.Core.Reporters.Html.Realtime;
 using Stryker.Core.Reporters.Html.Realtime.Events;
 using Xunit;
-using Xunit.Sdk;
-
+  
 namespace Stryker.Core.UnitTest.Reporters.Html.Realtime;
 
 public class SseServerTest : TestBase
@@ -67,7 +66,7 @@ public class SseServerTest : TestBase
         WaitForConnection(500).ShouldBeTrue();
 
         _sut.SendEvent(new SseEvent<string> { Event = SseEventType.Finished, Data = "" });
-        Assert.True(eventReceived.WaitOne(500), "SSEWait timeout. Please retry");
+        eventReceived.WaitOne();
 
         @event.ShouldBeSemantically("finished");
         data.ShouldBeSemantically("\"\"");
@@ -91,8 +90,6 @@ public class SseServerTest : TestBase
             eventReceived.Set();
         };
 
-        Task.Yield();
-
         Task.Run(() => sseClient.StartAsync());
         WaitForConnection(500).ShouldBeTrue();
         
@@ -101,9 +98,10 @@ public class SseServerTest : TestBase
             Event = SseEventType.MutantTested,
             Data = @object
         });
-        Assert.True(eventReceived.WaitOne(500), "SSEWait timeout. Please retry");
+        eventReceived.WaitOne();
 
         @event.ShouldBeSemantically("mutant-tested");
         data.ShouldBeSemantically("{\"id\":\"1\",\"status\":\"Survived\"}");
     }
+
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/Realtime/SseServerTest.cs
@@ -15,7 +15,7 @@ public class SseServerTest : TestBase
     public SseServerTest() => _sut = new SseServer();
 
     [Fact]
-    public void ShouldSendFinishedEventCorrectlyAsync()
+    public void ShouldSendFinishedEventCorrectly()
     {
         _sut.OpenSseEndpoint();
 
@@ -41,7 +41,7 @@ public class SseServerTest : TestBase
     }
 
     [Fact]
-    public void ShouldSendMutantTestedEventCorrectlyAsync()
+    public void ShouldSendMutantTestedEventCorrectly()
     {
         _sut.OpenSseEndpoint();
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -431,8 +431,7 @@ public class VsTestMockingHelper : TestBase
             }));
 
     protected Mock<IVsTestConsoleWrapper> BuildVsTestRunnerPool(StrykerOptions options,
-        out VsTestRunnerPool runner, IReadOnlyCollection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases = null, TestProjectsInfo testProjectsInfo = null,
-        bool succeed = true)
+        out VsTestRunnerPool runner, IReadOnlyCollection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases = null, TestProjectsInfo testProjectsInfo = null)
     {
         testCases ??= TestCases.ToList();
         var mockedVsTestConsole = new Mock<IVsTestConsoleWrapper>(MockBehavior.Strict);
@@ -453,7 +452,7 @@ public class VsTestMockingHelper : TestBase
             new Mock<IVsTestHelper>().Object,
             _fileSystem,
             _ => mockedVsTestConsole.Object,
-            hostBuilder: _ => new MockStrykerTestHostLauncher(succeed, false),
+            hostBuilder: _ => new MockStrykerTestHostLauncher(false),
             NullLogger.Instance
         );
         foreach (var path in (testProjectsInfo ?? _testProjectsInfo).GetTestAssemblies())
@@ -487,19 +486,13 @@ public class VsTestMockingHelper : TestBase
 
     private class MockStrykerTestHostLauncher : IStrykerTestHostLauncher
     {
-        public MockStrykerTestHostLauncher(bool succeed, bool isDebug)
-        {
-            IsProcessCreated = succeed;
-            IsDebug = isDebug;
-        }
+        public MockStrykerTestHostLauncher(bool isDebug) => IsDebug = isDebug;
 
         public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo) => throw new NotImplementedException();
 
         public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo, CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public bool IsDebug { get; }
-
-        public bool IsProcessCreated { get; }
 
         public int ErrorCode { get; }
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -143,6 +143,11 @@ public class VsTestMockingHelper : TestBase
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase timeOutTest = null) =>
         Task.Run(() =>
         {
+            if (testResults.Count == 0)
+            {
+                // no test ==> no event at all
+                return;
+            }
             var timer = new Stopwatch();
             testRunEvents.HandleTestRunStatsChange(
                 new TestRunChangedEventArgs(new TestRunStatistics(0, null), null, timeOutTest == null ? null : new[] { timeOutTest }));

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -130,8 +130,8 @@ public class VsTestMockingHelper : TestBase
 
     protected IReadOnlyList<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> TestCases { get; }
 
-    private static void DiscoverTests(ITestDiscoveryEventsHandler discoveryEventsHandler, IReadOnlyCollection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> tests, bool aborted) =>
-        Task.Run(() => discoveryEventsHandler.HandleDiscoveredTests(tests)).
+    private static Task DiscoverTests(ITestDiscoveryEventsHandler discoveryEventsHandler, IReadOnlyCollection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> tests, bool aborted) =>
+         Task.Run(() => discoveryEventsHandler.HandleDiscoveredTests(tests)).
             ContinueWith((_, u) => discoveryEventsHandler.HandleDiscoveryComplete((int)u, null, aborted), tests.Count);
 
     protected Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase BuildCase(string name, TestFrameworks framework = TestFrameworks.xUnit, string displayName = null)
@@ -139,7 +139,7 @@ public class VsTestMockingHelper : TestBase
 
     private Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase FindOrBuildCase(string testResultId) => TestCases.FirstOrDefault(t => t.FullyQualifiedName == testResultId) ?? BuildCase(testResultId);
 
-    private static void MockTestRun(ITestRunEventsHandler testRunEvents, IReadOnlyList<TestResult> testResults,
+    private static Task MockTestRun(ITestRunEventsHandler testRunEvents, IReadOnlyList<TestResult> testResults,
         Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase timeOutTest = null) =>
         Task.Run(() =>
         {
@@ -202,11 +202,9 @@ public class VsTestMockingHelper : TestBase
                 It.Is<string>(settings => !settings.Contains("<Coverage")),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
-                ITestHostLauncher _) =>
-                // generate test results
-                MockTestRun(testRunEvents, results)).Returns(Task.CompletedTask);
+                ITestHostLauncher _) =>  MockTestRun(testRunEvents, results));
 
     protected void SetupFailingTestRun(Mock<IVsTestConsoleWrapper> mockVsTest) =>
         mockVsTest.Setup(x =>
@@ -215,9 +213,9 @@ public class VsTestMockingHelper : TestBase
                 It.Is<string>(settings => !settings.Contains("<Coverage")),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
-                ITestHostLauncher _) =>
+                    ITestHostLauncher _) =>
                 // generate test results
                 Task.Run(() =>
                 {
@@ -228,12 +226,14 @@ public class VsTestMockingHelper : TestBase
 
                     Thread.Sleep(10);
                     testRunEvents.HandleTestRunComplete(
-                        new TestRunCompleteEventArgs(new TestRunStatistics(0, null), false, false, new TransationLayerException("VsTest Crashed"),
+                        new TestRunCompleteEventArgs(new TestRunStatistics(0, null), false, false,
+                            new TransationLayerException("VsTest Crashed"),
                             null, timer.Elapsed),
-                        new TestRunChangedEventArgs(null, Array.Empty<TestResult>(), new List<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase>()),
+                        new TestRunChangedEventArgs(null, Array.Empty<TestResult>(),
+                            new List<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase>()),
                         null,
                         null);
-                })).Returns(Task.CompletedTask);
+                }));
 
     protected void SetupMockCoverageRun(Mock<IVsTestConsoleWrapper> mockVsTest, IReadOnlyDictionary<string, string> coverageResults) => SetupMockCoverageRun(mockVsTest, GenerateCoverageTestResults(coverageResults));
 
@@ -244,9 +244,9 @@ public class VsTestMockingHelper : TestBase
                 It.Is<string>(settings => settings.Contains("<Coverage")),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
-                ITestHostLauncher _) => MockTestRun(testRunEvents, results)).Returns(Task.CompletedTask);
+                ITestHostLauncher _) => MockTestRun(testRunEvents, results));
 
     private List<TestResult> GenerateCoverageTestResults(IReadOnlyDictionary<string, string> coverageResults)
     {
@@ -275,32 +275,6 @@ public class VsTestMockingHelper : TestBase
         return results;
     }
 
-    protected List<TestResult> GenerateCoverageTestResults(IEnumerable<(Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase testCase, string coverage)> data)
-    {
-        var results = new List<TestResult>();
-        foreach (var (testCase, coverage) in data)
-        {
-            var result = new TestResult(testCase)
-            {
-                Outcome = TestOutcome.Passed,
-                ComputerName = ".",
-            };
-            if (coverage != null)
-            {
-                var coveredList = coverage.Split('|');
-                result.SetPropertyValue(_coverageProperty, coveredList[0]);
-                if (coveredList.Length > 1)
-                {
-                    result.SetPropertyValue(_unexpectedCoverageProperty, coveredList[1]);
-                }
-            }
-
-            results.Add(result);
-        }
-
-        return results;
-    }
-
     protected void SetupMockCoveragePerTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, IReadOnlyDictionary<string, string> coverageResults) =>
         mockVsTest.Setup(x =>
             x.RunTestsWithCustomTestHostAsync(
@@ -308,7 +282,7 @@ public class VsTestMockingHelper : TestBase
                 It.Is<string>(settings => settings.Contains("<Coverage")),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
                 ITestHostLauncher _) =>
             {
@@ -324,8 +298,8 @@ public class VsTestMockingHelper : TestBase
                     var result = BuildCoverageTestResult(key, coveredList);
                     results.Add(result);
                 }
-                MockTestRun(testRunEvents, results);
-            }).Returns(Task.CompletedTask);
+                return MockTestRun(testRunEvents, results);
+            });
 
     protected TestResult BuildCoverageTestResult(string key, string[] coveredList)
     {
@@ -351,9 +325,9 @@ public class VsTestMockingHelper : TestBase
                 It.Is<string>(s => !s.Contains("<Coverage")),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> sources, string settings, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
-                ITestHostLauncher _) =>
+                ITestHostLauncher _) => Task.Run(()=>
             {
                 var collector = new CoverageCollector();
                 var start = new TestSessionStartArgs
@@ -391,9 +365,9 @@ public class VsTestMockingHelper : TestBase
                     runResults.Add(result);
                 }
                 // setup a normal test run
-                MockTestRun(testRunEvents, runResults);
+                MockTestRun(testRunEvents, runResults).Wait();
                 collector.TestSessionEnd(new TestSessionEndArgs());
-            }).Returns(Task.CompletedTask);
+            }));
 
     protected static void SetupMockTimeOutTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, IReadOnlyDictionary<string, string> results, string timeoutTest) =>
         mockVsTest.Setup(x =>
@@ -402,9 +376,9 @@ public class VsTestMockingHelper : TestBase
                 It.IsAny<string>(),
                 It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
                 It.IsAny<ITestRunEventsHandler>(),
-                It.IsAny<ITestHostLauncher>())).Callback(
+                It.IsAny<ITestHostLauncher>())).Returns(
             (IEnumerable<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> sources, string settings, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
-                ITestHostLauncher _) =>
+                ITestHostLauncher _) => Task.Run(()=>
             {
                 var collector = new CoverageCollector();
                 var start = new TestSessionStartArgs
@@ -446,10 +420,10 @@ public class VsTestMockingHelper : TestBase
                     runResults.Add(result);
                 }
                 // setup a normal test run
-                MockTestRun(testRunEvents, runResults, timeOutTestCase);
+                MockTestRun(testRunEvents, runResults, timeOutTestCase).Wait();
                 collector.TestSessionEnd(new TestSessionEndArgs());
 
-            }).Returns(Task.CompletedTask);
+            }));
 
     protected Mock<IVsTestConsoleWrapper> BuildVsTestRunnerPool(StrykerOptions options,
         out VsTestRunnerPool runner, IReadOnlyCollection<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase> testCases = null, TestProjectsInfo testProjectsInfo = null,
@@ -461,12 +435,13 @@ public class VsTestMockingHelper : TestBase
         mockedVsTestConsole.Setup(x => x.InitializeExtensions(It.IsAny<IEnumerable<string>>()));
         mockedVsTestConsole.Setup(x => x.AbortTestRun());
         mockedVsTestConsole.Setup(x => x.EndSession());
+        ITestDiscoveryEventsHandler discoveryHandler = null;
         mockedVsTestConsole.Setup(x =>
             x.DiscoverTestsAsync(It.Is<IEnumerable<string>>(d => d.Any(e => e == _testAssemblyPath)),
                 It.IsAny<string>(),
                 It.IsAny<ITestDiscoveryEventsHandler>())).Callback(
-            (IEnumerable<string> _, string _, ITestDiscoveryEventsHandler discoveryEventsHandler) =>
-                DiscoverTests(discoveryEventsHandler, testCases, false)).Returns(Task.CompletedTask);
+            (IEnumerable<string> _, string _, ITestDiscoveryEventsHandler handler) =>
+                 discoveryHandler = handler).Returns(() => DiscoverTests(discoveryHandler, testCases, false));
 
         var context = new VsTestContextInformation(
             options,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -239,7 +239,7 @@ public class VsTestMockingHelper : TestBase
                         null,
                         null);
                 }));
-    protected void SetupHangedTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, int repeated = 1) =>
+    protected void SetupFrozenTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, int repeated = 1) =>
         mockVsTest.Setup(x =>
             x.RunTestsWithCustomTestHostAsync(
                 It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),
@@ -267,7 +267,7 @@ public class VsTestMockingHelper : TestBase
                         null,
                         null);
                 }));
-   protected void SetupHangedVsTest(Mock<IVsTestConsoleWrapper> mockVsTest, int repeated = 1) =>
+   protected void SetupFrozenVsTest(Mock<IVsTestConsoleWrapper> mockVsTest, int repeated = 1) =>
         mockVsTest.Setup(x =>
             x.RunTestsWithCustomTestHostAsync(
                 It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -239,6 +239,34 @@ public class VsTestMockingHelper : TestBase
                         null,
                         null);
                 }));
+    protected void SetupHangedTestRun(Mock<IVsTestConsoleWrapper> mockVsTest, int repeated = 1) =>
+        mockVsTest.Setup(x =>
+            x.RunTestsWithCustomTestHostAsync(
+                It.Is<IEnumerable<string>>(t => t.Any(source => source == _testAssemblyPath)),
+                It.Is<string>(settings => !settings.Contains("<Coverage")),
+                It.Is<TestPlatformOptions>(o => o != null && o.TestCaseFilter == null),
+                It.IsAny<ITestRunEventsHandler>(),
+                It.IsAny<ITestHostLauncher>())).Returns(
+            (IEnumerable<string> _, string _, TestPlatformOptions _, ITestRunEventsHandler testRunEvents,
+                    ITestHostLauncher _) =>
+                // generate test results
+                Task.Run(() =>
+                {
+                    testRunEvents.HandleTestRunStatsChange(
+                        new TestRunChangedEventArgs(new TestRunStatistics(0, null), null, null));
+
+                    if (repeated-->0)
+                        Thread.Sleep(1000);
+                    else
+                        testRunEvents.HandleTestRunComplete(
+                            new TestRunCompleteEventArgs(new TestRunStatistics(0, null), false, false,
+                            null,
+                            null, TimeSpan.FromMilliseconds(10)),
+                        new TestRunChangedEventArgs(null, Array.Empty<TestResult>(),
+                            new List<Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase>()),
+                        null,
+                        null);
+                }));
 
     protected void SetupMockCoverageRun(Mock<IVsTestConsoleWrapper> mockVsTest, IReadOnlyDictionary<string, string> coverageResults) => SetupMockCoverageRun(mockVsTest, GenerateCoverageTestResults(coverageResults));
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -98,7 +98,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         [Fact]
         public void HandleVsTestCreationFailure()
         {
-            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner, succeed: false);
+            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             SetupFailingTestRun(mockVsTest);
 
             Action action = () => runner.InitialTest(SourceProjectInfo);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -116,6 +116,16 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
+        public void DoNotTestWhenNoTestPResent()
+        {
+            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner, testCases: new List<TestCase>());
+            SetupMockTestRun(mockVsTest, true, TestCases);
+            var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
+            // tests are successful => run should be successful
+            result.ExecutedTests.IsEmpty.ShouldBeTrue();
+        }
+
+        [Fact]
         public void RecycleRunnerOnError()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -22,7 +22,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         [Fact]
         public void InitializeProperly()
         {
-            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
+            BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             runner.GetTests(SourceProjectInfo).Count.ShouldBe(2);
         }
 
@@ -65,7 +65,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                 Duration = duration
             };
             SetupMockTestRun(mockVsTest, new[] { testResult });
-            var result = runner.InitialTest(SourceProjectInfo);
+            runner.InitialTest(SourceProjectInfo);
             runner.Context.VsTests[TestCases[0].Id].InitialRunTime.ShouldBe(duration);
         }
 
@@ -91,7 +91,7 @@ namespace Stryker.Core.UnitTest.TestRunners
                 Duration = duration
             };
             SetupMockTestRun(mockVsTest, new[] { testResult, otherTestResult });
-            var result = runner.InitialTest(SourceProjectInfo);
+            runner.InitialTest(SourceProjectInfo);
             runner.Context.VsTests[TestCases[0].Id].InitialRunTime.ShouldBe(duration);
         }
 
@@ -179,7 +179,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
-        public void RetryHungSession()
+        public void ShouldRetryFrozenSession()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             // the test session will hung twice
@@ -189,7 +189,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
-        public void HungVsTest()
+        public void ShouldNotRetryFrozenVsTest()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             // the test session will end properly, but VsTest will hang
@@ -208,7 +208,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             mockVsTest.Setup(x => x.CancelTestRun()).Verifiable();
             SetupMockTestRun(mockVsTest, false, TestCases);
 
-            var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, ((_, _, _, _) => false));
+            var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, (_, _, _, _) => false);
             // verify Abort has been called
             Mock.Verify(mockVsTest);
             // and test run is failed

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -145,7 +145,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             SetupFailingTestRun(mockVsTest);
             var action = () =>  runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
             action.ShouldThrow<GeneralStrykerException>();
-            // the test will always end in a crash, VsTestRunner should retry at least a gew times
+            // the test will always end in a crash, VsTestRunner should retry at least a few times
             mockVsTest.Verify(m => m.EndSession(), Times.AtLeast(4));
         }
 
@@ -177,6 +177,16 @@ namespace Stryker.Core.UnitTest.TestRunners
 
             var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
             result.TimedOutTests.IsEmpty.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void RetryHangedSession()
+        {
+            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
+            // the test session will hung twice
+            SetupHangedTestRun(mockVsTest, 2);
+            runner.TestMultipleMutants(SourceProjectInfo, new TimeoutValueCalculator(0, 10,9), new[] { Mutant }, null);
+            mockVsTest.Verify(m => m.EndSession(), Times.Exactly(3));
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -119,7 +119,20 @@ namespace Stryker.Core.UnitTest.TestRunners
         public void DoNotTestWhenNoTestPresent()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner, testCases: new List<TestCase>());
-            SetupMockTestRun(mockVsTest, true, TestCases);
+            SetupMockTestRun(mockVsTest, true, new List<TestCase>());
+            var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
+            // tests are successful => run should be successful
+            result.ExecutedTests.IsEmpty.ShouldBeTrue();
+        }
+
+
+        // If no tests are present in the assembly, VsTest raises no event at all
+        // previous versions of Stryker hanged when this happened
+        [Fact]
+        public void HandleWhenNoTestAreFound()
+        {
+            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner, TestCases);
+            SetupMockTestRun(mockVsTest, true, new List<TestCase>());
             var result = runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
             // tests are successful => run should be successful
             result.ExecutedTests.IsEmpty.ShouldBeTrue();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -124,10 +124,9 @@ namespace Stryker.Core.UnitTest.TestRunners
             // tests are successful => run should be successful
             result.ExecutedTests.IsEmpty.ShouldBeTrue();
         }
-
-
+        
         // If no tests are present in the assembly, VsTest raises no event at all
-        // previous versions of Stryker hanged when this happened
+        // previous versions of Stryker froze when this happened
         [Fact]
         public void HandleWhenNoTestAreFound()
         {
@@ -180,21 +179,21 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
-        public void RetryHangedSession()
+        public void RetryHungSession()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             // the test session will hung twice
-            SetupHangedTestRun(mockVsTest, 2);
+            SetupFrozenTestRun(mockVsTest, 2);
             runner.TestMultipleMutants(SourceProjectInfo, new TimeoutValueCalculator(0, 10,9), new[] { Mutant }, null);
             mockVsTest.Verify(m => m.EndSession(), Times.Exactly(3));
         }
 
         [Fact]
-        public void HangedVsTest()
+        public void HungVsTest()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             // the test session will end properly, but VsTest will hang
-            SetupHangedVsTest(mockVsTest, 3);
+            SetupFrozenVsTest(mockVsTest, 3);
             runner.TestMultipleMutants(SourceProjectInfo, new TimeoutValueCalculator(0, 10,9), new[] { Mutant }, null);
             mockVsTest.Verify(m => m.EndSession(), Times.Exactly(2));
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -116,7 +116,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
-        public void DoNotTestWhenNoTestPResent()
+        public void DoNotTestWhenNoTestPresent()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner, testCases: new List<TestCase>());
             SetupMockTestRun(mockVsTest, true, TestCases);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -190,6 +190,16 @@ namespace Stryker.Core.UnitTest.TestRunners
         }
 
         [Fact]
+        public void HangedVsTest()
+        {
+            var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
+            // the test session will end properly, but VsTest will hang
+            SetupHangedVsTest(mockVsTest, 3);
+            runner.TestMultipleMutants(SourceProjectInfo, new TimeoutValueCalculator(0, 10,9), new[] { Mutant }, null);
+            mockVsTest.Verify(m => m.EndSession(), Times.Exactly(2));
+        }
+
+        [Fact]
         public void AbortOnError()
         {
             var options = new StrykerOptions();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTextContextInformationTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTextContextInformationTests.cs
@@ -171,7 +171,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             _consoleParameters.TraceLevel.ShouldBe(TraceLevel.Verbose);
 
             // we should have the testdiscoverer log file name
-            _consoleParameters.LogFilePath.ShouldBe($"\"logs{_fileSystem.Path.DirectorySeparatorChar}TestDiscoverer_VsTest-log.txt\"");
+            _consoleParameters.LogFilePath.ShouldBe($"\"logs{_fileSystem.Path.DirectorySeparatorChar}TestDiscoverer-log.txt\"");
 
             // the log folders should exist
             _fileSystem.AllDirectories.Last().ShouldMatch(".*logs$");

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialTestProcess.cs
@@ -40,8 +40,8 @@ namespace Stryker.Core.Initialisation
             _logger.LogDebug("Initial test run output: {0}.", initTestRunResult.ResultMessage);
 
             TimeoutValueCalculator = new TimeoutValueCalculator(options.AdditionalTimeout,
-                (int)stopwatch.ElapsedMilliseconds - (int)initTestRunResult.Duration.TotalMilliseconds,
-                (int)stopwatch.ElapsedMilliseconds);
+                (int)stopwatch.ElapsedMilliseconds,
+                (int)initTestRunResult.Duration.TotalMilliseconds);
 
             return new InitialTestRun(initTestRunResult, TimeoutValueCalculator);
         }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/TimeoutValueCalculator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/TimeoutValueCalculator.cs
@@ -1,36 +1,31 @@
-using Microsoft.Extensions.Logging;
-using Stryker.Core.Logging;
+using System;
 
 namespace Stryker.Core.Initialisation
 {
     public interface ITimeoutValueCalculator
     {
-        int CalculateTimeoutValue(int initialTestrunDurationMS);
+        int CalculateTimeoutValue(int estimatedTime);
         int DefaultTimeout { get; }
     }
 
     public class TimeoutValueCalculator : ITimeoutValueCalculator
     {
         private readonly int _extraMs;
-        private readonly int _initTimeMs;
-        private readonly int _totalTestTime;
+        private readonly int _initializationTime;
+        private readonly int _aggregatedTestTimes;
         private const double Ratio = 1.5;
 
-        public TimeoutValueCalculator(int extraMS)
-        {
-            _extraMs = extraMS;
-        }
+        public TimeoutValueCalculator(int extraMs) => _extraMs = extraMs;
 
-        public TimeoutValueCalculator(int extraMs, int initTimeMs, int totalTestTime)
+        public TimeoutValueCalculator(int extraMs, int testSessionTime, int aggregatedTestTimes)
         {
             _extraMs = extraMs;
-            _initTimeMs = initTimeMs;
-            _totalTestTime = totalTestTime;
+            _initializationTime = Math.Max(testSessionTime - aggregatedTestTimes, 0);
+            _aggregatedTestTimes = aggregatedTestTimes;
         }
         
-        public int DefaultTimeout => Compute(_totalTestTime);
+        public int DefaultTimeout => CalculateTimeoutValue(_aggregatedTestTimes);
 
-        private int Compute(int time) => (int)(time * Ratio) + _extraMs;
-        public int CalculateTimeoutValue(int initialTestrunDurationMS) => Compute(_initTimeMs + initialTestrunDurationMS);
+        public int CalculateTimeoutValue(int estimatedTime) => (int)((_initializationTime + estimatedTime) * Ratio) + _extraMs;
     }
 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -191,31 +191,19 @@ namespace Stryker.Core.TestRunners.VsTest
 
         public void HandleRawMessage(string rawMessage) => _logger.LogTrace($"{_runnerId}: {rawMessage} [RAW]");
 
-        public bool WaitEnd(int? timeOut)
+        public bool WaitEnd(int timeOut)
         {
             lock (_lck)
             {
-                if (timeOut == null)
+                var delay = 0;
+                const int Unit = 500;
+                while (!_completed && delay < timeOut )
                 {
-                    while (!_completed)
-                    {
-                        Monitor.Wait(_lck);
-                    }
-
-                    return true;
+                    Monitor.Wait(_lck, Unit);
+                    delay += Unit;
                 }
-                else
-                {
-                    var delay = 0;
-                    const int Unit = 500;
-                    while (!_completed && delay < timeOut.Value * 3)
-                    {
-                        Monitor.Wait(_lck, Unit);
-                        delay += Unit;
-                    }
 
-                    return _completed;
-                }
+                return _completed;
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/RunEventHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -123,7 +124,6 @@ namespace Stryker.Core.TestRunners.VsTest
                     _inProgress[activeTest.Id] = activeTest;
                 }
             }
-
             if (testRunChangedArgs.NewTestResults == null || !testRunChangedArgs.NewTestResults.Any())
             {
                 return;
@@ -191,16 +191,16 @@ namespace Stryker.Core.TestRunners.VsTest
 
         public void HandleRawMessage(string rawMessage) => _logger.LogTrace($"{_runnerId}: {rawMessage} [RAW]");
 
-        public bool WaitEnd(int timeOut)
+        public bool Wait(int timeOut)
         {
             lock (_lck)
             {
-                var delay = 0;
-                const int Unit = 500;
-                while (!_completed && delay < timeOut )
+                var watch = new Stopwatch();
+                watch.Start();
+
+                while (!_completed && watch.ElapsedMilliseconds < timeOut )
                 {
-                    Monitor.Wait(_lck, Unit);
-                    delay += Unit;
+                    Monitor.Wait(_lck, Math.Max(0, (int)(timeOut-watch.ElapsedMilliseconds)));
                 }
 
                 return _completed;

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
@@ -11,7 +11,6 @@ namespace Stryker.Core.TestRunners.VsTest
 
     public interface IStrykerTestHostLauncher : ITestHostLauncher
     {
-         int ErrorCode { get; }
     }
 
     // can't be unit tested
@@ -20,7 +19,6 @@ namespace Stryker.Core.TestRunners.VsTest
     {
         private readonly string _id;
         private readonly bool _devMode;
-        public int ErrorCode { get; private set; }
 
         private static ILogger Logger { get; }
 
@@ -71,16 +69,8 @@ namespace Stryker.Core.TestRunners.VsTest
 
             currentProcess.BeginOutputReadLine();
             currentProcess.BeginErrorReadLine();
-            currentProcess.Exited += ProcessExited;
 
             return currentProcess.Id;
-        }
-
-        private void ProcessExited(object sender, System.EventArgs e)
-        {
-            var process = (Process) sender;
-            process.WaitForExit();
-            ErrorCode = process.ExitCode;
         }
 
         private void Process_ErrorDataReceived(object sender, DataReceivedEventArgs e)

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/StrykerVstestHostLauncher.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Interfaces;
 using Stryker.Core.Logging;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Stryker.Core.TestRunners.VsTest
@@ -10,15 +11,15 @@ namespace Stryker.Core.TestRunners.VsTest
 
     public interface IStrykerTestHostLauncher : ITestHostLauncher
     {
-         bool IsProcessCreated { get; }
          int ErrorCode { get; }
     }
 
+    // can't be unit tested
+    [ExcludeFromCodeCoverage]
     public class StrykerVsTestHostLauncher : IStrykerTestHostLauncher
     {
         private readonly string _id;
         private readonly bool _devMode;
-        private Process _currentProcess;
         public int ErrorCode { get; private set; }
 
         private static ILogger Logger { get; }
@@ -32,8 +33,6 @@ namespace Stryker.Core.TestRunners.VsTest
         }
 
         public bool IsDebug => false;
-
-        public bool IsProcessCreated => _currentProcess != null;
 
         public int LaunchTestHost(TestProcessStartInfo defaultTestHostStartInfo) =>
             LaunchTestHost(defaultTestHostStartInfo, CancellationToken.None);
@@ -58,23 +57,23 @@ namespace Stryker.Core.TestRunners.VsTest
                     ["Verify_DisableClipboard"] = "true",
                 },
             };
-            _currentProcess = new Process { StartInfo = processInfo, EnableRaisingEvents = true };
+            var currentProcess =  new Process { StartInfo = processInfo, EnableRaisingEvents = true };
 
             if (_devMode)
             {
-                _currentProcess.OutputDataReceived += Process_OutputDataReceived;
-                _currentProcess.ErrorDataReceived += Process_ErrorDataReceived;
+                currentProcess.OutputDataReceived += Process_OutputDataReceived;
+                currentProcess.ErrorDataReceived += Process_ErrorDataReceived;
             }
-            if (!_currentProcess.Start())
+            if (!currentProcess.Start())
             {
                 Logger.LogError($"Runner {_id}: Failed to start process {processInfo.Arguments}.");
             }
 
-            _currentProcess.BeginOutputReadLine();
-            _currentProcess.BeginErrorReadLine();
-            _currentProcess.Exited += ProcessExited;
+            currentProcess.BeginOutputReadLine();
+            currentProcess.BeginErrorReadLine();
+            currentProcess.Exited += ProcessExited;
 
-            return _currentProcess.Id;
+            return currentProcess.Id;
         }
 
         private void ProcessExited(object sender, System.EventArgs e)

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
@@ -166,6 +166,9 @@ namespace Stryker.Core.TestRunners.VsTest
         // keeps only test assemblies which have tests.
         public bool IsValidSourceList(IEnumerable<string> sources) => sources.Any( s=> TestsPerSource.TryGetValue(s, out var result ) && result.Count >0);
 
+        public IEnumerable<string> GetValidSources(IEnumerable<string> sources) =>
+            sources.Where(s => TestsPerSource.TryGetValue(s, out var result) && result.Count > 0);
+
         public bool AddTestSource(string source)
         {
             if (!_fileSystem.File.Exists(source))

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
@@ -147,7 +147,8 @@ namespace Stryker.Core.TestRunners.VsTest
             {
                 return determineConsoleParameters;
             }
-            var vsTestLogPath = _fileSystem.Path.Combine(LogPath, $"{runnerId}_VsTest-log.txt");
+
+            var vsTestLogPath = _fileSystem.Path.Combine(LogPath, $"{runnerId}-log.txt");
             _fileSystem.Directory.CreateDirectory(LogPath);
             determineConsoleParameters.LogFilePath = vsTestLogPath;
             return determineConsoleParameters;

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
@@ -252,7 +252,7 @@ namespace Stryker.Core.TestRunners.VsTest
         public string GenerateRunSettings(int? timeout, bool forCoverage, Dictionary<int, ITestGuids> mutantTestsMap, string helperNameSpace, bool isFullFramework)
         {
             var settingsForCoverage = string.Empty;
-            var needDataCollector = forCoverage || mutantTestsMap is { };
+            var needDataCollector = forCoverage || mutantTestsMap is not null;
             var dataCollectorSettings = needDataCollector
                 ? CoverageCollector.GetVsTestSettings(
                     forCoverage,
@@ -265,11 +265,10 @@ namespace Stryker.Core.TestRunners.VsTest
                 settingsForCoverage = "<CollectDataForEachTestSeparately>true</CollectDataForEachTestSeparately>";
             }
 
-            if (_testFramework.HasFlag(TestFrameworks.xUnit))
+            if (_testFramework.HasFlag(TestFrameworks.xUnit) || _testFramework.HasFlag(TestFrameworks.MsTest))
             {
                 settingsForCoverage += "<DisableParallelization>true</DisableParallelization>";
             }
-
             var timeoutSettings = timeout is > 0
                 ? $"<TestSessionTimeout>{timeout}</TestSessionTimeout>" + Environment.NewLine
                 : string.Empty;

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestContextInformation.cs
@@ -163,9 +163,11 @@ namespace Stryker.Core.TestRunners.VsTest
             return result;
         }
 
+        // keeps only test assemblies which have tests.
+        public bool IsValidSourceList(IEnumerable<string> sources) => sources.Any( s=> TestsPerSource.TryGetValue(s, out var result ) && result.Count >0);
+
         public bool AddTestSource(string source)
         {
-
             if (!_fileSystem.File.Exists(source))
             {
                 throw new GeneralStrykerException(

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -73,7 +73,7 @@ namespace Stryker.Core.TestRunners.VsTest
 
             if (testCases?.Count == 0)
             {
-                    return new TestRunResult(_context.VsTests.Values, TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), "Mutants are not covered by any test!", Enumerable.Empty<string>(), TimeSpan.Zero);
+                return new TestRunResult(_context.VsTests.Values, TestGuidsList.NoTest(), TestGuidsList.NoTest(), TestGuidsList.NoTest(), "Mutants are not covered by any test!", Enumerable.Empty<string>(), TimeSpan.Zero);
             }
             if (timeoutCalc != null && testCases != null)
             {

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -161,6 +161,10 @@ namespace Stryker.Core.TestRunners.VsTest
             var testCases = resultAsArray.Select(t => t.TestCase.Id).ToHashSet();
             var ranTestsCount = testCases.Count;
             var timeout = !_cancelled && ranTestsCount < expectedTests;
+            // ranTests is the list of test that have been executed. We detect the special case where all (existing and found) tests have been executed.
+            // this is needed when the tests list is not stable (mutations can generate variation for theories) and also helps for performance
+            // so we assume that if executed at least as much test as have been detected, it means all tests have been executed
+            // EXCEPT when no test have been found. Otherwise, an empty test project would transform non covered mutants to survivors.
             var ranTests = compressAll && totalCountOfTests>0 && ranTestsCount >= totalCountOfTests ? (ITestGuids)TestGuidsList.EveryTest() : new WrappedGuidsEnumeration(testCases);
             var failedTests = resultAsArray.Where(tr => tr.Outcome == TestOutcome.Failed).Select(t => t.TestCase.Id);
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -25,6 +25,8 @@ namespace Stryker.Core.TestRunners.VsTest
         private readonly ILogger _logger;
         // safety timeout for VsTestWrapper operations. We assume VsTest crashed if the timeout triggers
         private const int VsTestWrapperTimeOutInMs = 3*1000;
+        // maximum number of attempts for VsTest sessions, just in case we run into some of VsTest quirks
+        private const int MaxAttempts = 3;
 
         private string RunnerId => $"Runner {_id}";
 
@@ -203,7 +205,7 @@ namespace Stryker.Core.TestRunners.VsTest
                 return new RunEventHandler(_context.VsTests, _logger, RunnerId);
             }
 
-            for (var attempt = 0; attempt < 5; attempt++)
+            for (var attempt = 0; attempt < MaxAttempts; attempt++)
             {
                 var eventHandler = RunVsTest(tests, _context.GetValidSources(sources), runSettings, timeOut, updateHandler);
                 if (eventHandler != null)
@@ -216,7 +218,7 @@ namespace Stryker.Core.TestRunners.VsTest
             _logger.LogCritical($"{RunnerId}: VsTest failed, settings: {runSettings}");
 
             throw new GeneralStrykerException(
-                $"{RunnerId}: failed to run a test session despite 5 attempts. Aborting session.");
+                $"{RunnerId}: failed to run a test session despite ${MaxAttempts} attempts. Aborting session.");
         }
 
         private RunEventHandler RunVsTest(ITestGuids tests, IEnumerable<string> sources, string runSettings, int? timeOut,

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -267,6 +267,7 @@ namespace Stryker.Core.TestRunners.VsTest
                     // VsTestHost appears stuck and can't be aborted
                     _logger.LogError(
                         $"{RunnerId}: VsTest did not report the end of test session in due time ({timeOut} ms), it may have hanged.");
+                    _logger.LogError($"{RunnerId}: ran {eventHandler.GetResults().TestResults.Count} tests.");
                     _vsTestConsole.AbortTestRun();
                     vsTestFailed = true;
                 }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -265,19 +265,10 @@ namespace Stryker.Core.TestRunners.VsTest
                 {
                     // VsTestWrapper aborts the current test sessions on timeout, except on critical error, so we have an internal timeout (+ grace period)
                     // to detect and properly handle those events. 
-                    if (!strykerVsTestHostLauncher.IsProcessCreated)
-                    {
-                        // VsTestWrapper did not launch a test session for some reason
-                        _logger.LogError($"{RunnerId}: VsTest did not start properly.");
-                    }
-                    else
-                    {
-                        // VsTestHost appears stuck and can't be aborted
-                        _logger.LogError(
-                            $"{RunnerId}: VsTest did not report the end of test session in due time, it may have hang.");
-                        _vsTestConsole.AbortTestRun();
-                    }
-
+                    // VsTestHost appears stuck and can't be aborted
+                    _logger.LogError(
+                        $"{RunnerId}: VsTest did not report the end of test session in due time, it may have hang.");
+                    _vsTestConsole.AbortTestRun();
                     vsTestFailed = true;
                 }
             }

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -204,7 +204,7 @@ namespace Stryker.Core.TestRunners.VsTest
 
             for (var attempt = 0; attempt < 5; attempt++)
             {
-                var eventHandler = RunVsTest(tests, sources, runSettings, timeOut, updateHandler);
+                var eventHandler = RunVsTest(tests, _context.GetValidSources(sources), runSettings, timeOut, updateHandler);
                 if (eventHandler != null)
                 {
                     return eventHandler;

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -266,7 +266,7 @@ namespace Stryker.Core.TestRunners.VsTest
                 // ==> if it failed, results are uncertain
                 sessionFailed = !eventHandler.Wait(VsTestWrapperTimeOutInMs + timeOut.Value);
                 // we wait for vsTestProcess to stop
-                // ==> if it appears hanged, we recycle it.
+                // ==> if it appears hung, we recycle it.
                 vsTestFailed = !session.Wait(VsTestWrapperTimeOutInMs);
                 // VsTestHost appears stuck
                 // VsTestWrapper aborts the current test sessions on timeout, except on critical error, so we have an internal timeout (+ grace period)
@@ -274,7 +274,7 @@ namespace Stryker.Core.TestRunners.VsTest
                 if (sessionFailed)
                 {
                     _logger.LogError(
-                        $"{RunnerId}: VsTest did not report the end of test session in due time ({timeOut} ms), it may have hanged.");
+                        $"{RunnerId}: VsTest did not report the end of test session in due time ({timeOut} ms), it may be frozen.");
                     _logger.LogError($"{RunnerId}: ran {eventHandler.GetResults().TestResults.Count} tests.");
                     // workaround VsTest issue #4527
                     if (_cancelled && sources.Count() > 1)

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -254,8 +254,7 @@ namespace Stryker.Core.TestRunners.VsTest
             else
             {
                 session = _vsTestConsole.RunTestsWithCustomTestHostAsync(tests.GetGuids().Select(t => _context.VsTests[t].Case),
-                    runSettings,
-                    options, eventHandler, strykerVsTestHostLauncher);
+                    runSettings, options, eventHandler, strykerVsTestHostLauncher);
             }
 
 
@@ -267,7 +266,7 @@ namespace Stryker.Core.TestRunners.VsTest
                     // to detect and properly handle those events. 
                     // VsTestHost appears stuck and can't be aborted
                     _logger.LogError(
-                        $"{RunnerId}: VsTest did not report the end of test session in due time, it may have hang.");
+                        $"{RunnerId}: VsTest did not report the end of test session in due time ({timeOut} ms), it may have hanged.");
                     _vsTestConsole.AbortTestRun();
                     vsTestFailed = true;
                 }


### PR DESCRIPTION
Fix issue #2549 : Stryker now warns when no test are present.
Fix issue #2559 : Stryker now disables parallelism for MsTest
Also implement a revised strategy for handling hanged VsTest:
1. For initial test session: wait for VsTest to stop, then wait for the end notification (if not received yet). No failover available for the time being.
2. For other test sessions: 
      1. wait for the end notification: if it times out, this session is discarded
      2. then, wait for the end of the session: if it times out, we assume VsTest hanged during clean up phase, it will be recycled, but the session is discarded.
      1. if anything timed out, VsTest console is recycled
      1. if the test session is discarded, a new attempt is made
      1. an exception is thrown after 5 failed attempts