### PR TITLE
fix: Typo in exception message

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
+++ b/src/Stryker.CLI/Stryker.CLI/FileConfigReader.cs
@@ -92,7 +92,7 @@ public static class FileConfigReader
             }
             else
             {
-                throw new InputException($"Unkown file type for config file at \"{configFilePath}\"");
+                throw new InputException($"Unknown file type for config file at \"{configFilePath}\"");
             }
 
             if (root == null)


### PR DESCRIPTION
Fix typo in exception message when the configuration file doesn't appear to be JSON or YML.
