### PR TITLE
feat: Retry build with msbuild when dotnet build fails

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -11,6 +11,13 @@ namespace Stryker.Core.UnitTest.Initialisation
 {
     public class InitialBuildProcessTests : TestBase
     {
+        private string _cProjectsExampleCsproj;
+
+        public InitialBuildProcessTests()
+        {
+            _cProjectsExampleCsproj = Environment.OSVersion.Platform == PlatformID.Win32NT ? @"C:\Projects\Example.csproj" : "/usr/projects";
+        }
+
         [Fact]
         public void InitialBuildProcess_ShouldThrowStrykerInputExceptionOnFail()
         {
@@ -20,8 +27,8 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var target = new InitialBuildProcess(processMock.Object);
 
-            Should.Throw<InputException>(() => target.InitialBuild(false, @"C:\Projects\Example.csproj", null))
-                .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"dotnet build \"" + @"C:\Projects\Example.csproj" + "\"\"");
+            Should.Throw<InputException>(() => target.InitialBuild(false, _cProjectsExampleCsproj, null))
+                .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"dotnet build \"" + @"Example.csproj" + "\"\"");
         }
 
         [SkippableFact]
@@ -35,9 +42,28 @@ namespace Stryker.Core.UnitTest.Initialisation
 
             var target = new InitialBuildProcess(processMock.Object);
 
-            Should.Throw<InputException>(() => target.InitialBuild(true, null, @"C:\Projects\Example.csproj", @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
+            Should.Throw<InputException>(() => target.InitialBuild(true, null, _cProjectsExampleCsproj, @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
                 .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
-                                  @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" \"" + @"C:\Projects\Example.csproj" + "\"\"");
+                                  @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" \"" + _cProjectsExampleCsproj + "\"\"");
+        }
+
+        [SkippableFact]
+        public void InitialBuildProcess_WithPathAsBuildCommand_TriesWithMsBuildIfDotnetFails()
+        {
+            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "MSBuild is only available on Windows");
+
+            var processMock = new Mock<IProcessExecutor>(MockBehavior.Strict);
+
+            processMock.SetupProcessMockToReturn("", 2);
+
+            var target = new InitialBuildProcess(processMock.Object);
+
+            Should.Throw<InputException>(() => target.InitialBuild(false, null, _cProjectsExampleCsproj, @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
+                .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
+                                  @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" \"" + _cProjectsExampleCsproj + "\"\"");
+
+            processMock.Verify(x =>x.Start(It.IsAny<string>(), It.Is<string>(app => app.Contains("dotnet")), It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), 0), Times.Once());
+            processMock.Verify(x =>x.Start(It.IsAny<string>(), It.Is<string>(app => app.Contains("MSBuild.exe")), It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), 0), Times.Once());
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
@@ -28,40 +28,57 @@ namespace Stryker.Core.Initialisation
             _logger.LogDebug("Started initial build using {0}", fullFramework ? "msbuild.exe" : "dotnet build");
 
             ProcessResult result;
+            string buildCommand;
+            string buildPath;
             if (fullFramework)
             {
                 if (string.IsNullOrEmpty(solutionPath))
                 {
                     throw new InputException("Stryker could not build your project as no solution file was presented. Please pass the solution path to stryker.");
                 }
-                solutionPath = Path.GetFullPath(solutionPath);
-                var solutionDir = Path.GetDirectoryName(solutionPath);
-                msbuildPath ??= new MsBuildHelper().GetMsBuildPath(_processExecutor);
-
-                // Build project with MSBuild.exe
-                result = _processExecutor.Start(solutionDir, msbuildPath, $"\"{solutionPath}\"");
-                CheckBuildResult(result, msbuildPath, $"\"{solutionPath}\"");
+                result = BuildSolutionWithMsBuild(ref solutionPath, ref msbuildPath);
+                buildCommand = msbuildPath;
+                buildPath = solutionPath;
             }
             else
             {
-                var buildPath = !string.IsNullOrEmpty(solutionPath) ? solutionPath : Path.GetFileName(projectPath);
+                buildPath = !string.IsNullOrEmpty(solutionPath) ? solutionPath : Path.GetFileName(projectPath);
+                buildCommand = "dotnet build";
 
                 _logger.LogDebug("Initial build using path: {buildPath}", buildPath);
                 // Build with dotnet build
                 result = _processExecutor.Start(projectPath, "dotnet", $"build \"{buildPath}\"");
+                if (result.ExitCode!=ExitCodes.Success && !string.IsNullOrEmpty(solutionPath))
+                {
+                    _logger.LogWarning("Dotnet build failed, trying with MsBuild.");
+                    buildCommand = msbuildPath;
+                    result = BuildSolutionWithMsBuild(ref solutionPath, ref msbuildPath);
+                }
 
-                CheckBuildResult(result, "dotnet build", $"\"{projectPath}\"");
             }
+            CheckBuildResult(result, buildCommand, $"\"{buildPath}\"");
+        }
+
+        private ProcessResult BuildSolutionWithMsBuild(ref string solutionPath, ref string msbuildPath)
+        {
+            solutionPath = Path.GetFullPath(solutionPath);
+            var solutionDir = Path.GetDirectoryName(solutionPath);
+            msbuildPath ??= new MsBuildHelper().GetMsBuildPath(_processExecutor);
+
+            // Build project with MSBuild.exe
+            var result = _processExecutor.Start(solutionDir, msbuildPath, $"\"{solutionPath}\"");
+            return result;
         }
 
         private void CheckBuildResult(ProcessResult result, string buildCommand, string buildPath)
         {
-            _logger.LogTrace("Initial build output {0}", result.Output);
             if (result.ExitCode != ExitCodes.Success)
             {
+                _logger.LogError("Initial build failed: {0}", result.Output);
                 // Initial build failed
                 throw new InputException(result.Output, FormatBuildResultErrorString(buildCommand, buildPath));
             }
+            _logger.LogTrace("Initial build output {0}", result.Output);
             _logger.LogDebug("Initial build successful");
         }
 


### PR DESCRIPTION
Add a retry logic for initial build. If a solution fails to build with `dotnet build`, Stryker simply retries with `MsBuild` instead.

Fixes #2668 
EDIT: I did some manual testing of this by adding a SQL project to some netcore project: it fails without the fix and succeed with.