### PR TITLE
feat(mutating): constant patterns

### DIFF
--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -77,12 +77,12 @@ namespace IntegrationTests
             var latestReport = directory.GetFiles(MutationReportJson, SearchOption.AllDirectories)
                 .OrderByDescending(f => f.LastWriteTime)
                 .First();
-
+            
             var strykerRunOutput = File.ReadAllText(latestReport.FullName);
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 242, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
+            CheckReportMutants(report, total: 589, ignored: 246, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
             CheckReportTestCounts(report, total: 10);
         }
 
@@ -121,7 +121,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 106, survived: 2, killed: 8, timeout: 2, nocoverage: 436);
+            CheckReportMutants(report, total: 589, ignored: 106, survived: 2, killed: 8, timeout: 2, nocoverage: 440);
             CheckReportTestCounts(report, total: 20);
         }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -140,7 +140,7 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 242, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
+            CheckReportMutants(report, total: 589, ignored: 246, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
             CheckReportTestCounts(report, total: 22);
         }
 

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/StrykerCLITests.cs
@@ -18,451 +18,441 @@ using Stryker.Core.Options;
 using Stryker.Core.Reporters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Stryker.CLI.UnitTest
+namespace Stryker.CLI.UnitTest;
+
+
+[TestClass]
+public class StrykerCLITests
 {
-    [TestClass]
-    public class StrykerCLITests
+    private IStrykerInputs _inputs;
+    private readonly StrykerCli _target;
+    private readonly StrykerOptions _options;
+    private readonly StrykerRunResult _runResults;
+    private readonly Mock<IStrykerRunner> _strykerRunnerMock = new(MockBehavior.Strict);
+    private readonly Mock<IStrykerNugetFeedClient> _nugetClientMock = new(MockBehavior.Strict);
+    private readonly Mock<ILoggingInitializer> _loggingInitializerMock = new();
+
+    public StrykerCLITests()
     {
-        private IStrykerInputs _inputs;
-        private readonly StrykerCli _target;
-        private readonly StrykerOptions _options;
-        private readonly StrykerRunResult _runResults;
-        private readonly Mock<IStrykerRunner> _strykerRunnerMock = new(MockBehavior.Strict);
-        private readonly Mock<IStrykerNugetFeedClient> _nugetClientMock = new(MockBehavior.Strict);
-        private readonly Mock<ILoggingInitializer> _loggingInitializerMock = new();
+        _options = new StrykerOptions() { Thresholds = new Thresholds { Break = 0 } };
+        _runResults = new StrykerRunResult(_options, 0.3);
+        _strykerRunnerMock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => _inputs = c)
+            .Returns(_runResults)
+            .Verifiable();
+        _nugetClientMock.Setup(x => x.GetLatestVersionAsync()).Returns(Task.FromResult(new SemanticVersion(10, 0, 0)));
+        _nugetClientMock.Setup(x => x.GetPreviewVersionAsync()).Returns(Task.FromResult(new SemanticVersion(20, 0, 0)));
+        _target = new StrykerCli(_strykerRunnerMock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
+    }
 
-        public StrykerCLITests()
-        {
-            _options = new StrykerOptions() { Thresholds = new Thresholds { Break = 0 } };
-            _runResults = new StrykerRunResult(_options, 0.3);
-            _strykerRunnerMock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => _inputs = c)
-                .Returns(_runResults)
-                .Verifiable();
-            _nugetClientMock.Setup(x => x.GetLatestVersionAsync()).Returns(Task.FromResult(new SemanticVersion(10, 0, 0)));
-            _nugetClientMock.Setup(x => x.GetPreviewVersionAsync()).Returns(Task.FromResult(new SemanticVersion(20, 0, 0)));
-            _target = new StrykerCli(_strykerRunnerMock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
-        }
+    [TestMethod]
+    public void ShouldDisplayInfoOnHelp()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var console = new TestConsole().EmitAnsiSequences().Width(160);
+        var target = new StrykerCli(mock.Object, console:console);
 
-        [TestMethod]
-        public void ShouldDisplayInfoOnHelp()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var target = new StrykerCli(mock.Object);
+        target.Run(new string[] { "--help" });
 
-            using var sw = new StringWriter();
-            var originalOut = Console.Out;
-            try
-            {
-                Console.SetOut(sw);
-                target.Run(new string[] { "--help" });
-
-                var expected = @"Stryker: Stryker mutator for .Net
+        var expected = @"Stryker: Stryker mutator for .Net
 
 Stryker mutator for .Net
 
 Usage: Stryker [command] [options]
 
 Options:";
-                sw.ToString().ShouldContain(expected);
+        console.Output.ShouldContain(expected);
+    }
+
+    [TestMethod]
+    public void ShouldDisplayLogo()
+    {
+        var strykerRunnerMock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var strykerRunResult = new StrykerRunResult(_options, 0.3);
+
+        strykerRunnerMock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Returns(strykerRunResult)
+            .Verifiable();
+
+        var console = new TestConsole().EmitAnsiSequences().Width(160);
+        var target = new StrykerCli(strykerRunnerMock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object, console);
+
+        target.Run(Array.Empty<string>());
+
+        // wait 20ms to let the getVersion call be handled
+        Thread.Sleep(20);
+
+        var consoleOutput = console.Output;
+
+        consoleOutput.ShouldContain("Version:");
+        consoleOutput.ShouldContain(@"A new version of Stryker.NET (10.0.0) is available. Please consider upgrading using `dotnet tool update -g dotnet-stryker`");
+    }
+
+    [TestMethod]
+    public void OnMutationScoreBelowThresholdBreak_ShouldReturn_ExitCodeBreakThresholdViolated()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var options = new StrykerOptions()
+        {
+            Thresholds = new Thresholds
+            {
+                Break = 40
             }
-            finally
+        };
+        var strykerRunResult = new StrykerRunResult(options, 0.3);
+
+        mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => Core.Logging.ApplicationLogging.LoggerFactory = l)
+            .Returns(strykerRunResult)
+            .Verifiable();
+
+        var target = new StrykerCli(mock.Object);
+        var result = target.Run(new string[] { });
+
+        mock.Verify();
+        target.ExitCode.ShouldBe(ExitCodes.BreakThresholdViolated);
+        result.ShouldBe(ExitCodes.BreakThresholdViolated);
+    }
+
+    [TestMethod]
+    public void OnMutationScoreEqualToNullAndThresholdBreakEqualTo0_ShouldReturnExitCode0()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var options = new StrykerOptions()
+        {
+            Thresholds = new Thresholds
             {
-                //reset the console to prevent object disposed exceptions in other tests
-                Console.SetOut(originalOut);
+                Break = 0
             }
-        }
+        };
+        var strykerRunResult = new StrykerRunResult(options, double.NaN);
+        mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Returns(strykerRunResult)
+            .Verifiable();
 
-        [TestMethod]
-        public void ShouldDisplayLogo()
+        var target = new StrykerCli(mock.Object);
+        var result = target.Run(new string[] { });
+
+        mock.Verify();
+        target.ExitCode.ShouldBe(0);
+        result.ShouldBe(0);
+    }
+
+    [TestMethod]
+    public void OnMutationScoreEqualToNullAndThresholdBreakAbove0_ShouldReturnExitCode0()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var options = new StrykerOptions()
         {
-            var strykerRunnerMock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var strykerRunResult = new StrykerRunResult(_options, 0.3);
-
-            strykerRunnerMock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Returns(strykerRunResult)
-                .Verifiable();
-
-            var console = new TestConsole().EmitAnsiSequences().Width(160);
-            var target = new StrykerCli(strykerRunnerMock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object, console);
-
-            target.Run(Array.Empty<string>());
-
-            // wait 20ms to let the getVersion call be handled
-            Thread.Sleep(20);
-
-            var consoleOutput = console.Output;
-
-            consoleOutput.ShouldContain("Version:");
-            consoleOutput.ShouldContain(@"A new version of Stryker.NET (10.0.0) is available. Please consider upgrading using `dotnet tool update -g dotnet-stryker`");
-        }
-
-        [TestMethod]
-        public void OnMutationScoreBelowThresholdBreak_ShouldReturn_ExitCodeBreakThresholdViolated()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var options = new StrykerOptions()
+            Thresholds = new Thresholds
             {
-                Thresholds = new Thresholds
-                {
-                    Break = 40
-                }
-            };
-            var strykerRunResult = new StrykerRunResult(options, 0.3);
+                Break = 40
+            }
+        };
+        var strykerRunResult = new StrykerRunResult(options, double.NaN);
+        mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Returns(strykerRunResult)
+            .Verifiable();
 
-            mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Callback<IStrykerInputs, ILoggerFactory, IProjectOrchestrator>((c, l, p) => Core.Logging.ApplicationLogging.LoggerFactory = l)
-                .Returns(strykerRunResult)
-                .Verifiable();
+        var target = new StrykerCli(mock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
+        var result = target.Run(new string[] { });
 
-            var target = new StrykerCli(mock.Object);
-            var result = target.Run(new string[] { });
+        mock.Verify();
+        target.ExitCode.ShouldBe(0);
+        result.ShouldBe(0);
+    }
 
-            mock.Verify();
-            target.ExitCode.ShouldBe(ExitCodes.BreakThresholdViolated);
-            result.ShouldBe(ExitCodes.BreakThresholdViolated);
-        }
-
-        [TestMethod]
-        public void OnMutationScoreEqualToNullAndThresholdBreakEqualTo0_ShouldReturnExitCode0()
+    [TestMethod]
+    public void OnMutationScoreAboveThresholdBreak_ShouldReturnExitCode0()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var options = new StrykerOptions()
         {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var options = new StrykerOptions()
+            Thresholds = new Thresholds
             {
-                Thresholds = new Thresholds
-                {
-                    Break = 0
-                }
-            };
-            var strykerRunResult = new StrykerRunResult(options, double.NaN);
-            mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Returns(strykerRunResult)
-                .Verifiable();
-
-            var target = new StrykerCli(mock.Object);
-            var result = target.Run(new string[] { });
-
-            mock.Verify();
-            target.ExitCode.ShouldBe(0);
-            result.ShouldBe(0);
-        }
-
-        [TestMethod]
-        public void OnMutationScoreEqualToNullAndThresholdBreakAbove0_ShouldReturnExitCode0()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var options = new StrykerOptions()
-            {
-                Thresholds = new Thresholds
-                {
-                    Break = 40
-                }
-            };
-            var strykerRunResult = new StrykerRunResult(options, double.NaN);
-            mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Returns(strykerRunResult)
-                .Verifiable();
-
-            var target = new StrykerCli(mock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
-            var result = target.Run(new string[] { });
-
-            mock.Verify();
-            target.ExitCode.ShouldBe(0);
-            result.ShouldBe(0);
-        }
-
-        [TestMethod]
-        public void OnMutationScoreAboveThresholdBreak_ShouldReturnExitCode0()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var options = new StrykerOptions()
-            {
-                Thresholds = new Thresholds
-                {
-                    Break = 0
-                }
-            };
-            var strykerRunResult = new StrykerRunResult(options, 0.1);
-
-            mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>())).Returns(strykerRunResult).Verifiable();
-
-            var target = new StrykerCli(mock.Object);
-            var result = target.Run(new string[] { });
-
-            mock.Verify();
-            target.ExitCode.ShouldBe(0);
-            result.ShouldBe(0);
-        }
-
-        [TestMethod]
-        [DataRow("--help")]
-        [DataRow("-h")]
-        [DataRow("-?")]
-        public void ShouldNotStartStryker_WithHelpArgument(string argName)
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            var target = new StrykerCli(mock.Object);
-
-            target.Run(new string[] { argName });
-
-            mock.VerifyNoOtherCalls();
-        }
-
-        [TestMethod]
-        public void ShouldThrow_OnException()
-        {
-            var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
-            mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
-                .Throws(new Exception("Initial testrun failed"))
-                .Verifiable();
-
-            var target = new StrykerCli(mock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
-            Should.Throw<Exception>(() => target.Run(new string[] { }));
-        }
-
-        [TestMethod]
-        [DataRow("--reporter")]
-        [DataRow("-r")]
-        public void ShouldPassReporterArgumentsToStryker_WithReporterArgument(string argName)
-        {
-            _target.Run(new string[] { argName, Reporter.Html.ToString(), argName, Reporter.Dots.ToString() });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.ReportersInput.SuppliedInput.ShouldContain(Reporter.Html.ToString());
-            _inputs.ReportersInput.SuppliedInput.ShouldContain(Reporter.Dots.ToString());
-        }
-
-        [TestMethod]
-        [DataRow("--project")]
-        [DataRow("-p")]
-        public void ShouldPassProjectArgumentsToStryker_WithProjectArgument(string argName)
-        {
-            _target.Run(new string[] { argName, "SomeProjectName.csproj" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.SourceProjectNameInput.SuppliedInput.ShouldBe("SomeProjectName.csproj");
-        }
-
-        [TestMethod]
-        [DataRow("--solution")]
-        [DataRow("-s")]
-        public void ShouldPassSolutionArgumentPlusBasePathToStryker_WithSolutionArgument(string argName)
-        {
-            _target.Run(new string[] { argName, "SomeSolutionPath.sln" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.SolutionInput.SuppliedInput.ShouldBe("SomeSolutionPath.sln");
-        }
-
-        [TestMethod]
-        [DataRow("--test-project")]
-        [DataRow("-tp")]
-        public void ShouldPassTestProjectArgumentsToStryker_WithTestProjectArgument(string argName)
-        {
-            _target.Run(new string[] { argName, "SomeProjectName1.csproj", argName, "SomeProjectName2.csproj" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName1.csproj");
-            _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName2.csproj");
-        }
-
-        [TestMethod]
-        [DataRow("--verbosity")]
-        [DataRow("-V")]
-        public void ShouldPassLogConsoleArgumentsToStryker_WithLogConsoleArgument(string argName)
-        {
-            _target.Run(new[] { argName, "Debug" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.VerbosityInput.SuppliedInput.ShouldBe(LogEventLevel.Debug.ToString());
-        }
-
-        [TestMethod]
-        [DataRow("--log-to-file")]
-        [DataRow("-L")]
-        public void ShouldPassLogFileArgumentsToStryker_WithLogLevelFileArgument(string argName)
-        {
-            _target.Run(new string[] { argName });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.LogToFileInput.SuppliedInput.Value.ShouldBeTrue();
-        }
-
-        [TestMethod]
-        [DataRow("--dev-mode")]
-        public void WithDevModeArgument_ShouldPassDevModeArgumentsToStryker(string argName)
-        {
-            _target.Run(new string[] { argName });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.DevModeInput.SuppliedInput.Value.ShouldBeTrue();
-        }
-
-        [TestMethod]
-        [DataRow("--concurrency")]
-        [DataRow("-c")]
-        public void WithMaxConcurrentTestrunnerArgument_ShouldPassValidatedConcurrentTestrunnersToStryker(string argName)
-        {
-            _target.Run(new string[] { argName, "4" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.ConcurrencyInput.SuppliedInput.Value.ShouldBe(4);
-        }
-
-        [TestMethod]
-        [DataRow("--break-at")]
-        [DataRow("-b")]
-        public void WithCustomThresholdBreakParameter_ShouldPassThresholdBreakToStryker(string argName)
-        {
-            _target.Run(new string[] { argName, "20" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.ThresholdBreakInput.SuppliedInput.ShouldBe(20);
-        }
-
-        [TestMethod]
-        [DataRow("--mutate")]
-        [DataRow("-m")]
-        public void ShouldPassFilePatternSetToStryker_WithMutateArgs(string argName)
-        {
-            var firstFileToExclude = "**/*Service.cs";
-            var secondFileToExclude = "!**/MySpecialService.cs";
-            var thirdFileToExclude = "**/MyOtherService.cs{1..10}{32..45}";
-
-            _target.Run(new[] { argName, firstFileToExclude, argName, secondFileToExclude, argName, thirdFileToExclude });
-
-            _strykerRunnerMock.VerifyAll();
-
-            var filePatterns = _inputs.MutateInput.SuppliedInput.ToArray();
-            filePatterns.Length.ShouldBe(3);
-            filePatterns.ShouldContain(firstFileToExclude);
-            filePatterns.ShouldContain(secondFileToExclude);
-            filePatterns.ShouldContain(thirdFileToExclude);
-        }
-
-        [TestMethod]
-        [DataRow("--since")]
-        public void ShouldEnableDiffFeatureWhenPassed(string argName)
-        {
-            _target.Run(new string[] { argName });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.SinceInput.SuppliedInput.Value.ShouldBeTrue();
-        }
-
-        [TestMethod]
-        [DataRow("--since")]
-        public void ShouldSetGitDiffTargetWhenPassed(string argName)
-        {
-            _target.Run(new string[] { $"{argName}:development" });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.SinceInput.SuppliedInput.Value.ShouldBeTrue();
-            _inputs.SinceTargetInput.SuppliedInput.ShouldBe("development");
-        }
-
-        [TestMethod]
-        [DataRow("--mutation-level")]
-        [DataRow("-l")]
-        public void ShouldSetMutationLevelWhenPassed(string argName)
-        {
-            _target.Run(new string[] { argName, "Advanced" });
-
-            _inputs.MutationLevelInput.SuppliedInput.ShouldBe(MutationLevel.Advanced.ToString());
-        }
-
-        [TestMethod]
-        [DataRow("--version", "master")]
-        [DataRow("-v", "master")]
-        public void ShouldSetProjectVersionFeatureWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.ProjectVersionInput.SuppliedInput.ShouldBe("master");
-        }
-
-        [TestMethod]
-        [DataRow("--dashboard-api-key", "1234567890")]
-        public void ShouldSupplyDashboardApiKeyWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.DashboardApiKeyInput.SuppliedInput.ShouldBe("1234567890");
-        }
-
-        [TestMethod]
-        [DataRow("--with-baseline")]
-        public void ShouldSupplyWithBaselineWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.WithBaselineInput.SuppliedInput.Value.ShouldBeTrue();
-        }
-
-        [TestMethod]
-        [DataRow("-o", null)]
-        [DataRow("-o:html", "html")]
-        [DataRow("--open-report", null)]
-        [DataRow("--open-report:dashboard", "dashboard")]
-        public void ShouldSupplyOpenReportInputsWhenPassed(string arg, string expected)
-        {
-            _target.Run(new[] { arg });
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.OpenReportEnabledInput.SuppliedInput.ShouldBeTrue();
-            _inputs.OpenReportInput.SuppliedInput.ShouldBe(expected);
-        }
-
-        [TestMethod]
-        [DataRow("--azure-fileshare-sas", "sas")]
-        public void ShouldSupplyAzureFileshareSasWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.AzureFileStorageSasInput.SuppliedInput.ShouldBe("sas");
-        }
-
-        [TestMethod]
-        [DataRow("--break-on-initial-test-failure")]
-        public void ShouldSupplyBreakOnInitialTestFailureWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.BreakOnInitialTestFailureInput.SuppliedInput.HasValue.ShouldBeTrue();
-            _inputs.BreakOnInitialTestFailureInput.SuppliedInput.Value.ShouldBeTrue();
-        }
-
-        [TestMethod]
-        [DataRow("--target-framework", "net7.0")]
-        public void ShouldSupplyTargetFrameworkWhenPassed(params string[] argName)
-        {
-            _target.Run(argName);
-
-            _strykerRunnerMock.VerifyAll();
-
-            _inputs.TargetFrameworkInput.SuppliedInput.ShouldBe("net7.0");
-        }
+                Break = 0
+            }
+        };
+        var strykerRunResult = new StrykerRunResult(options, 0.1);
+
+        mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>())).Returns(strykerRunResult).Verifiable();
+
+        var target = new StrykerCli(mock.Object);
+        var result = target.Run(new string[] { });
+
+        mock.Verify();
+        target.ExitCode.ShouldBe(0);
+        result.ShouldBe(0);
+    }
+
+    [TestMethod]
+    [DataRow("--help")]
+    [DataRow("-h")]
+    [DataRow("-?")]
+    public void ShouldNotStartStryker_WithHelpArgument(string argName)
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        var target = new StrykerCli(mock.Object);
+
+        target.Run(new string[] { argName });
+
+        mock.VerifyNoOtherCalls();
+    }
+
+    [TestMethod]
+    public void ShouldThrow_OnException()
+    {
+        var mock = new Mock<IStrykerRunner>(MockBehavior.Strict);
+        mock.Setup(x => x.RunMutationTest(It.IsAny<IStrykerInputs>(), It.IsAny<ILoggerFactory>(), It.IsAny<IProjectOrchestrator>()))
+            .Throws(new Exception("Initial testrun failed"))
+            .Verifiable();
+
+        var target = new StrykerCli(mock.Object, null, _loggingInitializerMock.Object, _nugetClientMock.Object);
+        Should.Throw<Exception>(() => target.Run(new string[] { }));
+    }
+
+    [TestMethod]
+    [DataRow("--reporter")]
+    [DataRow("-r")]
+    public void ShouldPassReporterArgumentsToStryker_WithReporterArgument(string argName)
+    {
+        _target.Run(new string[] { argName, Reporter.Html.ToString(), argName, Reporter.Dots.ToString() });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.ReportersInput.SuppliedInput.ShouldContain(Reporter.Html.ToString());
+        _inputs.ReportersInput.SuppliedInput.ShouldContain(Reporter.Dots.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("--project")]
+    [DataRow("-p")]
+    public void ShouldPassProjectArgumentsToStryker_WithProjectArgument(string argName)
+    {
+        _target.Run(new string[] { argName, "SomeProjectName.csproj" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.SourceProjectNameInput.SuppliedInput.ShouldBe("SomeProjectName.csproj");
+    }
+
+    [TestMethod]
+    [DataRow("--solution")]
+    [DataRow("-s")]
+    public void ShouldPassSolutionArgumentPlusBasePathToStryker_WithSolutionArgument(string argName)
+    {
+        _target.Run(new string[] { argName, "SomeSolutionPath.sln" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.SolutionInput.SuppliedInput.ShouldBe("SomeSolutionPath.sln");
+    }
+
+    [TestMethod]
+    [DataRow("--test-project")]
+    [DataRow("-tp")]
+    public void ShouldPassTestProjectArgumentsToStryker_WithTestProjectArgument(string argName)
+    {
+        _target.Run(new string[] { argName, "SomeProjectName1.csproj", argName, "SomeProjectName2.csproj" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName1.csproj");
+        _inputs.TestProjectsInput.SuppliedInput.ShouldContain("SomeProjectName2.csproj");
+    }
+
+    [TestMethod]
+    [DataRow("--verbosity")]
+    [DataRow("-V")]
+    public void ShouldPassLogConsoleArgumentsToStryker_WithLogConsoleArgument(string argName)
+    {
+        _target.Run(new[] { argName, "Debug" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.VerbosityInput.SuppliedInput.ShouldBe(LogEventLevel.Debug.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("--log-to-file")]
+    [DataRow("-L")]
+    public void ShouldPassLogFileArgumentsToStryker_WithLogLevelFileArgument(string argName)
+    {
+        _target.Run(new string[] { argName });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.LogToFileInput.SuppliedInput.Value.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("--dev-mode")]
+    public void WithDevModeArgument_ShouldPassDevModeArgumentsToStryker(string argName)
+    {
+        _target.Run(new string[] { argName });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.DevModeInput.SuppliedInput.Value.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("--concurrency")]
+    [DataRow("-c")]
+    public void WithMaxConcurrentTestrunnerArgument_ShouldPassValidatedConcurrentTestrunnersToStryker(string argName)
+    {
+        _target.Run(new string[] { argName, "4" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.ConcurrencyInput.SuppliedInput.Value.ShouldBe(4);
+    }
+
+    [TestMethod]
+    [DataRow("--break-at")]
+    [DataRow("-b")]
+    public void WithCustomThresholdBreakParameter_ShouldPassThresholdBreakToStryker(string argName)
+    {
+        _target.Run(new string[] { argName, "20" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.ThresholdBreakInput.SuppliedInput.ShouldBe(20);
+    }
+
+    [TestMethod]
+    [DataRow("--mutate")]
+    [DataRow("-m")]
+    public void ShouldPassFilePatternSetToStryker_WithMutateArgs(string argName)
+    {
+        var firstFileToExclude = "**/*Service.cs";
+        var secondFileToExclude = "!**/MySpecialService.cs";
+        var thirdFileToExclude = "**/MyOtherService.cs{1..10}{32..45}";
+
+        _target.Run(new[] { argName, firstFileToExclude, argName, secondFileToExclude, argName, thirdFileToExclude });
+
+        _strykerRunnerMock.VerifyAll();
+
+        var filePatterns = _inputs.MutateInput.SuppliedInput.ToArray();
+        filePatterns.Length.ShouldBe(3);
+        filePatterns.ShouldContain(firstFileToExclude);
+        filePatterns.ShouldContain(secondFileToExclude);
+        filePatterns.ShouldContain(thirdFileToExclude);
+    }
+
+    [TestMethod]
+    [DataRow("--since")]
+    public void ShouldEnableDiffFeatureWhenPassed(string argName)
+    {
+        _target.Run(new string[] { argName });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.SinceInput.SuppliedInput.Value.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("--since")]
+    public void ShouldSetGitDiffTargetWhenPassed(string argName)
+    {
+        _target.Run(new string[] { $"{argName}:development" });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.SinceInput.SuppliedInput.Value.ShouldBeTrue();
+        _inputs.SinceTargetInput.SuppliedInput.ShouldBe("development");
+    }
+
+    [TestMethod]
+    [DataRow("--mutation-level")]
+    [DataRow("-l")]
+    public void ShouldSetMutationLevelWhenPassed(string argName)
+    {
+        _target.Run(new string[] { argName, "Advanced" });
+
+        _inputs.MutationLevelInput.SuppliedInput.ShouldBe(MutationLevel.Advanced.ToString());
+    }
+
+    [TestMethod]
+    [DataRow("--version", "master")]
+    [DataRow("-v", "master")]
+    public void ShouldSetProjectVersionFeatureWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.ProjectVersionInput.SuppliedInput.ShouldBe("master");
+    }
+
+    [TestMethod]
+    [DataRow("--dashboard-api-key", "1234567890")]
+    public void ShouldSupplyDashboardApiKeyWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.DashboardApiKeyInput.SuppliedInput.ShouldBe("1234567890");
+    }
+
+    [TestMethod]
+    [DataRow("--with-baseline")]
+    public void ShouldSupplyWithBaselineWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.WithBaselineInput.SuppliedInput.Value.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("-o", null)]
+    [DataRow("-o:html", "html")]
+    [DataRow("--open-report", null)]
+    [DataRow("--open-report:dashboard", "dashboard")]
+    public void ShouldSupplyOpenReportInputsWhenPassed(string arg, string expected)
+    {
+        _target.Run(new[] { arg });
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.OpenReportEnabledInput.SuppliedInput.ShouldBeTrue();
+        _inputs.OpenReportInput.SuppliedInput.ShouldBe(expected);
+    }
+
+    [TestMethod]
+    [DataRow("--azure-fileshare-sas", "sas")]
+    public void ShouldSupplyAzureFileshareSasWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.AzureFileStorageSasInput.SuppliedInput.ShouldBe("sas");
+    }
+
+    [TestMethod]
+    [DataRow("--break-on-initial-test-failure")]
+    public void ShouldSupplyBreakOnInitialTestFailureWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.BreakOnInitialTestFailureInput.SuppliedInput.HasValue.ShouldBeTrue();
+        _inputs.BreakOnInitialTestFailureInput.SuppliedInput.Value.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("--target-framework", "net7.0")]
+    public void ShouldSupplyTargetFrameworkWhenPassed(params string[] argName)
+    {
+        _target.Run(argName);
+
+        _strykerRunnerMock.VerifyAll();
+
+        _inputs.TargetFrameworkInput.SuppliedInput.ShouldBe("net7.0");
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/BaselineMutantFilterTests.cs
@@ -22,7 +22,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
     public class BaselineMutantFilterTests : TestBase
     {
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             // Arrange
             var gitInfoProvider = new Mock<IGitInfoProvider>(MockBehavior.Loose);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeMutationMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/ExcludeMutationMutantFilterTests.cs
@@ -11,7 +11,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
     public class ExcludeMutationMutantFilterTests : TestBase
     {
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             var target = new IgnoreMutationMutantFilter() as IMutantFilter;
             target.DisplayName.ShouldBe("mutation type filter");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/FilePatternMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/FilePatternMutantFilterTests.cs
@@ -15,7 +15,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
     public class FilePatternMutantFilterTests : TestBase
     {
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             var target = new FilePatternMutantFilter(new StrykerOptions()) as IMutantFilter;
             target.DisplayName.ShouldBe("mutate filter");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoreBlockMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoreBlockMutantFilterTests.cs
@@ -13,7 +13,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
     public class IgnoreBlockMutantFilterTests : TestBase
     {
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             var sut = new IgnoreBlockMutantFilter();
             sut.DisplayName.ShouldBe("block already covered filter");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -20,7 +20,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
 
 
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             var target = new IgnoredMethodMutantFilter() as IMutantFilter;
             target.DisplayName.ShouldBe("method filter");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/SinceMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/SinceMutantFilterTests.cs
@@ -18,7 +18,7 @@ namespace Stryker.Core.UnitTest.MutantFilters
     public class SinceMutantFilterTests : TestBase
     {
         [TestMethod]
-        public static void ShouldHaveName()
+        public void ShouldHaveName()
         {
             // Arrange
             var diffProviderMock = new Mock<IDiffProvider>(MockBehavior.Loose);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1469,7 +1469,7 @@ int TestMethod()
     }
 
     [TestMethod]
-    public void ShouldSkipStringsInSwitchExpression()
+    public void ShouldMutatetringsInSwitchExpression()
     {
         string source = @"string TestMethod()
 {
@@ -1480,11 +1480,14 @@ int TestMethod()
 }";
         string expected = @"string TestMethod()
 {if(StrykerNamespace.MutantControl.IsActive(0)){}else{
-	return input switch
+	return (StrykerNamespace.MutantControl.IsActive(1)?input switch
 	{
-		""test"" => (StrykerNamespace.MutantControl.IsActive(1)?"""":""test""
-)	};
-    }return default(string);}
+""""=> ""test""
+	}:input switch
+	{
+		""test"" => (StrykerNamespace.MutantControl.IsActive(2)?"""":""test""
+)	});
+}return default(string);}
 ";
         ShouldMutateSourceInClassToExpected(source, expected);
     }
@@ -1836,35 +1839,5 @@ else        {
             .Single();
 
         secondMutant.Id.ShouldBe(firstMutant.Id + 1);
-    }
-
-    [TestMethod]
-    public void ShouldMutateSwitchExpression()
-    {
-        var source = @"
-    public void ListPatterns()
-    {
-        decimal balance = 0m;
-        foreach (string[] transaction in transactions)
-        {
-            balance += transaction switch
-            {
-            [_, ""DEPOSIT"", _, var amount] => decimal.Parse(amount),
-                _ => throw new InvalidOperationException($""Record {string.Join("", "", transaction)} is not in the expected format!""),
-            };
-            Console.WriteLine($""Record: {string.Join("", "", transaction)}, New balance: {balance:C}"");
-        }
-    }";
-
-        var expected = @"static string Value
-{get {if(StrykerNamespace.MutantControl.IsActive(0)){}else{ return (StrykerNamespace.MutantControl.IsActive(1)?"""":""TestDescription"");
-        }
-return default(string);
-        }
-        set {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ value = (StrykerNamespace.MutantControl.IsActive(3)?"""":""TestDescription"");
-        }
-}}
-static TestClass() { using (new StrykerNamespace.MutantContext()) { } }}";
-        ShouldMutateSourceInClassToExpected(source, expected);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1816,11 +1816,18 @@ else        {
     [TestMethod]
     public void ShouldIncrementMutantCountUniquely()
     {
+        var strykerOptions = new StrykerOptions
+        {
+            MutantIdProvider = new BasicIdProvider()
+        };
+
+        var firstOrchestrator =
+            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: strykerOptions);
         var secondOrchestrator =
-            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: new StrykerOptions());
+            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: strykerOptions);
         var node = SyntaxFactory.ParseExpression("1 == 1") as BinaryExpressionSyntax;
 
-        var firstMutant = _target
+        var firstMutant = firstOrchestrator
             .GenerateMutationsForNode(node, null, new MutationContext(secondOrchestrator))
             .Single();
 
@@ -1830,4 +1837,6 @@ else        {
 
         secondMutant.Id.ShouldBe(firstMutant.Id + 1);
     }
+
+
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1838,5 +1838,33 @@ else        {
         secondMutant.Id.ShouldBe(firstMutant.Id + 1);
     }
 
+    [TestMethod]
+    public void ShouldMutateSwitchExpression()
+    {
+        var source = @"
+    public void ListPatterns()
+    {
+        decimal balance = 0m;
+        foreach (string[] transaction in transactions)
+        {
+            balance += transaction switch
+            {
+            [_, ""DEPOSIT"", _, var amount] => decimal.Parse(amount),
+                _ => throw new InvalidOperationException($""Record {string.Join("", "", transaction)} is not in the expected format!""),
+            };
+            Console.WriteLine($""Record: {string.Join("", "", transaction)}, New balance: {balance:C}"");
+        }
+    }";
 
+        var expected = @"static string Value
+{get {if(StrykerNamespace.MutantControl.IsActive(0)){}else{ return (StrykerNamespace.MutantControl.IsActive(1)?"""":""TestDescription"");
+        }
+return default(string);
+        }
+        set {if(StrykerNamespace.MutantControl.IsActive(2)){}else{ value = (StrykerNamespace.MutantControl.IsActive(3)?"""":""TestDescription"");
+        }
+}}
+static TestClass() { using (new StrykerNamespace.MutantContext()) { } }}";
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
@@ -12,10 +12,6 @@ namespace Stryker.Core.UnitTest.Mutants
     /// </summary>
     public partial class MutantOrchestratorTestsBase : TestBase
     {
-        [GeneratedRegex(@"IsActive\(\d+\)")]
-        private static partial Regex IsActiveRegex();
-        private const string Replacement = "IsActive(0)";
-
         protected CsharpMutantOrchestrator _target;
         protected CodeInjection _injector = new();
 
@@ -33,8 +29,6 @@ namespace Stryker.Core.UnitTest.Mutants
         {
             var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(actual), null);
             actual = actualNode.GetRoot().ToFullString();
-            expected = IsActiveRegex().Replace(expected, Replacement);
-            actual = IsActiveRegex().Replace(actual, Replacement);
             actual = actual.Replace(_injector.HelperNamespace, "StrykerNamespace");
             actualNode = CSharpSyntaxTree.ParseText(actual);
             var expectedNode = CSharpSyntaxTree.ParseText(expected);

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -470,7 +470,7 @@ public class InputFileResolver : IInputFileResolver
             throw new InputException($"No .csproj or .fsproj file found, please check your project directory at {path}");
         }
 
-            _logger.LogTrace("Scanned the directory {Path} for *.csproj files: found {ProjectFilesCount}", path, projectFiles);
+        _logger.LogTrace("Scanned the directory {Path} for *.csproj files: found {ProjectFilesCount}", path, projectFiles);
 
         switch (projectFiles.Length)
         {

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -4,7 +4,6 @@ using Stryker.Core.Options;
 
 namespace Stryker.Core.Mutants;
 
-
 public abstract class BaseMutantOrchestrator
 {
     public readonly StrykerOptions Options;
@@ -23,7 +22,6 @@ public abstract class BaseMutantOrchestrator
     public ICollection<Mutant> Mutants { get; set; }
 
     protected int GetNextId() => _idProvider.NextId();
-
 
     /// <summary>
     /// Gets the stored mutants and resets the mutant list to an empty collection

--- a/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/BaseMutantOrchestrator.cs
@@ -1,50 +1,51 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading;
 using Stryker.Core.Options;
 
-namespace Stryker.Core.Mutants
+namespace Stryker.Core.Mutants;
+
+
+public abstract class BaseMutantOrchestrator
 {
-    public abstract class BaseMutantOrchestrator
+    public readonly StrykerOptions Options;
+    private readonly IProvideId _idProvider;
+
+    protected BaseMutantOrchestrator(StrykerOptions options)
     {
-        public readonly StrykerOptions Options;
-
-        public bool MustInjectCoverageLogic =>
-            Options != null && Options.OptimizationMode.HasFlag(OptimizationModes.CoverageBasedTest) &&
-            !Options.OptimizationMode.HasFlag(OptimizationModes.CaptureCoveragePerTest);
-
-        public ICollection<Mutant> Mutants { get; set; }
-
-        private static int _mutantCount;
-
-        protected static int MutantCount => _mutantCount;
-
-        protected static void IncreaseMutantCount() => Interlocked.Increment(ref _mutantCount);
-
-        protected BaseMutantOrchestrator(StrykerOptions options) => Options = options;
-
-        /// <summary>
-        /// Gets the stored mutants and resets the mutant list to an empty collection
-        /// </summary>
-        public virtual IReadOnlyCollection<Mutant> GetLatestMutantBatch()
-        {
-            var tempMutants = Mutants;
-            Mutants = new Collection<Mutant>();
-            return (IReadOnlyCollection<Mutant>)tempMutants;
-        }
+        Options = options;
+        _idProvider = Options.MutantIdProvider ?? new BasicIdProvider();
     }
+
+    public bool MustInjectCoverageLogic =>
+        Options != null && Options.OptimizationMode.HasFlag(OptimizationModes.CoverageBasedTest) &&
+        !Options.OptimizationMode.HasFlag(OptimizationModes.CaptureCoveragePerTest);
+
+    public ICollection<Mutant> Mutants { get; set; }
+
+    protected int GetNextId() => _idProvider.NextId();
+
 
     /// <summary>
-    /// Mutates abstract syntax trees using mutators and places all mutations inside the abstract syntax tree.
-    /// Orchestrator: to arrange or manipulate, especially by means of clever or thorough planning or maneuvering.
+    /// Gets the stored mutants and resets the mutant list to an empty collection
     /// </summary>
-    /// <typeparam name="T">The type of syntax node to mutate</typeparam>
-    /// <typeparam name="TY">Associated semantic model if any</typeparam>
-    public abstract class BaseMutantOrchestrator<T, TY> : BaseMutantOrchestrator
+    public virtual IReadOnlyCollection<Mutant> GetLatestMutantBatch()
     {
-        protected BaseMutantOrchestrator(StrykerOptions input) : base(input)
-        {}
-
-        public abstract T Mutate(T input, TY semanticModel);
+        var tempMutants = Mutants;
+        Mutants = new Collection<Mutant>();
+        return (IReadOnlyCollection<Mutant>)tempMutants;
     }
+}
+
+/// <summary>
+/// Mutates abstract syntax trees using mutators and places all mutations inside the abstract syntax tree.
+/// Orchestrator: to arrange or manipulate, especially by means of clever or thorough planning or maneuvering.
+/// </summary>
+/// <typeparam name="T">The type of syntax node to mutate</typeparam>
+/// <typeparam name="TY">Associated semantic model if any</typeparam>
+public abstract class BaseMutantOrchestrator<T, TY> : BaseMutantOrchestrator
+{
+    protected BaseMutantOrchestrator(StrykerOptions input) : base(input)
+    {}
+
+    public abstract T Mutate(T input, TY semanticModel);
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -138,7 +138,7 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
         {
             foreach (var mutation in mutator.Mutate(current, semanticModel, Options))
             {
-                var newMutant = CreateNewMutant(mutation, mutator, context);
+                var newMutant = CreateNewMutant(mutation, context);
                 // Skip if the mutant is a duplicate
                 if (IsMutantDuplicate(newMutant, mutation))
                 {
@@ -159,7 +159,7 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
     /// Creates a new mutant for the given mutation, mutator and context. Returns null if the mutant
     /// is a duplicate.
     /// </summary>
-    private Mutant CreateNewMutant(Mutation mutation, IMutator mutator, MutationContext context)
+    private Mutant CreateNewMutant(Mutation mutation, MutationContext context)
     {
         var mutantIgnored = context.FilteredMutators?.Contains(mutation.Type) ?? false;
         return new Mutant

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -63,6 +63,7 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
         new MemberAccessExpressionOrchestrator<PostfixUnaryExpressionSyntax>(t =>
             t.IsKind(SyntaxKind.SuppressNullableWarningExpression)),
         new ConditionalExpressionOrchestrator(),
+        new ConstantPatternSyntaxOrchestrator(),
         // ensure static constructs are marked properly
         new StaticFieldDeclarationOrchestrator(),
         new StaticConstructorOrchestrator(),

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/ConstantPatternSyntaxOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/ConstantPatternSyntaxOrchestrator.cs
@@ -1,0 +1,9 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Stryker.Core.Mutants.CsharpNodeOrchestrators;
+internal class ConstantPatternSyntaxOrchestrator: NodeSpecificOrchestrator<ConstantPatternSyntax, ConstantPatternSyntax>
+{
+    protected override MutationContext PrepareContext(ConstantPatternSyntax node, MutationContext context) => base.PrepareContext(node, context).BlockInjection();
+
+    protected override void RestoreContext(MutationContext context) => base.RestoreContext(context.EnableInjection());
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/IdProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/IdProvider.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+
+namespace Stryker.Core.Mutants;
+
+public interface IProvideId
+{
+    int NextId();
+}
+
+internal class BasicIdProvider : IProvideId
+{
+    private int _id;
+
+    public int NextId() => Interlocked.Increment(ref _id)-1;
+}

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Stryker.Core.Mutants.CsharpNodeOrchestrators;
 using Stryker.Core.Mutators;
 
 namespace Stryker.Core.Mutants;
@@ -100,6 +99,17 @@ internal class MutationContext
         return control is MutationControl.Block or MutationControl.Member ? new MutationContext(this): this;
     }
 
+    public MutationContext BlockInjection()
+    {
+        _mutation.BlockInjection();
+        return this;
+    }
+
+    public MutationContext EnableInjection()
+    {
+        _mutation.EnableInjection();
+        return this;
+    }
     /// <summary>
     /// Call this when leaving a control syntax structure
     /// </summary>

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
-using RegexParser.Nodes;
 using Stryker.Core.Helpers;
 using Stryker.Core.Logging;
 
@@ -17,7 +16,7 @@ namespace Stryker.Core.Mutants;
 public enum MutationControl
 {
     /// <summary>
-    /// Syntax that is part of a member access expression (such as class.Property.Property.Invoke()
+    /// Syntax that is part of a member access expression (such as class.Property.Property.Invoke())
     /// </summary>
     MemberAccess,
     /// <summary>

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -171,7 +171,7 @@ internal class MutationStore
     /// <returns>a syntax expression with the mutations included </returns>
     public ExpressionSyntax Inject(ExpressionSyntax mutatedNode, ExpressionSyntax sourceNode)
     {
-        if (_injectionBlockCounter>0 || _pendingMutations.Peek().Control == MutationControl.MemberAccess)
+        if (_injectionBlockCounter > 0 || _pendingMutations.Peek().Control == MutationControl.MemberAccess)
         {
             // do not inject if explicitly blocked
             // never inject at member access level, there is no known control structure

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -114,6 +114,7 @@ internal class MutationStore
     /// Restore mutation injection
     /// </summary>
     public void EnableInjection() => _injectionBlockCounter--;
+
     private PendingMutations FindControl(MutationControl control) => _pendingMutations.FirstOrDefault(item => item.Control >= control);
 
     /// <summary>
@@ -172,7 +173,7 @@ internal class MutationStore
     {
         if (_injectionBlockCounter>0 || _pendingMutations.Peek().Control == MutationControl.MemberAccess)
         {
-            // do not inject if explicitly blocked;
+            // do not inject if explicitly blocked
             // never inject at member access level, there is no known control structure
             return mutatedNode;
         }

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -46,6 +46,7 @@ internal class MutationStore
     protected static readonly ILogger Logger = ApplicationLogging.LoggerFactory.CreateLogger<MutationStore>();
     private readonly MutantPlacer _mutantPlacer;
     private readonly Stack<PendingMutations> _pendingMutations = new();
+    private int _injectionBlockCounter;
 
     /// <summary>
     /// Constructor
@@ -103,6 +104,16 @@ internal class MutationStore
         }
     }
 
+    /// <summary>
+    /// Prevent any mutation injection
+    /// </summary>
+    /// <remarks>This method is typically used for constant syntax node, where mutations need to be controlled at a higher syntax level.</remarks>
+    public void BlockInjection() => _injectionBlockCounter++;
+
+    /// <summary>
+    /// Restore mutation injection
+    /// </summary>
+    public void EnableInjection() => _injectionBlockCounter--;
     private PendingMutations FindControl(MutationControl control) => _pendingMutations.FirstOrDefault(item => item.Control >= control);
 
     /// <summary>
@@ -159,8 +170,9 @@ internal class MutationStore
     /// <returns>a syntax expression with the mutations included </returns>
     public ExpressionSyntax Inject(ExpressionSyntax mutatedNode, ExpressionSyntax sourceNode)
     {
-        if (_pendingMutations.Peek().Control == MutationControl.MemberAccess)
+        if (_injectionBlockCounter>0 || _pendingMutations.Peek().Control == MutationControl.MemberAccess)
         {
+            // do not inject if explicitly blocked;
             // never inject at member access level, there is no known control structure
             return mutatedNode;
         }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
@@ -43,7 +43,7 @@ namespace Stryker.Core.MutationTest
                     "Test run for {Mutants} is {Result} ",
                     string.Join(", ", mutantsToTest.Select(x => x.DisplayName)),
                     result.FailingTests.Count == 0 ? "success" : "failed");
-                Logger.LogTrace("Test run : {ResultMessage}",result.ResultMessage);
+ 
                 if (result.Messages is not null && result.Messages.Any())
                 {
                     Logger.LogTrace(

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -34,8 +34,7 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
     private static bool IsStringLiteral(LiteralExpressionSyntax node)
     {
         var kind = node.Kind();
-        return kind == SyntaxKind.StringLiteralExpression
-               && node.Parent is not ConstantPatternSyntax;
+        return kind == SyntaxKind.StringLiteralExpression;
     }
 
     private static bool IsSpecialType(SyntaxNode root) => root switch

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerInputs.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using Stryker.Core.Mutants;
 using Stryker.Core.Mutators;
 using Stryker.Core.Options.Inputs;
 
@@ -168,6 +169,7 @@ namespace Stryker.Core.Options
                 SinceTarget = sinceTarget,
                 ReportTypeToOpen = OpenReportInput.Validate(OpenReportEnabledInput.Validate()),
                 BreakOnInitialTestFailure = BreakOnInitialTestFailureInput.Validate(),
+                MutantIdProvider = new BasicIdProvider()
             };
             return _strykerOptionsCache;
         }

--- a/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
+++ b/src/Stryker.Core/Stryker.Core/Options/StrykerOptions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.Baseline.Providers;
+using Stryker.Core.Mutants;
 using Stryker.Core.Mutators;
 using Stryker.Core.Options.Inputs;
 using Stryker.Core.Reporters;
@@ -18,7 +19,7 @@ public class StrykerOptions
     public string MsBuildPath { get; init; }
 
     /// <summary>
-    /// If true, stryker will fail when mutants are not being rollbacked.
+    /// when true: adjust Stryker logic to make it easier to analyse/debug
     /// </summary>
     public bool DevMode { get; init; }
 
@@ -224,7 +225,13 @@ public class StrykerOptions
     /// Instruct Stryker to break execution when at least one test failed on initial run.
     /// </summary>
     public bool BreakOnInitialTestFailure { get; set; }
-    
+
+
+    /// <summary>
+    /// Get/set the mutation id provider
+    /// </summary>
+    public IProvideId MutantIdProvider {get; set;}
+
 
     private readonly string _workingDirectoryField;
 


### PR DESCRIPTION
Main (unique?) visible impact is the ability to mutate strings that are part of case in switch expressions.
Note that this allows new mutators (that remain to be defined as of today).
Fix #2951

Not related: 
- Wrap Spectre Console for usage with CommandLineUtils. This increase overall consistency and fixes a flaky test.
- Mutant IDs generation is in a dedicated component
- Restore stable and known mutant IDs for unit tests