### PR TITLE
feat: Parse stryker-config.yml and stryker-config.yaml by default

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigBuilderTests.cs
@@ -66,6 +66,99 @@ namespace Stryker.CLI.UnitTest
             VerifyConfigFileDeserialized(Times.Once());
         }
 
+        [TestMethod]
+        public void ValidUserConfigFileWithDefault_ShouldParseUserConfig()
+        {
+            string[] args = ["-f", $"ConfigFiles{Path.DirectorySeparatorChar}UserConfigWithDefault{Path.DirectorySeparatorChar}custom_config.json"];
+
+            var reader = new ConfigBuilder();
+
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+            _inputs.Object.ModuleNameInput.Validate().ShouldBe("custom");
+        }
+
+        [TestMethod]
+        public void ValidDefaultYmlFile_ShouldParse()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            // Set directory to test folder containing single config yml
+            Directory.SetCurrentDirectory(Path.Combine(currentDirectory, "ConfigFiles", "SingleDefaultYml"));
+
+            string[] args = [];
+
+            var reader = new ConfigBuilder();
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+            _inputs.Object.ModuleNameInput.Validate().ShouldBe("hello_from_yml");
+
+            // Reset current directory to original folder
+            Directory.SetCurrentDirectory(currentDirectory);
+        }
+
+        [TestMethod]
+        public void ValidDefaultYamlFile_ShouldParse()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            // Set directory to test folder containing single config yml
+            Directory.SetCurrentDirectory(Path.Combine(currentDirectory, "ConfigFiles", "SingleDefaultYaml"));
+
+            string[] args = [];
+
+            var reader = new ConfigBuilder();
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+            _inputs.Object.ModuleNameInput.Validate().ShouldBe("hello_from_yaml");
+
+            // Reset current directory to original folder
+            Directory.SetCurrentDirectory(currentDirectory);
+        }
+
+        [TestMethod]
+        public void MultipleDefaultConfigsWithJson_ShouldParseJsonConfig()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            // Set directory to test folder containing multiple default files
+            Directory.SetCurrentDirectory(Path.Combine(currentDirectory, "ConfigFiles", "MultipleDefaultWithJson"));
+
+            string[] args = [];
+
+            var reader = new ConfigBuilder();
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+            _inputs.Object.ModuleNameInput.Validate().ShouldBe("hello_from_json");
+
+            // Reset current directory to original folder
+            Directory.SetCurrentDirectory(currentDirectory);
+        }
+
+        [TestMethod]
+        public void TwoDefaultConfigsWithYml_ShouldParseYmlConfig()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+
+            // Set directory to test folder containing two default files
+            Directory.SetCurrentDirectory(Path.Combine(currentDirectory, "ConfigFiles", "TwoWithYml"));
+
+            string[] args = [];
+
+            var reader = new ConfigBuilder();
+            reader.Build(_inputs.Object, args, _app, _cmdConfigHandler);
+
+            VerifyConfigFileDeserialized(Times.Once());
+            _inputs.Object.ModuleNameInput.Validate().ShouldBe("hello_from_yml");
+
+            // Reset current directory to original folder
+            Directory.SetCurrentDirectory(currentDirectory);
+        }
+
         private void VerifyConfigFileDeserialized(Times time) => _inputs.VerifyGet(x => x.CoverageAnalysisInput, time);
 
         private static CommandLineApplication GetCommandLineApplication()

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.json
@@ -1,0 +1,7 @@
+{
+  "stryker-config": {
+    "project-info": {
+      "module": "hello_from_json"
+    }
+  }
+}

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.yaml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.yaml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yaml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.yml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/MultipleDefaultWithJson/stryker-config.yml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/SingleDefaultYaml/stryker-config.yaml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/SingleDefaultYaml/stryker-config.yaml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yaml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/SingleDefaultYml/stryker-config.yml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/SingleDefaultYml/stryker-config.yml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/TwoWithYml/stryker-config.yaml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/TwoWithYml/stryker-config.yaml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yaml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/TwoWithYml/stryker-config.yml
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/TwoWithYml/stryker-config.yml
@@ -1,0 +1,3 @@
+stryker-config:
+  project-info:
+    module: "hello_from_yml"

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/UserConfigWithDefault/custom_config.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/UserConfigWithDefault/custom_config.json
@@ -1,0 +1,7 @@
+{
+  "stryker-config": {
+    "project-info": {
+      "module": "custom"
+    }
+  }
+}

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/UserConfigWithDefault/stryker-config.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/ConfigFiles/UserConfigWithDefault/stryker-config.json
@@ -1,0 +1,7 @@
+{
+  "stryker-config": {
+    "project-info": {
+      "module": "hello_from_json"
+    }
+  }
+}

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/Stryker.CLI.UnitTest.csproj
@@ -29,5 +29,32 @@
     <None Include="filled-stryker-config.json" CopyToOutputDirectory="Always" />
     <None Include="filled-stryker-config.yaml" CopyToOutputDirectory="Always" />
     <None Include="stryker-config.json" CopyToOutputDirectory="Always" />
+    <None Update="ConfigFiles\TwoWithYml\stryker-config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\TwoWithYml\stryker-config.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\SingleDefaultYml\stryker-config.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\SingleDefaultYaml\stryker-config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\MultipleDefaultWithJson\stryker-config.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\MultipleDefaultWithJson\stryker-config.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\MultipleDefaultWithJson\stryker-config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\UserConfigWithDefault\custom_config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="ConfigFiles\UserConfigWithDefault\stryker-config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #2830 

This PR adds support for parsing "stryker-config.yml" and "stryker-config.yaml" as default configuration files.
Eliminates the need to pass those files in each time.

Needed to add the "Collection" attribute to some tests so that they don't run in parallel and affect each other by setting/getting the default directory.