### PR TITLE
fix(real-time): naming inconsistencies

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/HtmlReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/HtmlReporterTests.cs
@@ -10,7 +10,7 @@ using Stryker.Core.Options;
 using Stryker.Core.Options.Inputs;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters.Html;
-using Stryker.Core.Reporters.Html.Realtime;
+using Stryker.Core.Reporters.Html.RealTime;
 using Stryker.Core.Reporters.WebBrowserOpener;
 using Xunit;
 
@@ -18,9 +18,7 @@ namespace Stryker.Core.UnitTest.Reporters.Html
 {
     public class HtmlReporterTests : TestBase
     {
-        private readonly Mock<IRealtimeMutantHandler> _handlerMock;
-
-        public HtmlReporterTests() => _handlerMock = new Mock<IRealtimeMutantHandler>();
+        private readonly Mock<IRealTimeMutantHandler> _handlerMock = new();
 
         [Fact]
         public void ShouldWriteJsonToFile()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/Events/SseEventTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/Events/SseEventTest.cs
@@ -1,7 +1,7 @@
-﻿using Stryker.Core.Reporters.Html.Realtime.Events;
+﻿using Stryker.Core.Reporters.Html.RealTime.Events;
 using Xunit;
 
-namespace Stryker.Core.UnitTest.Reporters.Html.Realtime.Events;
+namespace Stryker.Core.UnitTest.Reporters.Html.RealTime.Events;
 
 public class SseEventTest : TestBase
 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/Events/SseEventTypeTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/Events/SseEventTypeTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Shouldly;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 using Xunit;
 
-namespace Stryker.Core.UnitTest.Reporters.Html.Realtime.Events;
+namespace Stryker.Core.UnitTest.Reporters.Html.RealTime.Events;
 
 public class SseEventTypeTest : TestBase
 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/RealTimeMutantHandlerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/RealTimeMutantHandlerTest.cs
@@ -3,23 +3,21 @@ using Microsoft.CodeAnalysis.CSharp;
 using Moq;
 using Shouldly;
 using Stryker.Core.Mutants;
-using Stryker.Core.Reporters.Html.Realtime;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 using Stryker.Core.Reporters.Json.SourceFiles;
 using Xunit;
 
-namespace Stryker.Core.UnitTest.Reporters.Html.Realtime;
+namespace Stryker.Core.UnitTest.Reporters.Html.RealTime;
 
-public class RealtimeMutantHandlerTest : TestBase
+public class RealTimeMutantHandlerTest : TestBase
 {
-    private readonly Mock<ISseServer> _sseEventSenderMock;
-
-    public RealtimeMutantHandlerTest() => _sseEventSenderMock = new Mock<ISseServer>();
+    private readonly Mock<ISseServer> _sseEventSenderMock = new();
 
     [Fact]
     public void ShouldOpenSseEndpoint()
     {
-        var sut = new RealtimeMutantHandler(null, _sseEventSenderMock.Object);
+        var sut = new RealTimeMutantHandler(null, _sseEventSenderMock.Object);
 
         sut.OpenSseEndpoint();
 
@@ -41,7 +39,7 @@ public class RealtimeMutantHandlerTest : TestBase
             },
             ResultStatus = MutantStatus.Killed,
         };
-        var sut = new RealtimeMutantHandler(null, _sseEventSenderMock.Object);
+        var sut = new RealTimeMutantHandler(null, _sseEventSenderMock.Object);
 
         sut.SendMutantTestedEvent(mutant);
 
@@ -55,7 +53,7 @@ public class RealtimeMutantHandlerTest : TestBase
     public void ShouldCloseSseEndpoint()
     {
         _sseEventSenderMock.Setup(sse => sse.HasConnectedClients).Returns(true);
-        var sut = new RealtimeMutantHandler(null, _sseEventSenderMock.Object);
+        var sut = new RealTimeMutantHandler(null, _sseEventSenderMock.Object);
 
         sut.CloseSseEndpoint();
 
@@ -70,7 +68,7 @@ public class RealtimeMutantHandlerTest : TestBase
     public void ShouldSetPort()
     {
         _sseEventSenderMock.Setup(sse => sse.HasConnectedClients).Returns(true);
-        var sut = new RealtimeMutantHandler(null, _sseEventSenderMock.Object);
+        var sut = new RealTimeMutantHandler(null, _sseEventSenderMock.Object);
         _sseEventSenderMock.Setup(s => s.Port).Returns(8080);
 
         sut.Port.ShouldBeEquivalentTo(8080);
@@ -80,7 +78,7 @@ public class RealtimeMutantHandlerTest : TestBase
     public void ShouldQueueEventsUntilAtleastOneClientIsConnected()
     {
         _sseEventSenderMock.Setup(sse => sse.HasConnectedClients).Returns(false);
-        var sut = new RealtimeMutantHandler(null, _sseEventSenderMock.Object);
+        var sut = new RealTimeMutantHandler(null, _sseEventSenderMock.Object);
 
         var mutant = new Mutant
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/SseServerTest.cs
@@ -4,11 +4,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using LaunchDarkly.EventSource;
 using Shouldly;
-using Stryker.Core.Reporters.Html.Realtime;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 using Xunit;
-  
-namespace Stryker.Core.UnitTest.Reporters.Html.Realtime;
+
+namespace Stryker.Core.UnitTest.Reporters.Html.RealTime;
 
 public class SseServerTest : TestBase
 {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
@@ -77,7 +77,7 @@ public class HtmlReporter : IReporter
         }
 
         var aqua = new Style(Color.Aqua);
-        _console.WriteLine("Hint: by passing \"--open-report or -o\" the report will open automatically and update the report in realtime.", aqua);
+        _console.WriteLine("Hint: by passing \"--open-report or -o\" the report will open automatically and update the report in real-time.", aqua);
     }
 
     public void OnMutantTested(IReadOnlyMutant result)

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
@@ -8,7 +8,7 @@ using Stryker.Core.Options;
 using Stryker.Core.Options.Inputs;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.TestProjects;
-using Stryker.Core.Reporters.Html.Realtime;
+using Stryker.Core.Reporters.Html.RealTime;
 using Stryker.Core.Reporters.Json;
 using Stryker.Core.Reporters.WebBrowserOpener;
 
@@ -20,20 +20,20 @@ public class HtmlReporter : IReporter
     private readonly IFileSystem _fileSystem;
     private readonly IAnsiConsole _console;
     private readonly IWebbrowserOpener _browser;
-    private readonly IRealtimeMutantHandler _mutantHandler;
+    private readonly IRealTimeMutantHandler _mutantHandler;
 
     public HtmlReporter(
         StrykerOptions options,
         IFileSystem fileSystem = null,
         IAnsiConsole console = null,
         IWebbrowserOpener browser = null,
-        IRealtimeMutantHandler mutantHandler = null)
+        IRealTimeMutantHandler mutantHandler = null)
     {
         _options = options;
         _fileSystem = fileSystem ?? new FileSystem();
         _console = console ?? AnsiConsole.Console;
         _browser = browser ?? new CrossPlatformBrowserOpener();
-        _mutantHandler = mutantHandler ?? new RealtimeMutantHandler(_options);
+        _mutantHandler = mutantHandler ?? new RealTimeMutantHandler(_options);
     }
 
     public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent, TestProjectsInfo testProjectsInfo)

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/Events/SseEvent.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/Events/SseEvent.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace Stryker.Core.Reporters.Html.Realtime.Events;
+namespace Stryker.Core.Reporters.Html.RealTime.Events;
 
 public class SseEvent<T>
 {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/Events/SseEventType.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/Events/SseEventType.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Stryker.Core.Reporters.Html.Realtime.Events;
+namespace Stryker.Core.Reporters.Html.RealTime.Events;
 
 public enum SseEventType
 {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/IRealTimeMutantHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/IRealTimeMutantHandler.cs
@@ -1,8 +1,8 @@
 ﻿using Stryker.Core.Mutants;
 
-namespace Stryker.Core.Reporters.Html.Realtime;
+namespace Stryker.Core.Reporters.Html.RealTime;
 
-public interface IRealtimeMutantHandler
+public interface IRealTimeMutantHandler
 {
     public int Port { get; }
 

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/ISseServer.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/ISseServer.cs
@@ -1,7 +1,7 @@
 using System;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 
-namespace Stryker.Core.Reporters.Html.Realtime;
+namespace Stryker.Core.Reporters.Html.RealTime;
 
 public interface ISseServer
 {

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/RealTimeMutantHandler.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/RealTimeMutantHandler.cs
@@ -2,19 +2,19 @@ using System;
 using System.Collections.Generic;
 using Stryker.Core.Mutants;
 using Stryker.Core.Options;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 using Stryker.Core.Reporters.Json.SourceFiles;
 
-namespace Stryker.Core.Reporters.Html.Realtime;
+namespace Stryker.Core.Reporters.Html.RealTime;
 
-public class RealtimeMutantHandler : IRealtimeMutantHandler
+public class RealTimeMutantHandler : IRealTimeMutantHandler
 {
     public int Port => _server.Port;
 
     private readonly ISseServer _server;
     private readonly Queue<JsonMutant> _delayedEventQueue = new();
 
-    public RealtimeMutantHandler(StrykerOptions options, ISseServer server = null)
+    public RealTimeMutantHandler(StrykerOptions options, ISseServer server = null)
     {
         _server = server ?? new SseServer();
         _server.ClientConnected += ClientConnectedHandler;

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/SseServer.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/SseServer.cs
@@ -5,9 +5,9 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Stryker.Core.Reporters.Html.Realtime.Events;
+using Stryker.Core.Reporters.Html.RealTime.Events;
 
-namespace Stryker.Core.Reporters.Html.Realtime;
+namespace Stryker.Core.Reporters.Html.RealTime;
 
 public class SseServer : ISseServer
 {


### PR DESCRIPTION
Mostly `Realtime` -> `RealTime` for namespaces and filenames.