### PR TITLE
"NoCover" mutants can be optionally ignored

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -650,3 +650,11 @@ Command line: `--break-on-initial-test-failure`
 Config file: `break-on-initial-test-failure`
 
 Instruct Stryker to break execution when at least one test failed on initial test run.
+
+### `ignore-uncovered-mutants` <`flag`>
+
+Default: `false`  
+Command line: `--ignore-uncovered-mutants`  
+Config file: `ignore-uncovered-mutants`
+
+Instruct Stryker to ignore all NoCoverage mutants, so that the mutation score reflects the quality of existing tests.

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
@@ -126,6 +126,7 @@ namespace Stryker.CLI.UnitTest
             inputs.Setup(x => x.IgnoredMethodsInput).Returns(new IgnoreMethodsInput());
             inputs.Setup(x => x.ReportFileNameInput).Returns(new ReportFileNameInput());
             inputs.Setup(x => x.BreakOnInitialTestFailureInput).Returns(new BreakOnInitialTestFailureInput());
+            inputs.Setup(x => x.IgnoredUncoveredMutantsInput).Returns(new IgnoreUncoveredMutantsInput());
             inputs.Setup(x => x.OutputPathInput).Returns(new OutputPathInput());
 
             return inputs;

--- a/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/CommandLineConfig/CommandLineConfigReader.cs
@@ -140,6 +140,7 @@ namespace Stryker.CLI
             AddCliInput(inputs.OutputPathInput, "output", "O", optionType: CommandOptionType.SingleValue, category: InputCategory.Reporting);
             // Category: Misc
             AddCliInput(inputs.BreakOnInitialTestFailureInput, "break-on-initial-test-failure", null, optionType: CommandOptionType.NoValue, category: InputCategory.Misc);
+            AddCliInput(inputs.IgnoredUncoveredMutantsInput, "ignore-uncovered-mutants", null, optionType: CommandOptionType.NoValue, category: InputCategory.Misc);
             AddCliInput(inputs.DevModeInput, "dev-mode", null, optionType: CommandOptionType.NoValue, category: InputCategory.Misc);
         }
 

--- a/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileBasedInput.cs
@@ -91,6 +91,9 @@ namespace Stryker.CLI
         [JsonPropertyName("break-on-initial-test-failure")]
         public bool? BreakOnInitialTestFailure { get; init; }
 
+        [JsonPropertyName("ignore-uncovered-mutants")]
+        public bool? IgnoredUncoveredMutants { get; init; }
+
         [JsonExtensionData]
         public Dictionary<string, JsonElement> ExtraData { get; init; }
     }

--- a/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
@@ -62,6 +62,7 @@ namespace Stryker.CLI
 
             inputs.ReportFileNameInput.SuppliedInput = config.ReportFileName;
             inputs.BreakOnInitialTestFailureInput.SuppliedInput = config.BreakOnInitialTestFailure;
+            inputs.IgnoredUncoveredMutantsInput.SuppliedInput = config.IgnoredUncoveredMutants;
         }
 
         private static FileBasedInput LoadConfig(string configFilePath)

--- a/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
+++ b/src/Stryker.Core/Stryker.Core/CoverageAnalysis/CoverageAnalyser.cs
@@ -121,7 +121,7 @@ namespace Stryker.Core.CoverageAnalysis
             // assess status according to actual coverage
             if (mutant.CoveringTests.IsEmpty && mutant.ResultStatus == MutantStatus.Pending)
             {
-                mutant.ResultStatus = MutantStatus.NoCoverage;
+                mutant.ResultStatus = _options.IgnoreUncoveredMutants ? MutantStatus.Ignored : MutantStatus.NoCoverage;
                 mutant.ResultStatusReason = "Not covered by any test.";
                 _logger.LogDebug($"Mutant {mutant.Id} is not covered by any test.");
             }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreUncoveredMutantsInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreUncoveredMutantsInput.cs
@@ -1,0 +1,14 @@
+namespace Stryker.Core.Options.Inputs
+{
+    public class IgnoreUncoveredMutantsInput : Input<bool?>
+    {
+        public override bool? Default => false;
+
+        protected override string Description => "Instruct Stryker to ignore all No Coverage mutants, so that the mutation score reflects the quality of existing tests.";
+
+        public bool Validate()
+        {
+            return SuppliedInput == true;
+        }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
@@ -48,6 +48,7 @@ namespace Stryker.Core.Options
         OpenReportInput OpenReportInput { get; init; }
         OpenReportEnabledInput OpenReportEnabledInput { get; init; }
         BreakOnInitialTestFailureInput BreakOnInitialTestFailureInput { get; init; }
+        IgnoreUncoveredMutantsInput IgnoredUncoveredMutantsInput { get; init; }
 
         StrykerOptions ValidateAll();
     }
@@ -104,6 +105,7 @@ namespace Stryker.Core.Options
         public OpenReportInput OpenReportInput { get; init; } = new();
         public OpenReportEnabledInput OpenReportEnabledInput { get; init; } = new();
         public BreakOnInitialTestFailureInput BreakOnInitialTestFailureInput { get; init; } = new();
+        public IgnoreUncoveredMutantsInput IgnoredUncoveredMutantsInput { get; init; } = new();
 
         public StrykerOptions ValidateAll()
         {
@@ -165,6 +167,7 @@ namespace Stryker.Core.Options
                 SinceTarget = sinceTarget,
                 ReportTypeToOpen = OpenReportInput.Validate(OpenReportEnabledInput.Validate()),
                 BreakOnInitialTestFailure = BreakOnInitialTestFailureInput.Validate(),
+                IgnoreUncoveredMutants = IgnoredUncoveredMutantsInput.Validate(),
             };
             return _strykerOptionsCache;
         }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -234,6 +234,8 @@ namespace Stryker.Core.Options
         /// </summary>
         public bool BreakOnInitialTestFailure { get; set; }
 
+        public bool IgnoreUncoveredMutants { get; set; }
+
         // Keep a reference on the parent instance in order to flow get/set properties (ProjectName and ProjectVersion) up to the parent
         // This is required for the dashboard reporter to work properly
         private StrykerOptions _parentOptions;
@@ -280,6 +282,7 @@ namespace Stryker.Core.Options
             Thresholds = Thresholds,
             WithBaseline = WithBaseline,
             BreakOnInitialTestFailure = BreakOnInitialTestFailure,
+            IgnoreUncoveredMutants = IgnoreUncoveredMutants,
         };
     }
 }


### PR DESCRIPTION
We'd like to leverage the thresholds and mutation score feature that already exists in stryker, but we already have a fairly robust system in place for enforcing code coverage, so having stryker mix surviving mutants and "NoCover" mutants together when calculating the mutation score is problematic for us.  We would prefer to use stryker to only measure the quality of our existing unit tests.

https://github.com/stryker-mutator/stryker-net/issues/2709