### PR TITLE
fix: Increase time out before assuming VsTest is frozen

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestMockingHelper.cs
@@ -293,7 +293,7 @@ public class VsTestMockingHelper : TestBase
                         null);
 
                     if (repeated-->0)
-                        Thread.Sleep(5000);
+                        Thread.Sleep(1000);
                 }));
 
     protected void SetupMockCoverageRun(Mock<IVsTestConsoleWrapper> mockVsTest, IReadOnlyDictionary<string, string> coverageResults) => SetupMockCoverageRun(mockVsTest, GenerateCoverageTestResults(coverageResults));

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -9,6 +9,7 @@ using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
+using Stryker.Core.TestRunners.VsTest;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.TestRunners
@@ -192,9 +193,12 @@ namespace Stryker.Core.UnitTest.TestRunners
         public void ShouldNotRetryFrozenVsTest()
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
+            var defaultTimeOut = VsTestRunner.VsTestExtraTimeOutInMs;
             // the test session will end properly, but VsTest will hang
             SetupFrozenVsTest(mockVsTest, 3);
+            VsTestRunner.VsTestExtraTimeOutInMs = 500;
             runner.TestMultipleMutants(SourceProjectInfo, new TimeoutValueCalculator(0, 10,9), new[] { Mutant }, null);
+            VsTestRunner.VsTestExtraTimeOutInMs = defaultTimeOut;
             mockVsTest.Verify(m => m.EndSession(), Times.Exactly(2));
         }
 

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -24,7 +24,9 @@ namespace Stryker.Core.TestRunners.VsTest
         private int _instanceCount;
         private readonly ILogger _logger;
         // safety timeout for VsTestWrapper operations. We assume VsTest crashed if the timeout triggers
-        private const int VsTestWrapperTimeOutInMs = 3*1000;
+
+        public static int VsTestExtraTimeOutInMs { get; set; } = 10 * 1000;
+
         // maximum number of attempts for VsTest sessions, just in case we run into some of VsTest quirks
         private const int MaxAttempts = 3;
 
@@ -270,10 +272,10 @@ namespace Stryker.Core.TestRunners.VsTest
             {
                 // we wait for the end notification for the test session
                 // ==> if it failed, results are uncertain
-                sessionFailed = !eventHandler.Wait(VsTestWrapperTimeOutInMs + timeOut.Value);
+                sessionFailed = !eventHandler.Wait(VsTestExtraTimeOutInMs + timeOut.Value);
                 // we wait for vsTestProcess to stop
                 // ==> if it appears hung, we recycle it.
-                vsTestFailed = !session.Wait(VsTestWrapperTimeOutInMs);
+                vsTestFailed = !session.Wait(VsTestExtraTimeOutInMs);
                 // VsTestHost appears stuck
                 // VsTestWrapper aborts the current test sessions on timeout, except on critical error, so we have an internal timeout (+ grace period)
                 // to detect and properly handle those events. 
@@ -299,7 +301,7 @@ namespace Stryker.Core.TestRunners.VsTest
                 // we could add a configurable timeout, to prevent actual locking to happen during initial tests, but no idea what a good default should be
                 session.Wait();
                 // we add a grace delay for notifications to be propagated
-                eventHandler.Wait(VsTestWrapperTimeOutInMs);
+                eventHandler.Wait(VsTestExtraTimeOutInMs);
             }
             
             eventHandler.ResultsUpdated -= HandlerUpdate;


### PR DESCRIPTION
Testing on project shows that current timeout value before assuming VsTest is frozen is too aggressive, triggering unneeded retries.
This PR increase this value from 3 seconds to 10.
