### PR TITLE
 Add support for UTF8 string literals

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -157,7 +157,9 @@ Do you have a suggestion for a (new) mutator? Feel free to create an [issue](htt
 | Original | Mutated |
 | ------------- | ------------- |
 | `"foo"` | `""` |
+| `"foo"u8` | `""u8` |
 | `""` | `"Stryker was here!"` |
+| `""u8` | `"Stryker was here!"u8` |
 | `$"foo {bar}"` | `$""` |
 | `@"foo"` | `@""` |
 | `string.Empty` | `"Stryker was here!"` |

--- a/integrationtest/TargetProjects/NetCoreTestProject.XUnit/NetCoreTestProject.XUnit.csproj
+++ b/integrationtest/TargetProjects/NetCoreTestProject.XUnit/NetCoreTestProject.XUnit.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/integrationtest/TargetProjects/NetCoreTestProject.XUnit/String/Utf8StringMagicTests.cs
+++ b/integrationtest/TargetProjects/NetCoreTestProject.XUnit/String/Utf8StringMagicTests.cs
@@ -1,0 +1,50 @@
+using ExampleProject.String;
+using Xunit;
+
+namespace ExampleProject.XUnit.String
+{
+    public class Utf8StringMagicTests
+    {
+        [Fact]
+        public void AddTwoStrings()
+        {
+            var sut = new Utf8StringMagic();
+            var actual = sut.HelloWorld();
+            Assert.Equal("Hello World!"u8, actual);
+        }
+
+        [Fact]
+        public void IsNullOrEmpty()
+        {
+            var sut = new Utf8StringMagic();
+            var actual = sut.IsNullOrEmpty("hello"u8);
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void IsNullOrEmpty_Empty()
+        {
+            var sut = new Utf8StringMagic();
+            var actual = sut.IsNullOrEmpty(""u8);
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void Referenced()
+        {
+            var sut = new Utf8StringMagic();
+            var input = "hello"u8;
+            sut.Referenced(out input);
+            Assert.Equal("world"u8, input);
+        }
+
+        [Fact]
+        public void ReferencedEmpty()
+        {
+            var sut = new Utf8StringMagic();
+            var input = "hello"u8;
+            sut.ReferencedEmpty(out input);
+            Assert.Equal(""u8, input);
+        }
+    }
+}

--- a/integrationtest/TargetProjects/TargetProject/String/Utf8StringMagic.cs
+++ b/integrationtest/TargetProjects/TargetProject/String/Utf8StringMagic.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+
+namespace ExampleProject.String
+{
+    public class Utf8StringMagic
+    {
+        public ReadOnlySpan<byte> HelloWorld()
+        {
+            var a = "";
+            return "Hello"u8 + " "u8 + "World!"u8;
+        }
+
+        public void Referenced(out ReadOnlySpan<byte> test)
+        {
+            test = "world"u8;
+        }
+
+        public void ReferencedEmpty(out ReadOnlySpan<byte> test)
+        {
+            test = ""u8;
+        }
+
+        public bool IsNullOrEmpty(ReadOnlySpan<byte> myString)
+        {
+            if (myString.IsEmpty)
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/integrationtest/TargetProjects/TargetProject/String/Utf8StringMagic.cs
+++ b/integrationtest/TargetProjects/TargetProject/String/Utf8StringMagic.cs
@@ -7,7 +7,6 @@ namespace ExampleProject.String
     {
         public ReadOnlySpan<byte> HelloWorld()
         {
-            var a = "";
             return "Hello"u8 + " "u8 + "World!"u8;
         }
 

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -83,7 +83,7 @@ namespace IntegrationTests
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
             CheckReportMutants(report, total: 130, ignored: 60, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
-            CheckReportTestCounts(report, total: 14);
+            CheckReportTestCounts(report, total: 19);
         }
 
         [Fact]

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -121,7 +121,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 114, ignored: 27, survived: 8, killed: 8, timeout: 2, nocoverage: 67);
+            CheckReportMutants(report, total: 129, ignored: 31, survived: 9, killed: 12, timeout: 2, nocoverage: 67);
             CheckReportTestCounts(report, total: 35);
         }
 

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -82,7 +82,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 130, ignored: 60, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
+            CheckReportMutants(report, total: 129, ignored: 59, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
             CheckReportTestCounts(report, total: 19);
         }
 

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -140,7 +140,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 130, ignored: 55, survived: 4, killed: 6, timeout: 2, nocoverage: 45);
+            CheckReportMutants(report, total: 129, ignored: 59, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
             CheckReportTestCounts(report, total: 30);
         }
 

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -82,7 +82,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 114, ignored: 55, survived: 4, killed: 6, timeout: 2, nocoverage: 45);
+            CheckReportMutants(report, total: 130, ignored: 60, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
             CheckReportTestCounts(report, total: 14);
         }
 
@@ -140,7 +140,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 114, ignored: 55, survived: 4, killed: 6, timeout: 2, nocoverage: 45);
+            CheckReportMutants(report, total: 130, ignored: 55, survived: 4, killed: 6, timeout: 2, nocoverage: 45);
             CheckReportTestCounts(report, total: 30);
         }
 

--- a/integrationtest/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/ValidationProject/ValidateStrykerResults.cs
@@ -122,7 +122,7 @@ namespace IntegrationTests
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
             CheckReportMutants(report, total: 114, ignored: 27, survived: 8, killed: 8, timeout: 2, nocoverage: 67);
-            CheckReportTestCounts(report, total: 30);
+            CheckReportTestCounts(report, total: 35);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace IntegrationTests
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
             CheckReportMutants(report, total: 129, ignored: 59, survived: 5, killed: 10, timeout: 2, nocoverage: 45);
-            CheckReportTestCounts(report, total: 30);
+            CheckReportTestCounts(report, total: 35);
         }
 
         private void CheckMutationKindsValidity(JsonReport report)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -23,9 +23,9 @@ namespace Stryker.Core.UnitTest.Mutators
         [InlineData("foo", """
                            ""u8
                            """)]
-        public void ShouldMutateUtf8(string original, string expected)
+        public void ShouldMutateUtf8StringLiteral(string original, string expected)
         {
-            var syntaxTree = CSharpSyntaxTree.ParseText($"""var = "{original}"u8;""");
+            var syntaxTree = CSharpSyntaxTree.ParseText($"""var test = "{original}"u8;""");
       
             var literalExpression = syntaxTree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
             var mutator = new StringMutator();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -21,7 +21,7 @@ namespace Stryker.Core.UnitTest.Mutators
         [InlineData(@"""foo""u8", @"""""u8")]
         public void ShouldMutateUtf8StringLiteral(string original, string expected)
         {
-            var syntaxTree = CSharpSyntaxTree.ParseText($"""var test = "{original}"u8;""");
+            var syntaxTree = CSharpSyntaxTree.ParseText($"var test = {original};");
       
             var literalExpression = syntaxTree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
             var mutator = new StringMutator();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -17,12 +17,8 @@ namespace Stryker.Core.UnitTest.Mutators
         }
 
         [Theory]
-        [InlineData("", """
-                        "Stryker was here!"u8
-                        """)]
-        [InlineData("foo", """
-                           ""u8
-                           """)]
+        [InlineData(@"""""u8", @"""Stryker was here!""u8")]
+        [InlineData(@"""foo""u8", @"""""u8")]
         public void ShouldMutateUtf8StringLiteral(string original, string expected)
         {
             var syntaxTree = CSharpSyntaxTree.ParseText($"""var test = "{original}"u8;""");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -17,6 +17,29 @@ namespace Stryker.Core.UnitTest.Mutators
         }
 
         [Theory]
+        [InlineData("", """
+                        "Stryker was here!"u8
+                        """)]
+        [InlineData("foo", """
+                           ""u8
+                           """)]
+        public void ShouldMutateUtf8(string original, string expected)
+        {
+            var syntaxTree = CSharpSyntaxTree.ParseText($"""var = "{original}"u8;""");
+      
+            var literalExpression = syntaxTree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
+            var mutator = new StringMutator();
+
+            var result = mutator.ApplyMutations(literalExpression, null).ToList();
+
+            var mutation = result.ShouldHaveSingleItem();
+
+            mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>()
+                .Token.Text.ShouldBe(expected);
+            mutation.DisplayName.ShouldBe("String mutation");
+        }
+
+        [Theory]
         [InlineData("", "Stryker was here!")]
         [InlineData("foo", "")]
         public void ShouldMutate(string original, string expected)

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -17,39 +17,41 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         // Get objectCreationSyntax to check if it contains a regex type.
         var root = node.Parent?.Parent?.Parent;
 
-        if (!IsSpecialType(root))
+        if (IsSpecialType(root))
         {
-            SyntaxNode syntaxNode;
-            string currentValue;
-            string replacementValue;
+            yield break;
+        }
 
-            if (IsStringLiteral(node))
-            {
-                currentValue = (string)node.Token.Value;
-                replacementValue = currentValue == "" ? "Stryker was here!" : "";
-                syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
-                    SyntaxFactory.Literal(replacementValue));
-            }
-            else if(IsUtf8StringLiteral(node))
-            {
-                currentValue = (string)node.Token.Value;
-                replacementValue = currentValue == "" ? "Stryker was here!" : "";
-                syntaxNode = CreateUtf88String(node.GetLeadingTrivia(), replacementValue, node.GetTrailingTrivia());
-            }
-            else
-            {
-                yield break;
-            }
+        SyntaxNode syntaxNode;
+        string currentValue;
+        string replacementValue;
+
+        if (IsStringLiteral(node))
+        {
+            currentValue = (string)node.Token.Value;
+            replacementValue = currentValue == "" ? "Stryker was here!" : "";
+            syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(replacementValue));
+        }
+        else if(IsUtf8StringLiteral(node))
+        {
+            currentValue = (string)node.Token.Value;
+            replacementValue = currentValue == "" ? "Stryker was here!" : "";
+            syntaxNode = CreateUtf88String(node.GetLeadingTrivia(), replacementValue, node.GetTrailingTrivia());
+        }
+        else
+        {
+            yield break;
+        }
             
 
-            yield return new Mutation
-            {
-                OriginalNode = node,
-                ReplacementNode = syntaxNode,
-                DisplayName = "String mutation",
-                Type = Mutator.String
-            };
-        }
+        yield return new Mutation
+        {
+            OriginalNode = node,
+            ReplacementNode = syntaxNode,
+            DisplayName = "String mutation",
+            Type = Mutator.String
+        };
     }
 
     private static bool IsUtf8StringLiteral(LiteralExpressionSyntax node)

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -43,7 +43,6 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         {
             yield break;
         }
-            
 
         yield return new Mutation
         {
@@ -94,5 +93,4 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
 
         return SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, literal);
     }
-
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -17,24 +17,52 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         // Get objectCreationSyntax to check if it contains a regex type.
         var root = node.Parent?.Parent?.Parent;
 
-        if (!IsSpecialType(root) && IsStringLiteral(node))
+        if (!IsSpecialType(root))
         {
-            var currentValue = (string)node.Token.Value;
-            var replacementValue = currentValue == "" ? "Stryker was here!" : "";
+            SyntaxNode syntaxNode;
+            string currentValue;
+            string replacementValue;
+
+            if (IsStringLiteral(node))
+            {
+                currentValue = (string)node.Token.Value;
+                replacementValue = currentValue == "" ? "Stryker was here!" : "";
+                syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(replacementValue));
+            }
+            else if(IsUtf8StringLiteral(node))
+            {
+                currentValue = (string)node.Token.Value;
+                replacementValue = currentValue == "" ? "Stryker was here!" : "";
+                syntaxNode = CreateUtf88String(node.GetLeadingTrivia(), replacementValue, node.GetTrailingTrivia());
+            }
+            else
+            {
+                yield break;
+            }
+            
+
             yield return new Mutation
             {
                 OriginalNode = node,
-                ReplacementNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(replacementValue)),
+                ReplacementNode = syntaxNode,
                 DisplayName = "String mutation",
                 Type = Mutator.String
             };
         }
     }
 
+    private static bool IsUtf8StringLiteral(LiteralExpressionSyntax node)
+    {
+        var kind = node.Kind();
+        return kind is SyntaxKind.Utf8StringLiteralExpression
+               && node.Parent is not ConstantPatternSyntax;
+    }
+
     private static bool IsStringLiteral(LiteralExpressionSyntax node)
     {
         var kind = node.Kind();
-        return kind == SyntaxKind.StringLiteralExpression
+        return kind is SyntaxKind.StringLiteralExpression
                && node.Parent is not ConstantPatternSyntax;
     }
 
@@ -49,4 +77,20 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         var ctorType = ctor.Type.ToString();
         return ctorType == type.Name || ctorType == type.FullName;
     }
+
+    private static LiteralExpressionSyntax CreateUtf88String(SyntaxTriviaList leadingTrivia, string stringValue, SyntaxTriviaList trailingTrivia)
+    {
+        var quoteCharacter = '"';
+        var suffix = "u8";
+
+        var literal = SyntaxFactory.Token(
+                leading: leadingTrivia,
+                kind: SyntaxKind.Utf8StringLiteralToken,
+                text: quoteCharacter + stringValue + quoteCharacter + suffix,
+                valueText: "",
+                trailing: trailingTrivia);
+
+        return SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, literal);
+    }
+
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -33,7 +33,7 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
             syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
                 SyntaxFactory.Literal(replacementValue));
         }
-        else if(IsUtf8StringLiteral(node))
+        else if (IsUtf8StringLiteral(node))
         {
             currentValue = (string)node.Token.Value;
             replacementValue = currentValue == "" ? "Stryker was here!" : "";


### PR DESCRIPTION
Fixes #2923.

Implemented the same logic as in plain strings:
  - `""u8` -> `"Stryker was here!"u8`
  - `""something8` -> `""u8`

`SyntaxFactory.Literal(string)` method used for string mutations doesn't work with UTF8 string literal type (`ReadOnlySpan<byte>`), so I've taken inspiration on how to make it work from dotnet/roslyn analyzers' [code](https://github.com/dotnet/roslyn/blob/ac301e22853c9083a7aa8f22d49e389056da89de/src/Analyzers/CSharp/CodeFixes/UseUtf8StringLiteral/UseUtf8StringLiteralCodeFixProvider.cs#L193).

Tasks:
- [x] Modify `StringMutator` to support UTF8 string literals
- [x] Unit tests
- [x] Integration tests
- [x] Edit docs