### PR TITLE
fix: Handle Vstest freezes more gracefully

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestRunners/VsTestRunnerPoolTests.cs
@@ -105,8 +105,11 @@ namespace Stryker.Core.UnitTest.TestRunners
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             SetupFailingTestRun(mockVsTest);
 
-            Action action = () => runner.InitialTest(SourceProjectInfo);
-            action.ShouldThrow<GeneralStrykerException>();
+            var result = runner.InitialTest(SourceProjectInfo);
+            // legacy behavior was to crash on VsTest crash as an fail fast strategy
+            // now We have fixed Stryker issues related to VsTest and issues are rare, so this should be a minor event
+
+            result.SessionTimedOut.ShouldBeTrue();
         }
 
         [TestMethod]
@@ -146,8 +149,7 @@ namespace Stryker.Core.UnitTest.TestRunners
         {
             var mockVsTest = BuildVsTestRunnerPool(new StrykerOptions(), out var runner);
             SetupFailingTestRun(mockVsTest);
-            var action = () =>  runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
-            action.ShouldThrow<GeneralStrykerException>();
+            runner.TestMultipleMutants(SourceProjectInfo, null, new[] { Mutant }, null);
             // the test will always end in a crash, VsTestRunner should retry at least a few times
             mockVsTest.Verify(m => m.RunTestsWithCustomTestHost(It.IsAny<IEnumerable<string>>(),
                 It.IsAny<string>(), It.IsAny<TestPlatformOptions>(),

--- a/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/TestRunners/VsTest/VsTestRunner.cs
@@ -167,7 +167,7 @@ public sealed class VsTestRunner : IDisposable
         return testCases;
     }
 
-        private TestRunResult BuildTestRunResult(IRunResults testResults, int expectedTests, int totalCountOfTests,
+    private TestRunResult BuildTestRunResult(IRunResults testResults, int expectedTests, int totalCountOfTests,
             bool compressAll = true)
     {
         var resultAsArray = testResults.TestResults.ToArray();
@@ -185,22 +185,22 @@ public sealed class VsTestRunner : IDisposable
 
         if (ranTests.IsEmpty && (testResults.TestsInTimeout == null || testResults.TestsInTimeout.Count == 0))
         {
-                _logger.LogTrace("{RunnerId}: Test session reports 0 result and 0 stuck test.", RunnerId);
+            _logger.LogTrace("{RunnerId}: Test session reports 0 result and 0 stuck test.", RunnerId);
         }
 
         var duration = TimeSpan.FromTicks(_context.VsTests.Values.Sum(t => t.InitialRunTime.Ticks));
 
-        var message = string.Join(Environment.NewLine,
+        var errorMessages = string.Join(Environment.NewLine,
             resultAsArray.Where(tr => !string.IsNullOrWhiteSpace(tr.ErrorMessage))
                 .Select(tr => $"{tr.DisplayName}{Environment.NewLine}{Environment.NewLine}{tr.ErrorMessage}"));
-            var messages = resultAsArray.Select(tr =>
+        var messages = resultAsArray.Select(tr =>
                 $"{tr.DisplayName}{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, tr.Messages.Select(tm => tm.Text))}");
         var failedTestsDescription = new WrappedGuidsEnumeration(failedTests);
         var timedOutTests = new WrappedGuidsEnumeration(testResults.TestsInTimeout?.Select(t => t.Id));
         return timeout
                 ? TestRunResult.TimedOut(_context.VsTests.Values, ranTests, failedTestsDescription, timedOutTests,
-                    message, messages, duration)
-                : new TestRunResult(_context.VsTests.Values, ranTests, failedTestsDescription, timedOutTests, message,
+                    errorMessages, messages, duration)
+                : new TestRunResult(_context.VsTests.Values, ranTests, failedTestsDescription, timedOutTests, errorMessages,
                     messages, duration);
     }
 
@@ -264,10 +264,11 @@ public sealed class VsTestRunner : IDisposable
         }
     }
 
-        private void RunVsTest(ITestGuids tests, string source, string runSettings, TestPlatformOptions options,
+    private void RunVsTest(ITestGuids tests, string source, string runSettings, TestPlatformOptions options,
             int? timeOut, RunEventHandler eventHandler)
     {
-        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        var attempt = 0;
+        while (attempt<MaxAttempts)
         {
             var strykerVsTestHostLauncher = _context.BuildHostLauncher(RunnerId);
 
@@ -298,15 +299,15 @@ public sealed class VsTestRunner : IDisposable
             {
                 return;
             }
-
-            _logger.LogWarning("{RunnerId}: Retrying the test session.", RunnerId);
-            eventHandler.DiscardCurrentRun();
+            attempt++;
+            if (attempt < MaxAttempts)
+            {
+                _logger.LogInformation("{RunnerId}: Retrying the test session.", RunnerId);
+                eventHandler.DiscardCurrentRun();
+            }
         }
 
-        _logger.LogCritical("{0}: VsTest failed, settings: {1}", RunnerId, runSettings);
-
-        throw new GeneralStrykerException(
-            $"{RunnerId}: failed to run a test session despite {MaxAttempts} attempts. Aborting session.");
+        _logger.LogWarning("{0}: VsTest failed {2} times, settings: {1}", RunnerId, runSettings, attempt);
     }
 
     private bool WaitForEnd(Task session, RunEventHandler eventHandler, int? timeOut, ref int attempt)


### PR DESCRIPTION
Log when Vstest failed three times in a row instead of aborting the run. The run will be handled as a regular timeout instead.

The mutation test phase is now very stable and we have workaround with known VsTest issues.
Should fix #3061.