### PR TITLE
fix: support generic method calls for ignoremethodfilter

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -196,11 +196,8 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
             }
         }
 
-        [Theory]
-        [InlineData("Range", false)]
-        [InlineData("Where", false)]
-        [InlineData("ToList", true)]
-        public void MutantFilter_WorksWithConditionalInvocationStatement(string ignoredMethodName, bool shouldSkipMutant)
+        [Fact]
+        public void MutantFilter_WorksWithGenericMethodCalls()
         {
             // Arrange
             var source = @"
@@ -208,12 +205,12 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
 {
     private void TestMethod()
     {
-        Enumerable.Range(0, 9)?.Where(x => x < 5)?.ToList();
+        Enumerable.Range(0, 9)?.Where(x => x < 5)?.ToList<int>();
     }
 }";
             var options = new StrykerOptions
             {
-                IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { ignoredMethodName } }.Validate()
+                IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { "ToList" } }.Validate()
             };
 
             var sut = new IgnoredMethodMutantFilter();
@@ -224,14 +221,7 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
                 var filteredMutants = sut.FilterMutants(new[] { mutant }, null, options);
 
                 // Assert
-                if (shouldSkipMutant)
-                {
-                    filteredMutants.ShouldNotContain(mutant, $"{label} should have been filtered out.");
-                }
-                else
-                {
-                    filteredMutants.ShouldContain(mutant, $"{label} should have been kept.");
-                }
+                filteredMutants.ShouldNotContain(mutant, $"{label} should have been filtered out.");
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMethodsInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/IgnoreMethodsInputTests.cs
@@ -21,7 +21,7 @@ namespace Stryker.Core.UnitTest.Options.Inputs
 
             var result = target.Validate();
 
-            result.ShouldHaveSingleItem().ToString().ShouldBe(@"^(?:[^.]*\.)*Dispose$");
+            result.ShouldHaveSingleItem().ToString().ShouldBe(@"^(?:[^.]*\.)*Dispose(<[^>]*>)?$");
         }
 
         [Fact]
@@ -32,8 +32,8 @@ namespace Stryker.Core.UnitTest.Options.Inputs
             var result = target.Validate();
 
             result.Count().ShouldBe(2);
-            result.First().ToString().ShouldBe(@"^(?:[^.]*\.)*Dispose$");
-            result.Last().ToString().ShouldBe(@"^(?:[^.]*\.)*Test$");
+            result.First().ToString().ShouldBe(@"^(?:[^.]*\.)*Dispose(<[^>]*>)?$");
+            result.Last().ToString().ShouldBe(@"^(?:[^.]*\.)*Test(<[^>]*>)?$");
         }
 
         [Fact]

--- a/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreMethodsInput.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/Inputs/IgnoreMethodsInput.cs
@@ -15,7 +15,7 @@ namespace Stryker.Core.Options.Inputs
         private static IEnumerable<Regex> ParseRegex(IEnumerable<string> methodPatterns) =>
             methodPatterns
                 .Where(x => !string.IsNullOrEmpty(x))
-                .Select(methodPattern => new Regex("^(?:[^.]*\\.)*" + Regex.Escape(methodPattern).Replace("\\*", "[^.]*") + "$", RegexOptions.IgnoreCase))
+                .Select(methodPattern => new Regex("^(?:[^.]*\\.)*" + Regex.Escape(methodPattern).Replace("\\*", "[^.]*") + "(<[^>]*>)?$", RegexOptions.IgnoreCase))
                 .ToList();
     }
 }


### PR DESCRIPTION
Ensure (explicit) generic method calls (such as `ToList<int>()`) are supported by the `IgnoreMethodFilter`.
To be more specific, type specifications are simply ignored: `ToList<int>()` is dealt with as if it was simply `ToList()`.