### PR TITLE
chore: Fix flaky test

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/SourceProjects/SourceProjectInfoTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/SourceProjects/SourceProjectInfoTests.cs
@@ -8,7 +8,7 @@ using Stryker.Core.Initialisation.Buildalyzer;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Xunit;
 
-namespace Stryker.Core.UnitTest.ProjectCOmponents.SourceProjects
+namespace Stryker.Core.UnitTest.ProjectComponents.SourceProjects
 {
     public class SourceProjectInfoTests : TestBase
     {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectsInfoTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectsInfoTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Stryker.Core.UnitTest.ProjectComponents.TestProjects
 {
-    public class TestProjectsInfoTests
+    public class TestProjectsInfoTests : TestBase
     {
         [Fact]
         public void ShouldGenerateInjectionPath()


### PR DESCRIPTION
So flaky that I can reproduce :D 

https://github.com/stryker-mutator/stryker-net/assets/5451366/c2fdba0f-9157-410d-9061-06ee3831bbb3

I guess due to some object allocation reasons, the logger factory usually happens to be initialized for the TestProjectInfoTests, but looks like the common way to do it here is to inherit `TestBase` which does this in the ctor.