### PR TITLE
fix: Make sure to select valid IAnalyzerResult from Buildalyzer

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -152,7 +152,7 @@ namespace Stryker.Core.Initialisation
                     var projectLogName = Path.GetRelativePath(options.WorkingDirectory, project.ProjectFile.Path);
                     _logger.LogDebug("Analyzing {projectFilePath}", projectLogName);
                     var buildResult = project.Build();
-                    var projectAnalyzerResult = buildResult.Results.FirstOrDefault();
+                    var projectAnalyzerResult = buildResult.Results.FirstOrDefault(a => a.TargetFramework is not null);
                     if (projectAnalyzerResult is not null)
                     {
                         projectsAnalyzerResults.Add(projectAnalyzerResult);
@@ -386,7 +386,7 @@ namespace Stryker.Core.Initialisation
                     _foldersToExclude,
                     _logger,
                     FileSystem),
-                _ => throw new NotSupportedException()
+                _ => throw new NotSupportedException($"Language not supported: {language}")
             };
     }
 }


### PR DESCRIPTION
Just like #1900 but for the InputFileResolver.

This was not an issue until https://github.com/daveaglick/Buildalyzer/pull/198 was reverted in https://github.com/daveaglick/Buildalyzer/commit/8e85a15e324a65f9da5033f3d8a2320c76dda378 for the Buildalyzer 6.0.1 release. Before this change in Buildalyzer, the empty target framework was sorted last but since v6.0.1 it's sorted first instead.

Also, improve the NotSupportedException message when the language is undefined because `System.NotSupportedException: Specified method is not supported` is a terrible message.