### PR TITLE
chore: Passing Stryker options to F# project components

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/FsharpProjectComponentsBuilder.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/FsharpProjectComponentsBuilder.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.Extensions.Logging;
 using Microsoft.FSharp.Control;
 using Stryker.Core.Exceptions;
+using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using System;
@@ -19,12 +20,14 @@ namespace Stryker.Core.Initialisation
     internal class FsharpProjectComponentsBuilder : ProjectComponentsBuilder
     {
         private readonly SourceProjectInfo _projectInfo;
+        private readonly StrykerOptions _options;
         private readonly string[] _foldersToExclude;
         private readonly ILogger _logger;
 
-        public FsharpProjectComponentsBuilder(SourceProjectInfo projectInfo, string[] foldersToExclude, ILogger logger, IFileSystem fileSystem) : base(fileSystem)
+        public FsharpProjectComponentsBuilder(SourceProjectInfo projectInfo, StrykerOptions options, string[] foldersToExclude, ILogger logger, IFileSystem fileSystem) : base(fileSystem)
         {
             _projectInfo = projectInfo;
+            _options = options;
             _foldersToExclude = foldersToExclude;
             _logger = logger;
         }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -370,6 +370,7 @@ namespace Stryker.Core.Initialisation
 
                 Language.Fsharp => new FsharpProjectComponentsBuilder(
                     projectInfo,
+                    options,
                     _foldersToExclude,
                     _logger,
                     FileSystem),


### PR DESCRIPTION
Part of [this PR](https://github.com/stryker-mutator/stryker-net/pull/2645).

This is just aligning the code flow with C#. Options will be of use.