### PR TITLE
docs: update header level in technical documentation

### DIFF
--- a/docs/technical-reference/testing-framework.md
+++ b/docs/technical-reference/testing-framework.md
@@ -95,7 +95,7 @@ Also, if a mutation ends up changing a test case name - typically by changing th
 test identifier so this testcase will only run when running **all tests** and can no longer be executed in isolation, as
 Stryker can't anticipate the test name.
 
-### NUnit
+## NUnit
 
 ### Conflicting test cases
 If multiple NUnit test cases have the same id (_Guid_), NUnit will report them as a single test case, and will merge all associated results in a single test result.


### PR DESCRIPTION
I was reading the technical documentation, and came across what seemed like an error in the header level.

Consequently this PR proposes a minor change to the `docs/technical-reference/testing-framework.md` file. The change involves adjusting the heading level for the NUnit section to improve document structure.