### PR TITLE
Fix: NullReferenceException when mutating parameterless delegates

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1231,7 +1231,7 @@ if(StrykerNamespace.MutantControl.IsActive(3)){;}else{		request.Headers.Add((Str
     }
 
     [Fact]
-    public void ShouldMutateDeleage()
+    public void ShouldMutateDelegate()
     {
         var source = @"private void LocalFun()
 {
@@ -1245,6 +1245,27 @@ Console.WriteLine($""Hello {name}"");
 	var test = delegate(string name)
 {if(StrykerNamespace.MutantControl.IsActive(1)){}else{
 if(StrykerNamespace.MutantControl.IsActive(2)){;}else{Console.WriteLine((StrykerNamespace.MutantControl.IsActive(3)?$"""":$""Hello {name}""));
+}}};
+}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    [Fact]
+    public void ShouldMutateParameterLessDelegate()
+    {
+        var source = @"private void LocalFun()
+{
+	var test = delegate
+{
+Console.WriteLine(""Hello"");
+};
+}";
+        string expected = @"private void LocalFun()
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+	var test = delegate
+{if(StrykerNamespace.MutantControl.IsActive(1)){}else{
+if(StrykerNamespace.MutantControl.IsActive(2)){;}else{Console.WriteLine((StrykerNamespace.MutantControl.IsActive(3)?"""":""Hello""));
 }}};
 }}";
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseFunctionOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseFunctionOrchestrator.cs
@@ -16,8 +16,13 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators;
 /// <remarks>This class is helpful because there is no (useful) shared parent class for those syntax construct</remarks>
 internal abstract class BaseFunctionOrchestrator<T> :MemberDefinitionOrchestrator<T>, IInstrumentCode where T : SyntaxNode
 {
+    private readonly SeparatedSyntaxList<ParameterSyntax> _emptyParameterList;
 
-    protected BaseFunctionOrchestrator() => Marker = MutantPlacer.RegisterEngine(this, true);
+    protected BaseFunctionOrchestrator()
+    {
+        Marker = MutantPlacer.RegisterEngine(this, true);
+        _emptyParameterList = SyntaxFactory.SeparatedList<ParameterSyntax>();
+    }
 
     private SyntaxAnnotation Marker { get; }
 
@@ -107,7 +112,7 @@ internal abstract class BaseFunctionOrchestrator<T> :MemberDefinitionOrchestrato
         }
         var wasInExpressionForm = GetBodies(sourceNode).expression != null;
         var returnType = ReturnType(sourceNode);
-        var parameters = ParameterList(sourceNode).Parameters;
+        var parameters = ParameterList(sourceNode)?.Parameters??_emptyParameterList;
 
         // no mutations to inject
         if (!context.HasLeftOverMutations)

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseFunctionOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BaseFunctionOrchestrator.cs
@@ -112,7 +112,7 @@ internal abstract class BaseFunctionOrchestrator<T> :MemberDefinitionOrchestrato
         }
         var wasInExpressionForm = GetBodies(sourceNode).expression != null;
         var returnType = ReturnType(sourceNode);
-        var parameters = ParameterList(sourceNode)?.Parameters??_emptyParameterList;
+        var parameters = ParameterList(sourceNode)?.Parameters ?? _emptyParameterList;
 
         // no mutations to inject
         if (!context.HasLeftOverMutations)


### PR DESCRIPTION
Parameterless delegates returns a null parameter block, which is now properly handled
fixes #2925.