### PR TITLE
Improve error message when all discovered projects are test projects

### DIFF
--- a/src/Stryker.Abstractions/Exceptions/InvalidProjectsException.cs
+++ b/src/Stryker.Abstractions/Exceptions/InvalidProjectsException.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Stryker.Abstractions.Exceptions;
+
+/// <summary>
+/// Represents error when no test projects are found in the solution or configured for stryker.
+/// </summary>
+public class InvalidProjectsException : Exception
+{
+    public InvalidProjectsException(string message)
+        : base(message)
+    {
+    }
+
+    public static InvalidProjectsException NoTestProjectsFound()
+    {
+        return new InvalidProjectsException("No test projects found. Please add a test project to your solution or fix your stryker config.");
+    }
+
+    public static InvalidProjectsException OnlyTestProjectsFound()
+    {
+        return new InvalidProjectsException("Only test projects found. Please ensure that your solution contains non-test projects.");
+    }
+}

--- a/src/Stryker.Abstractions/Exceptions/NoTestProjectsException.cs
+++ b/src/Stryker.Abstractions/Exceptions/NoTestProjectsException.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace Stryker.Abstractions.Exceptions;
-
-/// <summary>
-/// Represents error when no test projects are found in the solution or configured for stryker.
-/// </summary>
-public class NoTestProjectsException()
-    : Exception("No test projects found. Please add a test project to your solution or fix your stryker config.");

--- a/src/Stryker.CLI/Stryker.CLI/Program.cs
+++ b/src/Stryker.CLI/Stryker.CLI/Program.cs
@@ -13,7 +13,7 @@ public static class Program
             var app = new StrykerCli();
             return app.Run(args);
         }
-        catch (NoTestProjectsException exception)
+        catch (InvalidProjectsException exception)
         {
             AnsiConsole.WriteLine(exception.Message);
             return ExitCodes.Success;

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -181,7 +181,12 @@ public class StrykerRunner : IStrykerRunner
     {
         if (!projectComponents.Any())
         {
-            throw new NoTestProjectsException();
+            throw InvalidProjectsException.NoTestProjectsFound();
+        }
+
+        if (projectComponents.All(pc => pc is TestProject))
+        {
+            throw InvalidProjectsException.OnlyTestProjectsFound();
         }
 
         if (projectComponents.Count() > 1)


### PR DESCRIPTION
Fixes #3065

Update error handling to provide a clear message when only test projects are found.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stryker-mutator/stryker-net/issues/3065?shareId=22691ce1-eef2-4ca2-9087-fd36de86f455).