### PR TITLE
Fix issue for Buildalyzer couldn't fin sourcefiles

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/TargetFrameworkResolutionTests.cs
@@ -25,7 +25,10 @@ namespace Stryker.Core.UnitTest.Initialisation
             analyzerManagerMock
                 .Setup(m => m.GetProject(It.IsAny<string>()))
                 .Returns(projectAnalyzerMock.Object);
-
+            analyzerManagerMock
+                .Setup(m => m.SolutionFilePath)
+                .Returns((string)null);
+            
             projectAnalyzerMock
                 .Setup(m => m.Build())
                 .Returns(analyzerResultsMock.Object);

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectFileReader.cs
@@ -53,7 +53,10 @@ namespace Stryker.Core.Initialisation
             string targetFramework,
             string msBuildPath = null)
         {
-
+            // Buildalyzers need solution path 
+            if (string.IsNullOrEmpty(AnalyzerManager.SolutionFilePath) && !string.IsNullOrEmpty(solutionFilePath)) {
+                _analyzerManager = _analyzerProvider.Provide(solutionFilePath, new AnalyzerManagerOptions{LogWriter = _buildalyzerLog});
+            }
             _logger.LogDebug("Analyzing project file {0}", projectFilePath);
             var analyzerResult = GetProjectInfo(projectFilePath, targetFramework);
             LogAnalyzerResult(analyzerResult);


### PR DESCRIPTION
For specific solution, when csproj is not "standalone" buildable without solution file, we need to get to Buildalyzers the solution file path