### PR TITLE
docs(readme): link lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For more information read our [getting started](https://stryker-mutator.io/docs/
 
 ## Documentation
 
-For the full documentation on how to use Stryker.NET, see our [configuration docs](https://stryker-mutator.io/docs/stryker-net/Configuration).
+For the full documentation on how to use Stryker.NET, see our [configuration docs](https://stryker-mutator.io/docs/stryker-net/configuration).
 
 ## Migrating
 
@@ -49,7 +49,7 @@ For the full list of all available mutations, see the [mutations docs](https://s
 
 ## Supported Reporters
 
-For the full list of all available reporters, see the [reporter docs](https://stryker-mutator.io/docs/stryker-net/Reporters).
+For the full list of all available reporters, see the [reporter docs](https://stryker-mutator.io/docs/stryker-net/reporters).
 
 ## Contributing
 


### PR DESCRIPTION
due to case sensitivity of stryker-mutator.io

With uppercase first letter (before this change) the browser briefly shows a "page not found" before loading the correct page.
Some browsers (like mine) will keep showing a "do you want to check if a saved version .." at the top of the page.

![image](https://github.com/stryker-mutator/stryker-net/assets/63558489/02536685-257b-4f13-8fdd-8382b30040e4)
