### PR TITLE
Revert "chore(performance): Parallel testinit"

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Stryker.Core.Exceptions;
 using Stryker.Core.Initialisation.Buildalyzer;
@@ -102,21 +101,17 @@ namespace Stryker.Core.Initialisation
         public IReadOnlyCollection<MutationTestInput> GetMutationTestInputs(StrykerOptions options, IReadOnlyCollection<SourceProjectInfo> projects, ITestRunner runner)
         {
             var result = new List<MutationTestInput>();
-            try
+            foreach (var info in projects)
             {
-                Parallel.ForEach(projects, projectInfo => result.Add(new MutationTestInput
+                result.Add(new MutationTestInput
                 {
-                    SourceProjectInfo = projectInfo,
-                    TestProjectsInfo = projectInfo.TestProjectsInfo,
+                    SourceProjectInfo = info,
+                    TestProjectsInfo = info.TestProjectsInfo,
                     TestRunner = runner,
-                    InitialTestRun = InitialTest(options, projectInfo, runner, projects.Count == 1)
-                })
-                );
+                    InitialTestRun = InitialTest(options, info, runner, projects.Count==1)
+                });
             }
-            catch (AggregateException ex)
-            {
-                throw ex.InnerException;
-            }
+
             return result;
         }
 


### PR DESCRIPTION
Reverts stryker-mutator/stryker-net#2894 since this seems to cause a lot of timeouts