### PR TITLE
doc(contributing): fixes solution file name 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ While developing on Stryker.NET we advise to work in [the latest Visual Studio](
 
 ### Example: Steps to run Stryker.NET on a local project
 *	Clone the repository `https://github.com/stryker-mutator/stryker-net.git`
-*	Open `Stryker.CLI.sln`
+*	Open `Stryker.sln`
 *	On `Stryker.CLI` open `properties > Debug`
 *	Create a new Debug profile
 *	Set `Launch` as `Project`


### PR DESCRIPTION
There is a small glitch in the steps described to run Stryker.NET on a local project.
The Stryker.CLI.sln file is mentioned but it's actually Stryker.sln that should be used.