### PR TITLE
deps(reporting): update mutation-testing-elements to `3.0.2`

### DIFF
--- a/src/Stryker.Core/Stryker.Core/libman.json
+++ b/src/Stryker.Core/Stryker.Core/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "jsdelivr",
   "libraries": [
     {
-      "library": "mutation-testing-elements@2.0.3",
+      "library": "mutation-testing-elements@3.0.2",
       "files": [
         "dist/mutation-test-elements.js"
       ],


### PR DESCRIPTION
Includes plenty of fixes and improvements, so we should use this in Stryker.NET.

https://github.com/stryker-mutator/mutation-testing-elements/compare/v2.0.3...v3.0.2