### PR TITLE
fix: Add node orchestrator for global statements

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -957,6 +957,28 @@ if(StrykerNamespace.MutantControl.IsActive(1)){;}else{if(StrykerNamespace.Mutant
     }
 
     [TestMethod]
+    public void ShouldNotMutateTopLevelStatementsIfDisabledByComment()
+    {
+        var source = @"
+	var x = 0;
+x++;
+// Stryker disable all
+	x++;
+	x/=2;
+";
+        var expected = @"	var x = 0;
+if(StrykerNamespace.MutantControl.IsActive(0)){;}else{if(StrykerNamespace.MutantControl.IsActive(1)){x--;
+}else{x++;
+}}// Stryker disable all
+	x++;
+	x/=2;
+";
+
+        ShouldMutateSourceToExpected(source, expected);
+            
+    }
+
+    [TestMethod]
     public void ShouldNotMutateIfDisabledByMultilineComment()
     {
         var source = @"public void SomeMethod() {

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -83,6 +83,7 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
         // ensure declaration are mutated at the block level
         new LocalDeclarationOrchestrator(),
         new InvocationExpressionOrchestrator(),
+        new NodeSpecificOrchestrator<GlobalStatementSyntax, GlobalStatementSyntax>(),
         new MemberDefinitionOrchestrator<MemberDeclarationSyntax>(),
         new MutateAtStatementLevelOrchestrator<AssignmentExpressionSyntax>(),
         new BlockOrchestrator(),

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationContext.cs
@@ -209,15 +209,11 @@ internal class MutationContext
         if (mode)
         {
             result.FilteredMutators = filteredMutators;
+            result.FilterComment = comment;
         }
         else if (result.FilteredMutators is not null)
         {
             result.FilteredMutators = result.FilteredMutators.Where(t => !filteredMutators.Contains(t)).ToArray();
-        }
-
-        if (mode)
-        {
-            result.FilterComment = comment;
         }
 
         return result;

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Stryker.Abstractions.Logging;
 using Stryker.Abstractions.Mutants;
-using Stryker.Abstractions;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.MutantFilters;
 using Stryker.Core.Mutants;


### PR DESCRIPTION
Fix issues with global statements, such as handling of stryker comments and complex mutation declarations (block level).
Declare an orchestrator for global statements. For some reason, the GlobalStatementSyntax class inherits from MemberDefinitionSyntax, which does not lead to the expected behavior: Stryker treats Member Definition as hard barriers.
fix #3081
fix #3073 