### PR TITLE
feat(ignore mutation): Add support for ignoring mutations in code using mutiline string comments

### DIFF
--- a/docs/ignore-mutations.md
+++ b/docs/ignore-mutations.md
@@ -80,8 +80,8 @@ x = x +
 SomeMethod(x*5)
 * SomeOtherMethod(x/2);
 ```
-will only mark mutations impacting `SomeMEthod(x*5)` as ignored, keeping every other mutations in the expression.
-- while multi line comments cannot be used anywhere within the code, Stryker may not be able to identiy which part of the code they refer to.
+will only mark mutations impacting `SomeMethod(x*5)` as ignored, keeping every other mutations in the expression.
+- while multi line comments cann be used anywhere within the code, Stryker may not be able to identiy which part of the code they refer to.
 Meaning you may get what you expect. This is due to how Stryker and the Roslyn compiler interact. That is why we recommend using single line comments.
 
 ### Examples
@@ -100,4 +100,3 @@ y++; // will be mutated
 // Stryker disable once Arithmetic,Update
 i--; // won't be mutated
 ```
-

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -932,25 +932,8 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 	x/=2;
 }}";
 
-        //ShouldMutateSourceInClassToExpected(source, expected);
-        
-        source = @"public void SomeMethod() {
-	var x = 0;
-	{ /* Stryker disable all */
-	  x++;
-	}
-	x/=2;
-}";
-        expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(4)){}else{
-	var x = 0;
-{if(StrykerNamespace.MutantControl.IsActive(5)){}else{ /* Stryker disable all */
-	  x++;
-	}
-}if(StrykerNamespace.MutantControl.IsActive(8)){	x*=2;
-}else{	x/=2;
-}}}";
-
         ShouldMutateSourceInClassToExpected(source, expected);
+
         source = @"public void SomeMethod() {
 	var x = 0;
 	{
@@ -969,6 +952,70 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 }else{	x/=2;
 }}}";
         ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateIfDisabledByMultilineComment()
+    {
+        var source = @"public void SomeMethod() {
+	var x = 0;
+    if (condition && other) /* Stryker disable once all */ {  
+	  x++;
+      x*=2;
+	}
+	x/=2;
+}";
+        var expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+	var x = 0;
+    if ((StrykerNamespace.MutantControl.IsActive(0)?!(condition && other):(StrykerNamespace.MutantControl.IsActive(0)?condition || other:condition && other))) /* Stryker disable once all */ {  
+	  x++;
+      x*=2;
+	}
+if(StrykerNamespace.MutantControl.IsActive(0)){	x*=2;
+}else{	x/=2;
+}}}";
+        ;
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+
+        source = @"public void SomeMethod() {
+	var x = 0;
+	{ /* Stryker disable all */
+	  x++;
+	}
+	x/=2;
+}";
+        expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(4)){}else{
+	var x = 0;
+{if(StrykerNamespace.MutantControl.IsActive(5)){}else{ /* Stryker disable all */
+	  x++;
+	}
+}if(StrykerNamespace.MutantControl.IsActive(8)){	x*=2;
+}else{	x/=2;
+}}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+        
+
+    }
+
+    [TestMethod]
+    [DataRow("/* Stryker disable once all*/ x++;", "/* Stryker disable once all*/ x++;")]
+    [DataRow("if (cond) /* Stryker disable once all*/ x++;", "if ((StrykerNamespace.MutantControl.IsActive(0)?!(cond):cond)) /* Stryker disable once all*/ x++;")]
+    [DataRow("if (/* Stryker disable once all*/cond) x++;", "if (/* Stryker disable once all*/cond) if(StrykerNamespace.MutantControl.IsActive(0)){;}else{if(StrykerNamespace.MutantControl.IsActive(0)){x--;}else{x++;}}")]
+    public void ShouldNotMutateDependingOnWhereMultilineCommentIs(string source, string expected)
+    {
+        var sourceTemplate = $@"public void SomeMethod() {{
+	var x = 0;
+	{source}
+}}";
+        var expectedTemplate = $@"public void SomeMethod() {{if(StrykerNamespace.MutantControl.IsActive(0)){{}}else{{
+	var x = 0;
+{expected}
+ }}}}";
+        ;
+
+        ShouldMutateSourceInClassToExpected(sourceTemplate, expectedTemplate);
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -932,20 +932,18 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 	x/=2;
 }}";
 
-//        ShouldMutateSourceInClassToExpected(source, expected);
+        //ShouldMutateSourceInClassToExpected(source, expected);
         
         source = @"public void SomeMethod() {
 	var x = 0;
-	{
-	/* Stryker disable all */
+	{ /* Stryker disable all */
 	  x++;
 	}
 	x/=2;
 }";
         expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(4)){}else{
 	var x = 0;
-{if(StrykerNamespace.MutantControl.IsActive(5)){}else	{
-	/* Stryker disable all */
+{if(StrykerNamespace.MutantControl.IsActive(5)){}else{ /* Stryker disable all */
 	  x++;
 	}
 }if(StrykerNamespace.MutantControl.IsActive(8)){	x*=2;
@@ -953,7 +951,6 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 }}}";
 
         ShouldMutateSourceInClassToExpected(source, expected);
-        /*
         source = @"public void SomeMethod() {
 	var x = 0;
 	{
@@ -972,7 +969,6 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 }else{	x/=2;
 }}}";
         ShouldMutateSourceInClassToExpected(source, expected);
-        */
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -86,7 +86,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
             MutationLevel = MutationLevel.Complete,
             OptimizationMode = OptimizationModes.CoverageBasedTest,
         };
-        _target = new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: options);
+        Target = new CsharpMutantOrchestrator(new MutantPlacer(Injector), options: options);
 
         string source = @"private void Move()
 			{
@@ -967,11 +967,11 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 }";
         var expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(0)){}else{
 	var x = 0;
-    if ((StrykerNamespace.MutantControl.IsActive(0)?!(condition && other):(StrykerNamespace.MutantControl.IsActive(0)?condition || other:condition && other))) /* Stryker disable once all */ {  
+    if ((StrykerNamespace.MutantControl.IsActive(2)?!(condition && other):(StrykerNamespace.MutantControl.IsActive(1)?condition || other:condition && other))) /* Stryker disable once all */ {  
 	  x++;
       x*=2;
 	}
-if(StrykerNamespace.MutantControl.IsActive(0)){	x*=2;
+if(StrykerNamespace.MutantControl.IsActive(7)){	x*=2;
 }else{	x/=2;
 }}}";
         ;
@@ -985,12 +985,12 @@ if(StrykerNamespace.MutantControl.IsActive(0)){	x*=2;
 	}
 	x/=2;
 }";
-        expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(4)){}else{
+        expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(8)){}else{
 	var x = 0;
-{if(StrykerNamespace.MutantControl.IsActive(5)){}else{ /* Stryker disable all */
+{if(StrykerNamespace.MutantControl.IsActive(9)){}else{ /* Stryker disable all */
 	  x++;
 	}
-}if(StrykerNamespace.MutantControl.IsActive(8)){	x*=2;
+}if(StrykerNamespace.MutantControl.IsActive(12)){	x*=2;
 }else{	x/=2;
 }}}";
 
@@ -1001,10 +1001,11 @@ if(StrykerNamespace.MutantControl.IsActive(0)){	x*=2;
 
     [TestMethod]
     [DataRow("/* Stryker disable once all*/ x++;", "/* Stryker disable once all*/ x++;")]
-    [DataRow("if (cond) /* Stryker disable once all*/ x++;", "if ((StrykerNamespace.MutantControl.IsActive(0)?!(cond):cond)) /* Stryker disable once all*/ x++;")]
-    [DataRow("if (/* Stryker disable once all*/cond) x++;", "if (/* Stryker disable once all*/cond) if(StrykerNamespace.MutantControl.IsActive(0)){;}else{if(StrykerNamespace.MutantControl.IsActive(0)){x--;}else{x++;}}")]
+    [DataRow("if (cond) /* Stryker disable once all*/ x++;", "if ((StrykerNamespace.MutantControl.IsActive(1)?!(cond):cond)) /* Stryker disable once all*/ x++;")]
+    [DataRow("if (/* Stryker disable once all*/cond) x++;", "if (/* Stryker disable once all*/cond) if(StrykerNamespace.MutantControl.IsActive(2)){;}else{if(StrykerNamespace.MutantControl.IsActive(3)){x--;}else{x++;}}")]
     public void ShouldNotMutateDependingOnWhereMultilineCommentIs(string source, string expected)
     {
+        // must call reset as MsTest reuse test instance on datarow
         var sourceTemplate = $@"public void SomeMethod() {{
 	var x = 0;
 	{source}
@@ -1161,13 +1162,13 @@ if(StrykerNamespace.MutantControl.IsActive(3)){// Stryker restore all
 
         ShouldMutateSourceInClassToExpected(source, expected);
 
-        _target.Mutants.Count.ShouldBe(4);
-        _target.Mutants.ElementAt(0).ResultStatus.ShouldBe(MutantStatus.Pending);
-        _target.Mutants.ElementAt(1).ResultStatus.ShouldBe(MutantStatus.Ignored);
-        _target.Mutants.ElementAt(1).ResultStatusReason.ShouldBe("comment");
-        _target.Mutants.ElementAt(2).ResultStatus.ShouldBe(MutantStatus.Ignored);
-        _target.Mutants.ElementAt(2).ResultStatusReason.ShouldBe("comment");
-        _target.Mutants.ElementAt(3).ResultStatus.ShouldBe(MutantStatus.Pending);
+        Target.Mutants.Count.ShouldBe(4);
+        Target.Mutants.ElementAt(0).ResultStatus.ShouldBe(MutantStatus.Pending);
+        Target.Mutants.ElementAt(1).ResultStatus.ShouldBe(MutantStatus.Ignored);
+        Target.Mutants.ElementAt(1).ResultStatusReason.ShouldBe("comment");
+        Target.Mutants.ElementAt(2).ResultStatus.ShouldBe(MutantStatus.Ignored);
+        Target.Mutants.ElementAt(2).ResultStatusReason.ShouldBe("comment");
+        Target.Mutants.ElementAt(3).ResultStatus.ShouldBe(MutantStatus.Pending);
     }
 
     [TestMethod]
@@ -1341,9 +1342,9 @@ if(StrykerNamespace.MutantControl.IsActive(2)){;}else{Console.WriteLine((Stryker
 {
 	var test3 = 2 + 5;
 }";
-        _target.Mutate(CSharpSyntaxTree.ParseText(source), null);
+        Target.Mutate(CSharpSyntaxTree.ParseText(source), null);
 
-        var mutants = _target.GetLatestMutantBatch().ToList();
+        var mutants = Target.GetLatestMutantBatch().ToList();
         mutants.Count.ShouldBe(2);
         var blockLinespan = mutants.First().Mutation.OriginalNode.GetLocation().GetLineSpan();
         blockLinespan.StartLinePosition.Line.ShouldBe(1);
@@ -1368,9 +1369,9 @@ namespace TestApp
 		}
 	}
 }";
-        _target.Mutate(CSharpSyntaxTree.ParseText(source), null);
+        Target.Mutate(CSharpSyntaxTree.ParseText(source), null);
 
-        var mutants = _target.GetLatestMutantBatch().ToList();
+        var mutants = Target.GetLatestMutantBatch().ToList();
         mutants.Count.ShouldBe(7);
 
         var blockLinespan = mutants.First().Mutation.OriginalNode.GetLocation().GetLineSpan();
@@ -1666,8 +1667,8 @@ static string Value {get;} = """";}";
         var expected = @"class Test {
 static string Value {get;} = StrykerNamespace.MutantContext.TrackValue(()=>(StrykerNamespace.MutantControl.IsActive(0)?""Stryker was here!"":""""));}}}";
         ShouldMutateSourceInClassToExpected(source, expected);
-        _target.Mutants.Count.ShouldBe(1);
-        _target.Mutants.First().IsStaticValue.ShouldBeTrue();
+        Target.Mutants.Count.ShouldBe(1);
+        Target.Mutants.First().IsStaticValue.ShouldBeTrue();
     }
 
     [TestMethod]
@@ -1891,9 +1892,9 @@ else        {
         };
 
         var firstOrchestrator =
-            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: strykerOptions);
+            new CsharpMutantOrchestrator(new MutantPlacer(Injector), options: strykerOptions);
         var secondOrchestrator =
-            new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: strykerOptions);
+            new CsharpMutantOrchestrator(new MutantPlacer(Injector), options: strykerOptions);
         var node = SyntaxFactory.ParseExpression("1 == 1") as BinaryExpressionSyntax;
 
         var firstMutant = firstOrchestrator

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -918,6 +918,7 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
     [TestMethod]
     public void ShouldNotMutateIfDisabledByComment()
     {
+        
         string source = @"public void SomeMethod() {
 	var x = 0;
 // Stryker disable all
@@ -931,11 +932,32 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 	x/=2;
 }}";
 
-        ShouldMutateSourceInClassToExpected(source, expected);
+//        ShouldMutateSourceInClassToExpected(source, expected);
+        
         source = @"public void SomeMethod() {
 	var x = 0;
 	{
-	// Stryker disable all
+	/* Stryker disable all */
+	  x++;
+	}
+	x/=2;
+}";
+        expected = @"public void SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(4)){}else{
+	var x = 0;
+{if(StrykerNamespace.MutantControl.IsActive(5)){}else	{
+	/* Stryker disable all */
+	  x++;
+	}
+}if(StrykerNamespace.MutantControl.IsActive(8)){	x*=2;
+}else{	x/=2;
+}}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+        /*
+        source = @"public void SomeMethod() {
+	var x = 0;
+	{
+	// Stryker disable all 
 	  x++;
 	}
 	x/=2;
@@ -950,6 +972,7 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
 }else{	x/=2;
 }}}";
         ShouldMutateSourceInClassToExpected(source, expected);
+        */
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantOrchestratorTestsBase.cs
@@ -5,40 +5,36 @@ using Stryker.Core.Mutants;
 using Stryker.Core.Mutators;
 using Stryker.Core.Options;
 
-namespace Stryker.Core.UnitTest.Mutants
+namespace Stryker.Core.UnitTest.Mutants;
+
+/// <summary>
+/// This base class provides helper to test source file mutation
+/// </summary>
+public class MutantOrchestratorTestsBase : TestBase
 {
-    /// <summary>
-    /// This base class provides helper to test source file mutation
-    /// </summary>
-    public partial class MutantOrchestratorTestsBase : TestBase
+    protected CsharpMutantOrchestrator Target;
+    protected CodeInjection Injector = new();
+
+    public MutantOrchestratorTestsBase() => Target = new CsharpMutantOrchestrator(new MutantPlacer(Injector), options: new StrykerOptions
     {
-        protected CsharpMutantOrchestrator _target;
-        protected CodeInjection _injector = new();
+        MutationLevel = MutationLevel.Complete,
+        OptimizationMode = OptimizationModes.CoverageBasedTest,
+    });
 
-        public MutantOrchestratorTestsBase()
-        {
-            var options = new StrykerOptions
-            {
-                MutationLevel = MutationLevel.Complete,
-                OptimizationMode = OptimizationModes.CoverageBasedTest,
-            };
-            _target = new CsharpMutantOrchestrator(new MutantPlacer(_injector), options: options);
-        }
+    protected void ShouldMutateSourceToExpected(string actual, string expected)
+    {
+        var actualNode = Target.Mutate(CSharpSyntaxTree.ParseText(actual), null);
+        actual = actualNode.GetRoot().ToFullString();
+        actual = actual.Replace(Injector.HelperNamespace, "StrykerNamespace");
+        actualNode = CSharpSyntaxTree.ParseText(actual);
+        var expectedNode = CSharpSyntaxTree.ParseText(expected);
+        actualNode.ShouldBeSemantically(expectedNode);
+        actualNode.ShouldNotContainErrors();
+    }
 
-        protected void ShouldMutateSourceToExpected(string actual, string expected)
-        {
-            var actualNode = _target.Mutate(CSharpSyntaxTree.ParseText(actual), null);
-            actual = actualNode.GetRoot().ToFullString();
-            actual = actual.Replace(_injector.HelperNamespace, "StrykerNamespace");
-            actualNode = CSharpSyntaxTree.ParseText(actual);
-            var expectedNode = CSharpSyntaxTree.ParseText(expected);
-            actualNode.ShouldBeSemantically(expectedNode);
-            actualNode.ShouldNotContainErrors();
-        }
-
-        protected void ShouldMutateSourceInClassToExpected(string actual, string expected)
-        {
-            actual = @"using System;
+    protected void ShouldMutateSourceInClassToExpected(string actual, string expected)
+    {
+        actual = @"using System;
 using System.Collections.Generic;
 using System.Text;
 namespace StrykerNet.UnitTest.Mutants.TestResources
@@ -47,7 +43,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     {" + actual + @"}
 }";
 
-            expected = @"using System;
+        expected = @"using System;
 using System.Collections.Generic;
 using System.Text;
 namespace StrykerNet.UnitTest.Mutants.TestResources
@@ -55,7 +51,6 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     class TestClass
     {" + expected + @"}
 }";
-            ShouldMutateSourceToExpected(actual, expected);
-        }
+        ShouldMutateSourceToExpected(actual, expected);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -197,29 +197,5 @@ namespace Stryker.Core.Helpers
                 return (child.Parent is not AnonymousFunctionExpressionSyntax function || function.ExpressionBody != child)
                        && (child.Parent is not LocalFunctionStatementSyntax localFunction || localFunction.ExpressionBody != child);
             } ).Any(predicate);
-
-        /// <summary>
-        /// Find the syntax node or token that is just before the given node.
-        /// </summary>
-        /// <param name="node"></param>
-        /// <returns>previous node or token. Null if non exists.</returns>
-        public static SyntaxNodeOrToken GetPreviousSyntaxNode(this SyntaxNode node)
-        {
-            SyntaxNodeOrToken previous = node.Parent;
-            if (previous == null)
-            {
-                return null;
-            }
-
-            foreach(var child in previous.ChildNodesAndTokens())
-            {
-                if (child == node)
-                {
-                    return previous;
-                }
-                previous = child;
-            }
-            return null;
-        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -198,13 +198,28 @@ namespace Stryker.Core.Helpers
                        && (child.Parent is not LocalFunctionStatementSyntax localFunction || localFunction.ExpressionBody != child);
             } ).Any(predicate);
 
-        public static bool HasAMemberBindingExpression(this ExpressionSyntax expression) =>
-            expression switch
+        /// <summary>
+        /// Find the syntax node or token that is just before the given node.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns>previous node or token. Null if non exists.</returns>
+        public static SyntaxNodeOrToken GetPreviousSyntaxNode(this SyntaxNode node)
+        {
+            SyntaxNodeOrToken previous = node.Parent;
+            if (previous == null)
             {
-                MemberBindingExpressionSyntax => true,
-                MemberAccessExpressionSyntax memberAccess => memberAccess.Expression.HasAMemberBindingExpression(),
-                InvocationExpressionSyntax invocation => invocation.Expression.HasAMemberBindingExpression(),
-                _ => false
-            };
+                return null;
+            }
+
+            foreach(var child in previous.ChildNodesAndTokens())
+            {
+                if (child == node)
+                {
+                    return previous;
+                }
+                previous = child;
+            }
+            return null;
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BlockOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/BlockOrchestrator.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/CommentParser.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/CommentParser.cs
@@ -65,7 +65,7 @@ internal static class CommentParser
         return context.FilterMutators(disable, filteredMutators, match.Groups[OnceGroup].Value.ToLower() == "once", comment);
     }
 
-    public static MutationContext ParseNodeComments(SyntaxNode node, MutationContext context)
+    public static MutationContext ParseNodeLeadingComments(SyntaxNode node, MutationContext context)
     {
         foreach (var commentTrivia in node.GetLeadingTrivia()
                      .Where(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia) ||

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/NodeSpecificOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpNodeOrchestrators/NodeSpecificOrchestrator.cs
@@ -14,7 +14,8 @@ namespace Stryker.Core.Mutants.CsharpNodeOrchestrators;
 /// <typeparam name="TBase">Type of the node once mutated. In practice, either <see cref="TNode"/> or a base class of it.</typeparam>
 /// <remarks>Those classes are an implementation of the 'Strategy' pattern. They must remain stateless, as the same instance is used for all syntax node of
 /// the given type. They can still embark some readonly options/parameters, as long as they remain constant during parsing.</remarks>
-internal class NodeSpecificOrchestrator<TNode, TBase> : INodeOrchestrator where TBase : SyntaxNode where TNode : TBase{
+internal class NodeSpecificOrchestrator<TNode, TBase> : INodeOrchestrator where TBase : SyntaxNode where TNode : TBase
+{
     /// <summary>
     /// Get the Roslyn type handled by this class
     /// </summary>
@@ -88,7 +89,7 @@ internal class NodeSpecificOrchestrator<TNode, TBase> : INodeOrchestrator where 
     /// <param name="context">context to be updated</param>
     /// <returns>a context capturing changes, if any</returns>
     /// <remarks>base implementation parse stryker comments.</remarks>
-    protected virtual MutationContext PrepareContext(TNode node, MutationContext context) => CommentParser.ParseNodeComments(node, context);
+    protected virtual MutationContext PrepareContext(TNode node, MutationContext context) => CommentParser.ParseNodeLeadingComments(node, context);
 
     /// <summary>
     /// Restore the mutation context after mutation have been performed


### PR DESCRIPTION
Add support for the so called multiline comments format (`/* comment */ `) for Stryker comments.
Updated the doc and provided some detailed explanation for `once` option. Note that the Stryker comment must still be on a single line.

Multiline comments should work exactly line single line comments when put on a dedicated line.

Stryker attempts to associate comments within the line with the **previous** syntax node, that is:

`if (condition) {/* Stryker comment*/;....}`: this comment will apply to the whole syntax block
`if (/* Stryker comment*/ condition) {....}`: this comment will apply to the whole condition expression

Stryker comments may not be detected if they are within a syntax node
`if (cond/* Stryker comment*/ition) {....}`: will have no effect
`if (condition /* Stryker comment*/) {....}`: will have no effect

Fixes #3008 