### PR TITLE
ci: Stop publishing Stryker.Core for integration test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ variables:
   PackageVersion: '3.9.2'
   VersionBuildNumber: $[counter('3.9.2', 1)]
   IntegrationTestVersion: $(PackageVersion)-alpha.$(VersionBuildNumber)
-  ProjectsToPack: src/Stryker.Core/Stryker.Core/Stryker.Core.csproj;src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
+  ProjectsToPack: src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj
   MygetFeed: https://www.myget.org/F/stryker-mutator-integrationtest
   AzureArtifactFeedUri: https://pkgs.dev.azure.com/stryker-mutator/Stryker/_packaging/stryker-net/nuget/v3/index.json
   MygetFeedUri: https://www.myget.org/F/stryker-mutator-integrationtest/api/v3/index.json
@@ -290,45 +290,6 @@ stages:
         custom: pack
         arguments: --output $(Build.ArtifactStagingDirectory)/release
         workingDirectory: 'src/Stryker.Core/Stryker.Core'
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: release'
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)/release'
-        ArtifactName: release
-
-- stage: PublishBranchReleaseArtifact
-  displayName: Publish Release Artifact
-  dependsOn:
-    - Analysis
-    - IntegrationTests
-  condition: and(not(failed()), and(ne(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranch'], 'refs/heads/master')))
-  jobs:
-  - job: PublishRelease
-    displayName: Publish Release Artifacts
-    steps:
-    - template: pipeline-templates/populate-cache-steps.yml
-    - task: UseDotNet@2
-      displayName: 'Use dotnet 6'
-      inputs:
-        version: 6.x
-    - task: DotNetCoreCLI@2
-      displayName: 'Restore vstest binaries'
-      inputs:
-        command: 'custom'
-        custom: 'restore'
-        arguments: '--packages ./.vstest/'
-        workingDirectory: 'src/Stryker.Core/Stryker.Core/ToolHelpers/'
-    - script: dotnet pack --output $(Build.ArtifactStagingDirectory)/release
-      displayName: 'Pack Stryker.CLI'
-      workingDirectory: 'src/Stryker.CLI/Stryker.CLI'
-    - script: dotnet pack --output $(Build.ArtifactStagingDirectory)/release
-      displayName: 'Pack Stryker.Core'
-      workingDirectory: 'src/Stryker.Core/Stryker.Core'
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: release'
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)/release'
-        ArtifactName: release
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: release'
       inputs:


### PR DESCRIPTION
Since it's not being tested anyway