### PR TITLE
fix(report): Use fullPath for file name in json and html report

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Clients/DashboardClientsTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Clients/DashboardClientsTest.cs
@@ -13,7 +13,7 @@ using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters;
 using Stryker.Core.Reporters.Json;
-using Stryker.Core.UnitTest.Reporters;
+using Stryker.Core.UnitTest.Reporters.Json;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.Clients

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
@@ -13,7 +13,7 @@ using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters;
 using Stryker.Core.Reporters.Json;
 using Stryker.Core.Reporters.Json.SourceFiles;
-using Stryker.Core.UnitTest.Reporters;
+using Stryker.Core.UnitTest.Reporters.Json;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.MutantFilters

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -153,12 +154,12 @@ namespace ExtraProject.XUnit
         [Fact]
         public void JsonReport_ShouldContainFullPath()
         {
-            var folderComponent = ReportTestHelper.CreateProjectWith();
+            var folderComponent = ReportTestHelper.CreateProjectWith(root: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c://" : "");
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
             var path = report.Files.Keys.First();
 
-            Path.IsPathFullyQualified(path).ShouldBeFalse($"{path} should not be a relative path");
+            Path.IsPathFullyQualified(path).ShouldBeTrue($"{path} should not be a relative path");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -156,8 +156,9 @@ namespace ExtraProject.XUnit
             var folderComponent = ReportTestHelper.CreateProjectWith();
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
+            var path = report.Files.Keys.First();
 
-            Path.IsPathFullyQualified(report.Files.Keys.First()).ShouldBeFalse("Path should not be a relative path");
+            Path.IsPathFullyQualified(path).ShouldBeFalse($"{path} should not be a relative path");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -154,7 +154,7 @@ namespace ExtraProject.XUnit
         [Fact]
         public void JsonReport_ShouldContainFullPath()
         {
-            var folderComponent = ReportTestHelper.CreateProjectWith(root: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c://" : "");
+            var folderComponent = ReportTestHelper.CreateProjectWith(root: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c://" : "/");
 
             var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
             var path = report.Files.Keys.First();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -19,7 +19,7 @@ using Stryker.Core.Reporters.Json;
 using Stryker.Core.Reporters.Json.SourceFiles;
 using Xunit;
 
-namespace Stryker.Core.UnitTest.Reporters
+namespace Stryker.Core.UnitTest.Reporters.Json
 {
     public class JsonReporterTests : TestBase
     {
@@ -39,10 +39,7 @@ namespace ExtraProject.XUnit
     }
 }
 ";
-        public JsonReporterTests()
-        {
-            _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
-        }
+        public JsonReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
 
         [Fact]
         public void JsonMutantPositionLine_ThrowsArgumentExceptionWhenSetToLessThan1()
@@ -75,7 +72,7 @@ namespace ExtraProject.XUnit
         }
 
         [Fact]
-        public void JsonReportFileComponent_ShouldHaveLanguageSetToCs()
+        public void JsonReportFileComponent_ShouldHaveLanguageSet()
         {
             var folderComponent = ReportTestHelper.CreateProjectWith();
             var fileComponent = (CsharpFileLeaf)(folderComponent as CsharpFolderComposite).GetAllFiles().First();
@@ -98,7 +95,7 @@ namespace ExtraProject.XUnit
             var folderComponent = ReportTestHelper.CreateProjectWith();
             foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
             {
-                var jsonReportComponent = new SourceFile(((CsharpFileLeaf)file));
+                var jsonReportComponent = new SourceFile((CsharpFileLeaf)file);
                 foreach (var mutant in file.Mutants)
                 {
                     jsonReportComponent.Mutants.ShouldContain(m => m.Id == mutant.Id.ToString());
@@ -113,7 +110,7 @@ namespace ExtraProject.XUnit
             var folderComponent = ReportTestHelper.CreateProjectWith(duplicateMutant: true);
             foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
             {
-                var jsonReportComponent = new SourceFile(((CsharpFileLeaf)file), loggerMock);
+                var jsonReportComponent = new SourceFile((CsharpFileLeaf)file, loggerMock);
                 foreach (var mutant in file.Mutants)
                 {
                     jsonReportComponent.Mutants.ShouldContain(m => m.Id == mutant.Id.ToString());
@@ -151,6 +148,16 @@ namespace ExtraProject.XUnit
             var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
 
             report.ProjectRoot.ShouldBe("/home/user/src/project/");
+        }
+
+        [Fact]
+        public void JsonReport_ShouldContainFullPath()
+        {
+            var folderComponent = ReportTestHelper.CreateProjectWith();
+
+            var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
+
+            Path.IsPathFullyQualified(report.Files.Keys.First()).ShouldBeFalse("Path should not be a relative path");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/MockJsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/MockJsonReport.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using Stryker.Core.Reporters.Json;
 using Stryker.Core.Reporters.Json.SourceFiles;
 
-namespace Stryker.Core.UnitTest.Reporters
+namespace Stryker.Core.UnitTest.Reporters.Json
 {
     public class MockJsonReport : JsonReport
     {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/MockJsonReportFileComponent.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/MockJsonReportFileComponent.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Stryker.Core.Reporters.Json.SourceFiles;
 
-namespace Stryker.Core.UnitTest.Reporters
+namespace Stryker.Core.UnitTest.Reporters.Json
 {
     public class MockJsonReportFileComponent : SourceFile
     {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
@@ -10,7 +10,7 @@ namespace Stryker.Core.UnitTest.Reporters
 {
     public static class ReportTestHelper
     {
-        public static IProjectComponent CreateProjectWith(bool duplicateMutant = false, int mutationScore = 60)
+        public static IProjectComponent CreateProjectWith(bool duplicateMutant = false, int mutationScore = 60, string root = "/")
         {
             var tree = CSharpSyntaxTree.ParseText("void M(){ int i = 0 + 8; }");
             var originalNode = tree.GetRoot().DescendantNodes().OfType<BinaryExpressionSyntax>().First();
@@ -23,14 +23,14 @@ namespace Stryker.Core.UnitTest.Reporters
                 Type = Mutator.Arithmetic
             };
 
-            var folder = new CsharpFolderComposite { FullPath = "/home/user/src/project/", RelativePath = "" };
-            int mutantCount = 0;
+            var folder = new CsharpFolderComposite { FullPath = $"{root}home/user/src/project/", RelativePath = "" };
+            var mutantCount = 0;
             for (var i = 1; i <= 2; i++)
             {
                 var addedFolder = new CsharpFolderComposite
                 {
                     RelativePath = $"{i}",
-                    FullPath = $"/home/user/src/project/{i}",
+                    FullPath = $"{root}home/user/src/project/{i}",
                 };
                 folder.Add(addedFolder);
 
@@ -40,7 +40,7 @@ namespace Stryker.Core.UnitTest.Reporters
                     addedFolder.Add(new CsharpFileLeaf()
                     {
                         RelativePath = $"{i}/SomeFile{y}.cs",
-                        FullPath = $"/home/user/src/project/{i}/SomeFile{y}.cs",
+                        FullPath = $"{root}home/user/src/project/{i}/SomeFile{y}.cs",
                         Mutants = m,
                         SourceCode = "void M(){ int i = 0 + 8; }"
                     });

--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
@@ -57,7 +57,7 @@ namespace Stryker.Core.Reporters.Json
             return files;
         }
 
-        private static IDictionary<string, SourceFile> GenerateFileReportComponents(IReadOnlyFileLeaf fileComponent) => new Dictionary<string, SourceFile> { { fileComponent.RelativePath, new SourceFile(fileComponent) } };
+        private static IDictionary<string, SourceFile> GenerateFileReportComponents(IReadOnlyFileLeaf fileComponent) => new Dictionary<string, SourceFile> { { fileComponent.FullPath, new SourceFile(fileComponent) } };
 
         private void AddTestFiles(TestProjectsInfo testProjectsInfo)
         {


### PR DESCRIPTION
fix #2564 