### PR TITLE
fix: Disable debug trace

### DIFF
--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.NUnit/Constructs.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.NUnit/Constructs.cs
@@ -49,7 +49,7 @@ namespace NetCoreTestProject.NUnit
         [Test]
         [TestCaseSource(nameof(ObjectSource))]
         // all test cases refer to the same test
-        public void TestAgeIndirectObject(StrykerComments sut)
+        public void TestAgeIndirectObject(KilledMutants sut)
         {
             Console.WriteLine($"ObjectSource test:{sut.Age}");
             ClassicAssert.AreEqual(sut.Age > 29 ? "Yes" : "No", sut.IsExpired());

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
@@ -4,7 +4,7 @@ namespace NetCoreTestProject.XUnit;
 public class VariousTests
 {
     [Fact]
-    public void UseAssertTest()
+    public void AssertShouldKillMutation()
     {
         var target = new TargetProject.StrykerFeatures.UseAssert();
         target.IncrementCounter();

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace NetCoreTestProject.XUnit;
+public class VariousTests
+{
+    [Fact]
+    public void UseAssertTest()
+    {
+        var target = new TargetProject.StrykerFeatures.UseAssert();
+        target.IncrementCounter();
+        // no assert needed, Debug.Assert will throw if counter is less than 0
+    }
+}

--- a/integrationtest/TargetProjects/NetCore/TargetProject/StrykerFeatures/UseAssert.cs
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/StrykerFeatures/UseAssert.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace TargetProject.StrykerFeatures;
+public class UseAssert
+{
+    private int _counter = 0;
+
+    public void IncrementCounter()
+    {
+        _counter++;
+        Debug.Assert(_counter > 0, "Counter should be greater than 0");
+    }
+
+}

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -82,8 +82,8 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 242, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
-            CheckReportTestCounts(report, total: 10);
+            CheckReportMutants(report, total: 592, ignored: 244, survived: 4, killed: 9, timeout: 2, nocoverage: 302);
+            CheckReportTestCounts(report, total: 11);
         }
 
         [Fact]
@@ -121,8 +121,8 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 106, survived: 2, killed: 8, timeout: 2, nocoverage: 436);
-            CheckReportTestCounts(report, total: 20);
+            CheckReportMutants(report, total: 592, ignored: 107, survived: 5, killed: 11, timeout: 2, nocoverage: 436);
+            CheckReportTestCounts(report, total: 21);
         }
 
         [Fact]
@@ -140,8 +140,8 @@ namespace IntegrationTests
 
             var report = JsonConvert.DeserializeObject<JsonReport>(strykerRunOutput);
 
-            CheckReportMutants(report, total: 585, ignored: 242, survived: 2, killed: 6, timeout: 2, nocoverage: 302);
-            CheckReportTestCounts(report, total: 22);
+            CheckReportMutants(report, total: 592, ignored: 244, survived: 4, killed: 9, timeout: 2, nocoverage: 302);
+            CheckReportTestCounts(report, total: 23);
         }
 
         private void CheckMutationKindsValidity(JsonReport report)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/CoverageCollectorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/CoverageCollectorTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using Shouldly;
 using Stryker.DataCollector;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
 
 namespace Stryker.Core.UnitTest.TestRunners
 {
@@ -28,6 +29,26 @@ namespace Stryker.Core.UnitTest.TestRunners
             collector.TestSessionStart(start);
             collector.TestCaseStart(new TestCaseStartArgs(new TestCase("theTest", new Uri("xunit://"), "source.cs")));
             MutantControl.CaptureCoverage.ShouldBeTrue();
+            collector.TestSessionEnd(new TestSessionEndArgs());
+        }
+
+        [TestMethod]
+        public void RedirectDebugAssert()
+        {
+            var collector = new CoverageCollector();
+
+            var start = new TestSessionStartArgs
+            {
+                Configuration = CoverageCollector.GetVsTestSettings(false, null, "Stryker.Core.UnitTest.TestRunners")
+            };
+            var mock = new Mock<IDataCollectionSink>(MockBehavior.Loose);
+            collector.Initialize(mock.Object);
+            collector.TestSessionStart(start);
+
+            var assert = () => Debug.Fail("test"); // NOSONAR : This is a test case, we want to test the behavior of Debug.Assert
+
+            assert.ShouldThrow<ArgumentException>();
+            collector.TestSessionEnd(new TestSessionEndArgs());
         }
 
         [TestMethod]
@@ -52,6 +73,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             collector.TestCaseStart(new TestCaseStartArgs(testCase));
 
             MutantControl.ActiveMutant.ShouldBe(10);
+            collector.TestSessionEnd(new TestSessionEndArgs());
         }
 
         [TestMethod]
@@ -72,6 +94,7 @@ namespace Stryker.Core.UnitTest.TestRunners
             collector.TestSessionStart(start);
 
             MutantControl.ActiveMutant.ShouldBe(5);
+            collector.TestSessionEnd(new TestSessionEndArgs());
         }
 
         [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/CoverageCollectorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/CoverageCollectorTests.cs
@@ -45,7 +45,10 @@ namespace Stryker.Core.UnitTest.TestRunners
             collector.Initialize(mock.Object);
             collector.TestSessionStart(start);
 
-            var assert = () => Debug.Fail("test"); // NOSONAR : This is a test case, we want to test the behavior of Debug.Assert
+            Debug.Write("This is lost.");
+            Debug.WriteLine("This also.");
+
+            var assert = () => Debug.Fail("test");
 
             assert.ShouldThrow<ArgumentException>();
             collector.TestSessionEnd(new TestSessionEndArgs());


### PR DESCRIPTION
Make Stryker compatible with debug assertions logic, so that a mutant is considered as killed if it result in a failed assertion.

Disable `Debug.Assert` report dialogs. Failed assertions result in an argument exception raised, ensuring this are recognized as failed tests by Stryker.

Fixes #2375

Note: coverage reporting is wrong. For some reason, Sonar does not capture any coverage data for the DataCollector. I have added a dedicated test that does cover all testable lines.