### PR TITLE
fix: Ensure MutationControl compiles with 'nullable' enabled

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
@@ -57,7 +57,50 @@ namespace Stryker.Core.UnitTest.InjectedHelpers
                 references: references);
 
             compilation.GetDiagnostics().ShouldNotContain(diag => diag.Severity == DiagnosticSeverity.Error,
-                $"errors :{string.Join(Environment.NewLine, compilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).Select(diag => $"'{diag.GetMessage()}' at {diag.Location.SourceTree.FilePath}, {diag.Location.GetLineSpan().StartLinePosition.Line}:{diag.Location.GetLineSpan().StartLinePosition.Character}"))}");
+                $"errors :{string.Join(Environment.NewLine, compilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).Select(diag => $"{diag.Id}: '{diag.GetMessage()}' at {diag.Location.SourceTree.FilePath}, {diag.Location.GetLineSpan().StartLinePosition.Line+1}:{diag.Location.GetLineSpan().StartLinePosition.Character}"))}");
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp8)]
+        [InlineData(LanguageVersion.CSharp9)]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        [InlineData(LanguageVersion.CSharp12)]
+        [InlineData(LanguageVersion.Default)]
+        [InlineData(LanguageVersion.Latest)]
+        [InlineData(LanguageVersion.LatestMajor)]
+        [InlineData(LanguageVersion.Preview)]
+        public void InjectHelpers_ShouldCompile_ForAllLanguageVersionsWithNullableOptions(LanguageVersion version)
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
+            var references = new List<MetadataReference>();
+            var hack = new NamedPipeClientStream("test");
+            foreach (var assembly in assemblies)
+            {
+                if (needed.Any(x => assembly.FullName.Contains(x)))
+                {
+                    references.Add(MetadataReference.CreateFromFile(assembly.Location));
+                }
+            }
+
+            var syntaxes = new List<SyntaxTree>();
+            var codeInjection = new CodeInjection();
+
+            foreach (var helper in codeInjection.MutantHelpers)
+            {
+                syntaxes.Add(CSharpSyntaxTree.ParseText(helper.Value, new CSharpParseOptions(languageVersion: version),
+                    helper.Key));
+            }
+
+            var compilation = CSharpCompilation.Create("dummy.dll",
+                syntaxes,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable, generalDiagnosticOption: ReportDiagnostic.Error),
+                references: references);
+
+            compilation.GetDiagnostics().ShouldNotContain(diag => diag.Severity == DiagnosticSeverity.Error,
+                $"errors :{string.Join(Environment.NewLine, compilation.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error).Select(diag => $"{diag.Id}: '{diag.GetMessage()}' at {diag.Location.SourceTree.FilePath}, {diag.Location.GetLineSpan().StartLinePosition.Line+1}:{diag.Location.GetLineSpan().StartLinePosition.Character}"))}");
         }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
@@ -2,20 +2,15 @@ namespace Stryker
 {
     public static class MutantControl
     {
-        private static System.Collections.Generic.List<int> _coveredMutants;
-        private static System.Collections.Generic.List<int> _coveredStaticdMutants;
-        private static string envName;
+        private static System.Collections.Generic.List<int> _coveredMutants = new System.Collections.Generic.List<int>();
+        private static System.Collections.Generic.List<int> _coveredStaticdMutants = new System.Collections.Generic.List<int>();
+        private static string envName = string.Empty;
         private static System.Object _coverageLock = new System.Object();
 
         // this attribute will be set by the Stryker Data Collector before each test
         public static bool CaptureCoverage;
         public static int ActiveMutant = -2;
         public const int ActiveMutantNotInitValue = -2;
-
-        static MutantControl()
-        {
-            InitCoverage();
-        }
 
         public static void InitCoverage()
         {
@@ -51,6 +46,7 @@ namespace Stryker
             }
             if (ActiveMutant == ActiveMutantNotInitValue)
             {
+                #pragma warning disable CS8600
                 string environmentVariable = System.Environment.GetEnvironmentVariable("ActiveMutation");
                 if (string.IsNullOrEmpty(environmentVariable))
                 {


### PR DESCRIPTION
Ensure MutationControl class, which is injected into mutated code, compiles without warnings with 'nullable' option on while remaining compatible with C# 2
Fix issue #2867 