### PR TITLE
Correctly add test projects to strykerOptions TestProjects in solution mode for use in filters

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/DiffProviders/GitDiffProviderTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using DotNet.Globbing;
 using LibGit2Sharp;
 using Moq;
 using Shouldly;
@@ -25,7 +24,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             var gitInfoProvider = new Mock<IGitInfoProvider>(MockBehavior.Strict);
 
-            Action act = () => new GitDiffProvider(options, null, gitInfoProvider.Object);
+            Action act = () => new GitDiffProvider(options, gitInfoProvider.Object);
 
             act.ShouldNotThrow();
 
@@ -92,7 +91,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -156,7 +155,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -204,7 +203,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.Setup(x => x.DetermineCommit()).Returns((Commit)null);
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             Should.Throw<InputException>(() => target.ScanDiff());
         }
@@ -275,7 +274,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -351,7 +350,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns(FilePathUtils.NormalizePathSeparators("/c/Path/To/Repo"));
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -427,7 +426,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns(FilePathUtils.NormalizePathSeparators("/c/Path/To/Repo"));
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -498,7 +497,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -588,7 +587,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();
@@ -675,7 +674,7 @@ namespace Stryker.Core.UnitTest.DiffProviders
 
             gitInfoMock.SetupGet(x => x.Repository).Returns(repositoryMock.Object);
             gitInfoMock.SetupGet(x => x.RepositoryPath).Returns("/c/Path/To/Repo");
-            var target = new GitDiffProvider(options, null, gitInfoMock.Object);
+            var target = new GitDiffProvider(options, gitInfoMock.Object);
 
             // Act
             var res = target.ScanDiff();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
@@ -32,7 +32,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         public ProjectOrchestratorTests()
         {
             _mutationTestProcessMock.Setup(x => x.Mutate());
-            _projectMutatorMock.Setup(x => x.MutateProject(It.IsAny<StrykerOptions>(),  It.IsAny<MutationTestInput>(), It.IsAny<IReporter>()))
+            _projectMutatorMock.Setup(x => x.MutateProject(It.IsAny<StrykerOptions>(), It.IsAny<MutationTestInput>(), It.IsAny<IReporter>()))
                 .Returns(new Mock<IMutationTestProcess>().Object);
             var currentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var filesystemRoot = Path.GetPathRoot(currentDirectory);
@@ -54,11 +54,11 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
 
             var csPathName = _fileSystem.Path.Combine(_projectPath, "someFile.cs");
-            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object, 
+            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object,
                 TestProjectAnalyzerMock(testCsprojPathName, csprojPathName).Object, out var mockRunner);
 
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -80,7 +80,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
 
             var csPathName = _fileSystem.Path.Combine(_projectPath, "someFile.cs");
-            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object, 
+            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object,
                 TestProjectAnalyzerMock(testCsprojPathName, csprojPathName).Object, out var mockRunner);
 
             // act
@@ -102,11 +102,11 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
 
             var csPathName = _fileSystem.Path.Combine(_projectPath, "someFile.cs");
-            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object, 
+            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object,
                 TestProjectAnalyzerMock(testCsprojPathName, csprojPathName).Object, out var mockRunner);
-            
+
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var mutateAction = () => target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -129,11 +129,11 @@ namespace Stryker.Core.UnitTest.Initialisation
             };
 
             var csPathName = _fileSystem.Path.Combine(_projectPath, "someFile.cs");
-            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object, 
+            var target = BuildProjectOrchestratorForSimpleProject(SourceProjectAnalyzerMock(csprojPathName, new[] { csPathName }).Object,
                 TestProjectAnalyzerMock(testCsprojPathName, csprojPathName).Object, out var mockRunner);
-            
+
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -158,10 +158,10 @@ namespace Stryker.Core.UnitTest.Initialisation
             var properties1 = new Dictionary<string, string>
                 { { "IsTestProject", "True" }, { "Language", "F#" } };
             var target = BuildProjectOrchestratorForSimpleProject(BuildProjectAnalyzerMock(csprojPathName, new[] { csPathName }, properties, new List<string>()).Object,
-                BuildProjectAnalyzerMock(testCsprojPathName, Array.Empty<string>(), properties1, new List<string>{ csprojPathName}).Object, out var mockRunner);
-            
+                BuildProjectAnalyzerMock(testCsprojPathName, Array.Empty<string>(), properties1, new List<string> { csprojPathName }).Object, out var mockRunner);
+
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -195,7 +195,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var target = BuildProjectOrchestrator(analyzerResults, out var mockRunner);
 
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -233,6 +233,36 @@ namespace Stryker.Core.UnitTest.Initialisation
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
             // assert
             result.Count.ShouldBe(2);
+        }
+
+        [Fact]
+        public void ShouldFindTestProjectsAndReportThemInStrykerOptions()
+        {
+            // arrange
+            var testCsprojPathName = _fileSystem.Path.Combine(_projectPath, "testproject.csproj");
+            var csprojPathName = _fileSystem.Path.Combine(_projectPath, "sourceproject.csproj");
+            var options = new StrykerOptions
+            {
+                ProjectPath = _projectPath,
+                SolutionPath = _fileSystem.Path.Combine(_projectPath, "MySolution.sln")
+            };
+            var libraryProject = _fileSystem.Path.Combine(_projectPath, "libraryproject.csproj");
+
+            // The analyzer finds two projects
+            var analyzerResults = new Dictionary<string, IProjectAnalyzer>
+            {
+                { "MyProject", SourceProjectAnalyzerMock(csprojPathName, new[]
+                        { _fileSystem.Path.Combine(_projectPath, "someFile.cs")}
+                    , new[] {libraryProject}).Object },
+                { "MyProject.UnitTests", TestProjectAnalyzerMock(testCsprojPathName, csprojPathName).Object }
+            };
+            var target = BuildProjectOrchestrator(analyzerResults, out var mockRunner);
+
+            _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
+            // act
+            _ = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
+            // assert
+            options.TestProjects.Count().ShouldBe(1);
         }
 
         [Fact]
@@ -290,7 +320,7 @@ namespace Stryker.Core.UnitTest.Initialisation
             var target = BuildProjectOrchestrator(analyzerResults, out var mockRunner);
 
             _fileSystem.Directory.SetCurrentDirectory(_fileSystem.Path.GetFullPath(testCsprojPathName));
-            
+
             // act
             var result = target.MutateProjects(options, _reporterMock.Object, mockRunner.Object).ToList();
 
@@ -366,7 +396,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         {
             var properties = new Dictionary<string, string>
                 { { "IsTestProject", "False" }, { "ProjectTypeGuids", "not testproject" }, { "Language", "C#" } };
-            projectReferences??= new List<string>();
+            projectReferences ??= new List<string>();
 
             return BuildProjectAnalyzerMock(csprojPathName, sourceFiles, properties, projectReferences);
         }
@@ -380,7 +410,7 @@ namespace Stryker.Core.UnitTest.Initialisation
         /// <remarks>the test project references the production code project and contains no source file</remarks>
         private Mock<IProjectAnalyzer> TestProjectAnalyzerMock(string testCsprojPathName, string csprojPathName)
         {
-            var properties = new Dictionary<string, string>{ { "IsTestProject", "True" }, { "Language", "C#" } };
+            var properties = new Dictionary<string, string> { { "IsTestProject", "True" }, { "Language", "C#" } };
 
             return BuildProjectAnalyzerMock(testCsprojPathName, Array.Empty<string>(), properties, new List<string> { csprojPathName });
         }

--- a/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/DiffProviders/GitDiffProvider.cs
@@ -4,20 +4,17 @@ using System.Linq;
 using LibGit2Sharp;
 using Stryker.Core.Baseline.Providers;
 using Stryker.Core.Exceptions;
-using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 
 namespace Stryker.Core.DiffProviders
 {
     public class GitDiffProvider : IDiffProvider
     {
-        public TestSet Tests { get; }
         private readonly StrykerOptions _options;
         private readonly IGitInfoProvider _gitInfoProvider;
 
-        public GitDiffProvider(StrykerOptions options, TestSet tests, IGitInfoProvider gitInfoProvider = null)
+        public GitDiffProvider(StrykerOptions options, IGitInfoProvider gitInfoProvider = null)
         {
-            Tests = tests;
             _options = options;
             _gitInfoProvider = gitInfoProvider ?? new GitInfoProvider(options);
         }

--- a/src/Stryker.Core/Stryker.Core/DiffProviders/IDiffProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/DiffProviders/IDiffProvider.cs
@@ -1,11 +1,7 @@
-using Stryker.Core.Mutants;
-
 namespace Stryker.Core.DiffProviders
 {
     public interface IDiffProvider
     {
         DiffResult ScanDiff();
-
-        TestSet Tests { get; }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -77,6 +77,10 @@ namespace Stryker.Core.Initialisation
             var projectsUnderTestAnalyzerResult = solutionAnalyzerResults.Where(p => !p.IsTestProject()).ToList();
             _logger.LogInformation("Found {0} source projects", projectsUnderTestAnalyzerResult.Count);
             _logger.LogInformation("Found {0} test projects", solutionTestProjects.Count);
+            if (options.IsSolutionContext)
+            {
+                options.TestProjects = solutionTestProjects.Select(analyzerResult => new FileInfo(analyzerResult.ProjectFilePath).DirectoryName).ToArray();
+            }
 
             var dependents = FindDependentProjects(projectsUnderTestAnalyzerResult);
             if (!string.IsNullOrEmpty(options.SourceProjectName))

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/MutantFilterFactory.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Stryker.Core.Baseline.Providers;
 using Stryker.Core.DiffProviders;
+using Stryker.Core.Logging;
+using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
 using Stryker.Core.Options;
 
@@ -14,10 +17,18 @@ namespace Stryker.Core.MutantFilters
         private static IGitInfoProvider _gitInfoProvider;
         private static IBaselineProvider _baselineProvider;
         private static MutationTestInput _input;
+        private static readonly ILogger _logger;
+        private static DiffResult _diffResult;
+        private static TestSet _tests;
+
+        static MutantFilterFactory()
+        {
+            _logger = ApplicationLogging.LoggerFactory.CreateLogger(nameof(MutantFilterFactory));
+        }
 
         public static IMutantFilter Create(StrykerOptions options, MutationTestInput mutationTestInput,
-            IDiffProvider diffProvider = null, IBaselineProvider baselineProvider = null,
-            IGitInfoProvider gitInfoProvider = null)
+                IDiffProvider diffProvider = null, IBaselineProvider baselineProvider = null,
+                IGitInfoProvider gitInfoProvider = null)
         {
             if (options == null)
             {
@@ -25,7 +36,7 @@ namespace Stryker.Core.MutantFilters
             }
 
             _input = mutationTestInput;
-            _diffProvider = diffProvider ;
+            _diffProvider = diffProvider;
             _baselineProvider = baselineProvider;
             _gitInfoProvider = gitInfoProvider;
 
@@ -49,7 +60,8 @@ namespace Stryker.Core.MutantFilters
             }
             if (options.Since || options.WithBaseline)
             {
-                enabledFilters.Add(new SinceMutantFilter(_diffProvider ?? new GitDiffProvider(options, _input.TestRunner.GetTests(_input.SourceProjectInfo))));
+                ScanDiff(options);
+                enabledFilters.Add(new SinceMutantFilter(_diffResult, _tests));
             }
             if (options.ExcludedLinqExpressions.Any())
             {
@@ -59,9 +71,42 @@ namespace Stryker.Core.MutantFilters
             return enabledFilters;
         }
 
+        private static void ScanDiff(StrykerOptions options)
+        {
+            if (_diffResult is null)
+            {
+                _tests = _input.TestRunner.GetTests(_input.SourceProjectInfo);
+                _diffProvider ??= new GitDiffProvider(options, _gitInfoProvider);
+
+                _diffResult = _diffProvider.ScanDiff();
+
+                if (_diffResult is not null)
+                {
+                    _logger.LogInformation("{NumberOf} files changed",
+                            (_diffResult.ChangedSourceFiles?.Count ?? 0) + (_diffResult.ChangedTestFiles?.Count ?? 0));
+
+                    if (_diffResult.ChangedSourceFiles is not null)
+                    {
+                        foreach (var changedFile in _diffResult.ChangedSourceFiles)
+                        {
+                            _logger.LogInformation("Changed file {SourceFile}", changedFile);
+                        }
+                    }
+
+                    if (_diffResult.ChangedTestFiles is not null)
+                    {
+                        foreach (var changedFile in _diffResult.ChangedTestFiles)
+                        {
+                            _logger.LogInformation("Changed test file {TestFile}", changedFile);
+                        }
+                    }
+                }
+            }
+        }
+
         private sealed class ByMutantFilterType : IComparer<IMutantFilter>
         {
-            public int Compare(IMutantFilter x, IMutantFilter y) => x?.Type.CompareTo(y?.Type) ?? -1; 
+            public int Compare(IMutantFilter x, IMutantFilter y) => x?.Type.CompareTo(y?.Type) ?? -1;
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
@@ -1,13 +1,11 @@
-
-using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.DiffProviders;
 using Stryker.Core.Logging;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
 using Stryker.Core.ProjectComponents;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Stryker.Core.MutantFilters
 {
@@ -20,32 +18,12 @@ namespace Stryker.Core.MutantFilters
         public MutantFilter Type => MutantFilter.Since;
         public string DisplayName => "since filter";
 
-        public SinceMutantFilter(IDiffProvider diffProvider = null)
+        public SinceMutantFilter(DiffResult diffResult, TestSet tests)
         {
             _logger = ApplicationLogging.LoggerFactory.CreateLogger<SinceMutantFilter>();
 
-            _diffResult = diffProvider.ScanDiff();
-            _tests = diffProvider.Tests;
-
-            if (_diffResult != null)
-            {
-                _logger.LogInformation("{0} files changed", (_diffResult.ChangedSourceFiles?.Count ?? 0) + (_diffResult.ChangedTestFiles?.Count ?? 0));
-
-                if (_diffResult.ChangedSourceFiles != null)
-                {
-                    foreach (var changedFile in _diffResult.ChangedSourceFiles)
-                    {
-                        _logger.LogInformation("Changed file {0}", changedFile);
-                    }
-                }
-                if (_diffResult.ChangedTestFiles != null)
-                {
-                    foreach (var changedFile in _diffResult.ChangedTestFiles)
-                    {
-                        _logger.LogInformation("Changed test file {0}", changedFile);
-                    }
-                }
-            }
+            _diffResult = diffResult;
+            _tests = tests;
         }
 
         public IEnumerable<Mutant> FilterMutants(IEnumerable<Mutant> mutants, IReadOnlyFileLeaf file, StrykerOptions options)

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -96,7 +96,7 @@ namespace Stryker.Core.Options
         /// <summary>
         /// When not empty, use these test projects to test the project under test.
         /// </summary>
-        public IEnumerable<string> TestProjects { get; init; } = Enumerable.Empty<string>();
+        public IEnumerable<string> TestProjects { get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// Filters out tests in the project using the given expression.


### PR DESCRIPTION
The Since filter bases the testproject detection on the strykerOptions TestProjects property. This is currently not being filled in solution mode.

This PR fixes this issue and addresses issue: https://github.com/stryker-mutator/stryker-net/issues/2748