### PR TITLE
fix(file config): Since and Baseline are implicitly enabled when the config object exists in the config file

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
@@ -65,7 +65,7 @@ namespace Stryker.CLI.UnitTest
             VerifyConfigFileDeserialized(Times.Once());
         }
 
-        private void VerifyConfigFileDeserialized(Times time) => _inputs.VerifyGet(x => x.BaselineProviderInput, time);
+        private void VerifyConfigFileDeserialized(Times time) => _inputs.VerifyGet(x => x.CoverageAnalysisInput, time);
 
         private static CommandLineApplication GetCommandLineApplication()
         {

--- a/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
@@ -21,21 +21,27 @@ namespace Stryker.CLI
             // As json values are first in line we can just overwrite all supplied inputs
             inputs.ConcurrencyInput.SuppliedInput = config.Concurrency;
 
-            // Since is implicitly enabled when the object exists in the file config
+
             if (config.Since is not null)
             {
+                // Since is implicitly enabled when the object exists in the file config
                 inputs.SinceInput.SuppliedInput = config.Since.Enabled ?? true;
-            }
-            // Baseline is implicitly enabled when the object exists in the file config
-            if (config.Baseline is not null)
-            {
-                inputs.WithBaselineInput.SuppliedInput = config.Baseline.Enabled ?? true;
+
+                inputs.SinceTargetInput.SuppliedInput = config.Since.Target;
+                inputs.DiffIgnoreChangesInput.SuppliedInput = config.Since.IgnoreChangesIn;
             }
 
-            inputs.BaselineProviderInput.SuppliedInput = config.Baseline?.Provider;
-            inputs.DiffIgnoreChangesInput.SuppliedInput = config.Since?.IgnoreChangesIn;
-            inputs.FallbackVersionInput.SuppliedInput = config.Baseline?.FallbackVersion;
-            inputs.AzureFileStorageUrlInput.SuppliedInput = config.Baseline?.AzureFileShareUrl;
+            if (config.Baseline is not null)
+            {
+                // Baseline is implicitly enabled when the object exists in the file config
+                inputs.WithBaselineInput.SuppliedInput = config.Baseline.Enabled ?? true;
+
+                inputs.BaselineProviderInput.SuppliedInput = config.Baseline.Provider;
+                inputs.FallbackVersionInput.SuppliedInput = config.Baseline.FallbackVersion;
+                inputs.AzureFileStorageUrlInput.SuppliedInput = config.Baseline.AzureFileShareUrl;
+            }
+
+
             inputs.CoverageAnalysisInput.SuppliedInput = config.CoverageAnalysis;
             inputs.DisableBailInput.SuppliedInput = config.DisableBail;
             inputs.DisableMixMutantsInput.SuppliedInput = config.DisableMixMutants;
@@ -47,7 +53,6 @@ namespace Stryker.CLI
             inputs.ProjectVersionInput.SuppliedInput = config.ProjectInfo?.Version;
             inputs.ReportersInput.SuppliedInput = config.Reporters;
 
-            inputs.SinceTargetInput.SuppliedInput = config.Since?.Target;
             inputs.SolutionInput.SuppliedInput = config.Solution;
             inputs.TargetFrameworkInput.SuppliedInput = config.TargetFramework;
 

--- a/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
@@ -21,13 +21,16 @@ namespace Stryker.CLI
             // As json values are first in line we can just overwrite all supplied inputs
             inputs.ConcurrencyInput.SuppliedInput = config.Concurrency;
 
-            inputs.SinceInput.SuppliedInput =
-                config.Since is not null &&
-                (config.Since.Enabled.HasValue && config.Since.Enabled.Value);
-
-            inputs.WithBaselineInput.SuppliedInput =
-                config.Baseline is not null &&
-                (config.Baseline.Enabled.HasValue && config.Baseline.Enabled.Value);
+            // Since is implicitly enabled when the object exists in the file config
+            if (config.Since is not null)
+            {
+                inputs.SinceInput.SuppliedInput = config.Since.Enabled ?? true;
+            }
+            // Baseline is implicitly enabled when the object exists in the file config
+            if (config.Baseline is not null)
+            {
+                inputs.WithBaselineInput.SuppliedInput = config.Baseline.Enabled ?? true;
+            }
 
             inputs.BaselineProviderInput.SuppliedInput = config.Baseline?.Provider;
             inputs.DiffIgnoreChangesInput.SuppliedInput = config.Since?.IgnoreChangesIn;


### PR DESCRIPTION
fix #2706 