### PR TITLE
fix: Duplicate Analyzer diagnostics

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
@@ -62,6 +62,45 @@ public class AnalyzerResultExtensionsTests
         diagOptions.ShouldContain(new KeyValuePair<string, ReportDiagnostic>("EXTEXP0002", ReportDiagnostic.Warn));
     }
 
+    [DataTestMethod]
+    [DataRow("NoWarn", ReportDiagnostic.Suppress)]
+    [DataRow("WarningsAsErrors", ReportDiagnostic.Error)]
+    [DataRow("WarningsNotAsErrors", ReportDiagnostic.Warn)]
+    public void GetDiagnosticOptions_DealWithDuplicate(string property, ReportDiagnostic reportDiagnostic)
+    {
+        // Arrange
+        var analyzerResult = Mock.Of<IAnalyzerResult>();
+        Mock.Get(analyzerResult)
+            .SetupGet(g => g.Properties)
+            .Returns(new Dictionary<string, string> { { property, "EXTEX0001;EXTEX0001" } });
+
+        // Act
+        var diagOptions = IAnalyzerResultExtensions.GetDiagnosticOptions(analyzerResult);
+
+        // Assert
+        diagOptions.ShouldHaveSingleItem();
+        diagOptions.ShouldContain(new KeyValuePair<string, ReportDiagnostic>("EXTEX0001", reportDiagnostic));
+    }
+
+    [TestMethod]
+    public void GetDiagnosticOptions_DealWithDuplicateConflicts()
+    {
+        // Arrange
+        var analyzerResult = Mock.Of<IAnalyzerResult>();
+        Mock.Get(analyzerResult)
+            .SetupGet(g => g.Properties)
+            .Returns(new Dictionary<string, string> { { "NoWarn", "EXTEX0001;EXTEX0001" },{ "WarningsAsErrors", "EXTEX0001;EXTEX0001" },
+                { "WarningsNotAsErrors", "EXTEX0001;EXTEX0001" }});
+
+        // Act
+        var diagOptions = IAnalyzerResultExtensions.GetDiagnosticOptions(analyzerResult);
+
+        // Assert
+        diagOptions.ShouldHaveSingleItem();
+        diagOptions.ShouldContain(new KeyValuePair<string, ReportDiagnostic>("EXTEX0001", ReportDiagnostic.Suppress));
+    }
+
+
     [TestMethod]
     public void GetDiagnosticOptions_DealWithConflicts()
     {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -202,22 +202,13 @@ public static class IAnalyzerResultExtensions
         this IAnalyzerResult analyzerResult)
     {
         var noWarnString = analyzerResult.GetPropertyOrDefault("NoWarn");
-        var noWarn = noWarnString is not null
-            ? noWarnString.Split(";").Where(x => !string.IsNullOrWhiteSpace(x))
-                .ToDictionary(x => x, _ => ReportDiagnostic.Suppress)
-            : new Dictionary<string, ReportDiagnostic>();
+        var noWarn = ParseDiagnostics(noWarnString).ToDictionary(x => x, _ => ReportDiagnostic.Suppress);
 
         var warningsAsErrorsString = analyzerResult.GetPropertyOrDefault("WarningsAsErrors");
-        var warningsAsErrors = warningsAsErrorsString is not null
-            ? warningsAsErrorsString.Split(";").Where(x => !string.IsNullOrWhiteSpace(x))
-                .ToDictionary(x => x, _ => ReportDiagnostic.Error)
-            : new Dictionary<string, ReportDiagnostic>();
+        var warningsAsErrors = ParseDiagnostics(warningsAsErrorsString).ToDictionary(x => x, _ => ReportDiagnostic.Error);
 
         var warningsNotAsErrorsString = analyzerResult.GetPropertyOrDefault("WarningsNotAsErrors");
-        var warningsNotAsErrors = warningsNotAsErrorsString is not null
-            ? warningsNotAsErrorsString.Split(";").Where(x => !string.IsNullOrWhiteSpace(x))
-                .ToDictionary(x => x, _ => ReportDiagnostic.Warn)
-            : new Dictionary<string, ReportDiagnostic>();
+        var warningsNotAsErrors = ParseDiagnostics(warningsNotAsErrorsString).ToDictionary(x => x, _ => ReportDiagnostic.Warn);
 
         // merge settings,
         var diagnosticOptions = new Dictionary<string, ReportDiagnostic>(warningsAsErrors);
@@ -233,6 +224,19 @@ public static class IAnalyzerResultExtensions
 
         return diagnosticOptions.ToImmutableDictionary();
     }
+
+    private static IEnumerable<string> ParseDiagnostics(string diagnostics)
+    {
+        if(string.IsNullOrWhiteSpace(diagnostics))
+        {
+            return [];
+        }
+
+        return diagnostics
+            .Split(";")
+            .Distinct()
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+    } 
 
     internal static int GetWarningLevel(this IAnalyzerResult analyzerResult) =>
         int.Parse(analyzerResult.GetPropertyOrDefault("WarningLevel", "4"));


### PR DESCRIPTION
Running Stryker 4.2.0 CLI on a project containing additional analyzers, will result in an exception as shown in an output below. 
This PR changes the way diagnostics are being parsed to avoid duplicate values.

Steps to reproduce:

```ps1
dotnet new classlib -o "StrykerDemo"
dotnet new nunit -o "StrykerDemo.Tests"
dotnet new sln --name "StrykerDemo"
dotnet sln add .\StrykerDemo\StrykerDemo.csproj
dotnet sln add .\StrykerDemo.Tests\StrykerDemo.Tests.csproj
dotnet add .\StrykerDemo\StrykerDemo.csproj package Antlr4BuildTasks
dotnet add .\StrykerDemo\StrykerDemo.csproj package Antlr4.Runtime
dotnet add .\StrykerDemo.Tests\StrykerDemo.Tests.csproj reference .\StrykerDemo\StrykerDemo.csproj
dotnet stryker
```

Command should result in this kind of an output:

```ps1

   _____ _              _               _   _ ______ _______  
  / ____| |            | |             | \ | |  ____|__   __| 
 | (___ | |_ _ __ _   _| | _____ _ __  |  \| | |__     | |    
  \___ \| __| '__| | | | |/ / _ \ '__| | . ` |  __|    | |    
  ____) | |_| |  | |_| |   <  __/ |    | |\  | |____   | |    
 |_____/ \__|_|   \__, |_|\_\___|_| (_)|_| \_|______|  |_|    
                   __/ |                                      
                  |___/                                       


Version: 4.2.0

[12:02:05 INF] Analysis starting.
[12:02:05 INF] Identifying projects to mutate in C:\Projects\Experiments\StrykerDemo\StrykerDemo.sln. This can take a while.
[12:02:07 INF] Found project C:\Projects\Experiments\StrykerDemo\StrykerDemo\StrykerDemo.csproj to mutate.
[12:02:07 INF] Analysis complete.
[12:02:07 INF] Building solution StrykerDemo.sln
[12:02:07 INF] Building project StrykerDemo.sln using dotnet build StrykerDemo.sln (directory C:\Projects\Experiments\StrykerDemo.)
[12:02:11 INF] Number of tests found: 1 for project C:\Projects\Experiments\StrykerDemo\StrykerDemo\StrykerDemo.csproj. Initial test run started.
[12:02:12 ERR] An error occurred during the mutation test run
System.AggregateException: One or more errors occurred. (An item with the same key has already been added. Key: 1701)
 ---> System.ArgumentException: An item with the same key has already been added. Key: 1701
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at Stryker.Core.Initialisation.Buildalyzer.IAnalyzerResultExtensions.GetDiagnosticOptions(IAnalyzerResult analyzerResult) in /_/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs:line 205
   at Stryker.Core.Initialisation.Buildalyzer.IAnalyzerResultCSharpExtensions.GetCompilationOptions(IAnalyzerResult analyzerResult) in /_/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultCSharpExtensions.cs:line 13
   at Stryker.Core.Compiling.CsharpCompilingProcess.GetCSharpCompilation(IEnumerable`1 syntaxTrees) in /_/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs:line 154
   at Stryker.Core.Compiling.CsharpCompilingProcess.GetSemanticModels(IEnumerable`1 syntaxTrees) in /_/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs:line 103
   at Stryker.Core.MutationTest.CsharpMutationProcess.Mutate(MutationTestInput input) in /_/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs:line 59
   at Stryker.Core.MutationTest.MutationTestProcess.Mutate() in /_/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs:line 89
   at Stryker.Core.Initialisation.ProjectMutator.MutateProject(StrykerOptions options, MutationTestInput input, IReporter reporters) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs:line 38
   at Stryker.Core.Initialisation.ProjectOrchestrator.<>c__DisplayClass7_0.<MutateProjects>b__0(MutationTestInput mutationTestInput) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectOrchestrator.cs:line 71
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
   at System.Threading.Tasks.TaskReplicator.Replica.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.TaskReplicator.Run[TState](ReplicatableUserAction`1 action, ParallelOptions options, Boolean stopOnFirstFailure)
   at System.Threading.Tasks.Parallel.ForWorker[TLocal,TInt](TInt fromInclusive, TInt toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.ForWorker[TLocal,TInt](TInt fromInclusive, TInt toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, Action`1 body)
   at Stryker.Core.Initialisation.ProjectOrchestrator.MutateProjects(StrykerOptions options, IReporter reporters, ITestRunner runner) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectOrchestrator.cs:line 69
   at Stryker.Core.StrykerRunner.RunMutationTest(IStrykerInputs inputs, ILoggerFactory loggerFactory, IProjectOrchestrator projectOrchestrator) in /_/src/Stryker.Core/Stryker.Core/StrykerRunner.cs:line 63
[12:02:12 INF] Time Elapsed 00:00:06.7339700
Unhandled exception. System.AggregateException: One or more errors occurred. (An item with the same key has already been added. Key: 1701)
 ---> System.ArgumentException: An item with the same key has already been added. Key: 1701
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at Stryker.Core.Initialisation.Buildalyzer.IAnalyzerResultExtensions.GetDiagnosticOptions(IAnalyzerResult analyzerResult) in /_/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultExtensions.cs:line 205
   at Stryker.Core.Initialisation.Buildalyzer.IAnalyzerResultCSharpExtensions.GetCompilationOptions(IAnalyzerResult analyzerResult) in /_/src/Stryker.Core/Stryker.Core/Initialisation/Buildalyzer/IAnalyzerResultCSharpExtensions.cs:line 13
   at Stryker.Core.Compiling.CsharpCompilingProcess.GetCSharpCompilation(IEnumerable`1 syntaxTrees) in /_/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs:line 154
   at Stryker.Core.Compiling.CsharpCompilingProcess.GetSemanticModels(IEnumerable`1 syntaxTrees) in /_/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs:line 103
   at Stryker.Core.MutationTest.CsharpMutationProcess.Mutate(MutationTestInput input) in /_/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs:line 59
   at Stryker.Core.MutationTest.MutationTestProcess.Mutate() in /_/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs:line 89
   at Stryker.Core.Initialisation.ProjectMutator.MutateProject(StrykerOptions options, MutationTestInput input, IReporter reporters) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs:line 38
   at Stryker.Core.Initialisation.ProjectOrchestrator.<>c__DisplayClass7_0.<MutateProjects>b__0(MutationTestInput mutationTestInput) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectOrchestrator.cs:line 71
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.<>c__DisplayClass19_0`2.<ForWorker>b__1(RangeWorker& currentWorker, Int64 timeout, Boolean& replicationDelegateYieldedBeforeCompletion)
   at System.Threading.Tasks.TaskReplicator.Replica.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.TaskReplicator.Run[TState](ReplicatableUserAction`1 action, ParallelOptions options, Boolean stopOnFirstFailure)
   at System.Threading.Tasks.Parallel.ForWorker[TLocal,TInt](TInt fromInclusive, TInt toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Parallel.ForWorker[TLocal,TInt](TInt fromInclusive, TInt toExclusive, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Func`4 bodyWithLocal, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinally)
   at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, Action`1 body)
   at Stryker.Core.Initialisation.ProjectOrchestrator.MutateProjects(StrykerOptions options, IReporter reporters, ITestRunner runner) in /_/src/Stryker.Core/Stryker.Core/Initialisation/ProjectOrchestrator.cs:line 69
   at Stryker.Core.StrykerRunner.RunMutationTest(IStrykerInputs inputs, ILoggerFactory loggerFactory, IProjectOrchestrator projectOrchestrator) in /_/src/Stryker.Core/Stryker.Core/StrykerRunner.cs:line 63
   at Stryker.CLI.StrykerCli.RunStryker(IStrykerInputs inputs) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 151
   at Stryker.CLI.StrykerCli.<>c__DisplayClass11_0.<Run>b__0() in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 123
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.<>c__DisplayClass143_0.<OnExecute>b__0(CancellationToken _)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.ExecuteAsync(String[] args, CancellationToken cancellationToken)
   at McMaster.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Stryker.CLI.StrykerCli.Run(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/StrykerCLI.cs:line 129
   at Stryker.CLI.Program.Main(String[] args) in /_/src/Stryker.CLI/Stryker.CLI/Program.cs:line 14
