### PR TITLE
fix: Validation on Since enablement when Baseline is also enabled

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
@@ -166,8 +166,8 @@ namespace Stryker.Core.UnitTest.Options
         [Fact]
         public void WithBaselineShouldNotThrow_2743() // https://github.com/stryker-mutator/stryker-net/issues/2743
         {
+            _target.ProjectVersionInput.SuppliedInput = "1";
             _target.WithBaselineInput.SuppliedInput = true;
-            _target.SinceInput.SuppliedInput = true;
 
             Should.NotThrow(() => _target.ValidateAll());
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using Shouldly;
-using Stryker.Core.Exceptions;
 using Stryker.Core.Baseline.Providers;
+using Stryker.Core.Exceptions;
 using Stryker.Core.Options;
 using Stryker.Core.Options.Inputs;
 using Xunit;
@@ -10,7 +10,7 @@ namespace Stryker.Core.UnitTest.Options
 {
     public class StrykerInputsTests : TestBase
     {
-        private StrykerInputs _target = new StrykerInputs()
+        private readonly StrykerInputs _target = new StrykerInputs()
         {
 
             AdditionalTimeoutInput = new AdditionalTimeoutInput(),
@@ -161,6 +161,15 @@ namespace Stryker.Core.UnitTest.Options
 
             var exception = Should.Throw<InputException>(() => _target.ValidateAll());
             exception.Message.ShouldBe("The since and baseline features are mutually exclusive.");
+        }
+
+        [Fact]
+        public void WithBaselineShouldNotThrow_2743() // https://github.com/stryker-mutator/stryker-net/issues/2743
+        {
+            _target.WithBaselineInput.SuppliedInput = true;
+            _target.SinceInput.SuppliedInput = true;
+
+            Should.NotThrow(() => _target.ValidateAll());
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceInput.cs
@@ -12,7 +12,7 @@ namespace Stryker.Core.Options.Inputs
         {
             if (withBaseline.IsNotNullAndTrue())
             {
-                if (SuppliedInput.Value)
+                if (SuppliedInput.HasValue && SuppliedInput.Value)
                 {
                     throw new InputException("The since and baseline features are mutually exclusive.");
                 }

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/SinceInput.cs
@@ -12,7 +12,7 @@ namespace Stryker.Core.Options.Inputs
         {
             if (withBaseline.IsNotNullAndTrue())
             {
-                if (SuppliedInput.HasValue)
+                if (SuppliedInput.Value)
                 {
                     throw new InputException("The since and baseline features are mutually exclusive.");
                 }


### PR DESCRIPTION
fix #2743 