### PR TITLE
Remove the 'please open an issue' part of safe mode error message.

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -234,7 +234,7 @@ namespace Stryker.Core.Compiling
                         errorLocation.StartLinePosition.Character, diagnostic.GetMessage(), brokenMutation);
 
                     Logger.LogWarning(
-                        "Safe Mode! Stryker will try to continue by rolling back all mutations in method. This should not happen, please report this as an issue on github with the previous error message.");
+                        "Safe Mode! Stryker will try to continue by rolling back all mutations in method.");
                     // backup, remove all mutations in the node
 
                     foreach (var mutant in scan.Where(mutant => !suspiciousMutations.Contains(mutant.Node)))


### PR DESCRIPTION
In the past couple of years, all reported issues where non fixable. 
I suggest we keep the warning and remove the 'please open an issue' part.