### PR TITLE
fix(real-time-reporting): missing mutants when running in solution mode

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 using Stryker.Core.Mutants;
@@ -1810,5 +1811,24 @@ else        {
             """;
 
         ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    [TestMethod]
+    public void ShouldIncrementMutantCountUniquely()
+    {
+        var secondOrchestrator =
+            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: new StrykerOptions());
+        var node = SyntaxFactory.ParseExpression("1 == 1") as BinaryExpressionSyntax;
+
+        var firstMutant = _target
+            .GenerateMutationsForNode(node, null, new MutationContext(secondOrchestrator))
+            .Single();
+
+        var secondMutant = secondOrchestrator
+            .GenerateMutationsForNode(node, null, new MutationContext(secondOrchestrator))
+            .Single();
+
+        firstMutant.Id.ShouldBe(0);
+        secondMutant.Id.ShouldBe(1);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1828,7 +1828,6 @@ else        {
             .GenerateMutationsForNode(node, null, new MutationContext(secondOrchestrator))
             .Single();
 
-        firstMutant.Id.ShouldBe(0);
-        secondMutant.Id.ShouldBe(1);
+        secondMutant.Id.ShouldBe(firstMutant.Id + 1);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.InjectedHelpers;
 using Stryker.Core.Mutants;
@@ -9,8 +10,12 @@ namespace Stryker.Core.UnitTest.Mutants
     /// <summary>
     /// This base class provides helper to test source file mutation
     /// </summary>
-    public class MutantOrchestratorTestsBase : TestBase
+    public partial class MutantOrchestratorTestsBase : TestBase
     {
+        [GeneratedRegex(@"IsActive\(\d+\)")]
+        private static partial Regex IsActiveRegex();
+        private const string Replacement = "IsActive(0)";
+
         protected CsharpMutantOrchestrator _target;
         protected CodeInjection _injector = new();
 
@@ -28,6 +33,8 @@ namespace Stryker.Core.UnitTest.Mutants
         {
             var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(actual), null);
             actual = actualNode.GetRoot().ToFullString();
+            expected = IsActiveRegex().Replace(expected, Replacement);
+            actual = IsActiveRegex().Replace(actual, Replacement);
             actual = actual.Replace(_injector.HelperNamespace, "StrykerNamespace");
             actualNode = CSharpSyntaxTree.ParseText(actual);
             var expectedNode = CSharpSyntaxTree.ParseText(expected);

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Threading;
 using Stryker.Core.Options;
 
 namespace Stryker.Core.Mutants
@@ -14,7 +15,11 @@ namespace Stryker.Core.Mutants
 
         public ICollection<Mutant> Mutants { get; set; }
 
-        protected static int MutantCount;
+        private static int _mutantCount;
+
+        protected static int MutantCount => _mutantCount;
+
+        protected static void IncreaseMutantCount() => Interlocked.Increment(ref _mutantCount);
 
         protected BaseMutantOrchestrator(StrykerOptions options) => Options = options;
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -14,7 +14,7 @@ namespace Stryker.Core.Mutants
 
         public ICollection<Mutant> Mutants { get; set; }
 
-        protected int MutantCount;
+        protected static int MutantCount;
 
         protected BaseMutantOrchestrator(StrykerOptions options) => Options = options;
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -147,7 +147,7 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
                 }
 
                 Mutants.Add(newMutant);
-                Interlocked.Increment(ref MutantCount);
+                IncreaseMutantCount();
                 mutations.Add(newMutant);
             }
         }


### PR DESCRIPTION
Previously the mutation testrun in solution mode would produce non-unique mutant ids, which resulted in incorrect mutant updates in the real-time report.

By making this value static, it works correctly again.