### PR TITLE
docs(contributing): Update debug log instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ This is the contribution guide for Stryker.NET. Great to have you here! Here are
 
 ## Creating issues
 Do you have an idea for a feature or have you found a bug? Please create an issue so we can talk about it!
-If you found a bug, please run ```dotnet stryker --log-console debug``` and add the output of the Stryker run to the issue.
+If you found a bug, please run ```dotnet stryker --verbosity debug``` and add the output of the Stryker run to the issue.
 
 ## Adding new features
 New features are welcome! Either as requests or proposals.


### PR DESCRIPTION
Existing instruction does not work (I assume the argument have been deprecated and removed).

Possibly this should be expanded with one more change as the instruction in `CONTRIBUTING.md` is similar to, but different from this:
https://github.com/stryker-mutator/stryker-net/blob/70adc60caad193ed6942ee970ea5373003ade4e4/.github/ISSUE_TEMPLATE/bug_report.md?plain=1#L13-L13