### PR TITLE
fix: Don't fail the test run if restoring test assemblies fails

### DIFF
--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProjectsInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProjectsInfo.cs
@@ -43,7 +43,14 @@ namespace Stryker.Core.ProjectComponents.TestProjects
                 var backupFilePath = GetBackupName(injectionPath);
                 if (_fileSystem.File.Exists(backupFilePath))
                 {
-                    _fileSystem.File.Copy(backupFilePath, injectionPath, true);
+                    try
+                    {
+                        _fileSystem.File.Copy(backupFilePath, injectionPath, true);
+                    }
+                    catch (IOException ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to restore output assembly {Path}. Mutated assembly is still in place.", injectionPath);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is a workaround for a relatively common issue where test assemblies are still in use by Windows Error Reporting (most likely) if there are crashes (e.g., stack overflows). It can be really painful when at the end of a long test run this happens and all results are just thrown away.

```
Unhandled exception. System.IO.IOException: The process cannot access the file 'C:\_work\1\s\artifacts\bin\Stryker\nnnn\net7.0\nnnn.dll' because it is being used by another process.
   at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at System.IO.Abstractions.FileWrapper.Copy(String sourceFileName, String destFileName, Boolean overwrite)
   at Stryker.Core.ProjectComponents.TestProjects.TestProjectsInfo.RestoreOriginalAssembly(IAnalyzerResult sourceProject) in /_/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProjectsInfo.cs:line 46
   at Stryker.Core.MutationTest.MutationTestProcess.Restore() in /_/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs:line 105
   at Stryker.Core.StrykerRunner.RunMutationTest(IStrykerInputs inputs, ILoggerFactory loggerFactory, IProjectOrchestrator projectOrchestrator) in /_/src/Stryker.Core/Stryker.Core/StrykerRunner.cs:line 125
   at Stryker.CLI.StrykerCli.RunStryker(IStrykerInputs inputs) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 93
   at Stryker.CLI.StrykerCli.<>c__DisplayClass10_0.<Run>b__0() in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 68
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass143_0.<OnExecute>b__0(CancellationToken _)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Stryker.CLI.StrykerCli.Run(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 74
   at Stryker.CLI.Program.Main(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/Program.cs:line 14
```