### PR TITLE
Add LINQ Append/Prepend mutation

### DIFF
--- a/src/Stryker.Abstractions/LinqExpression.cs
+++ b/src/Stryker.Abstractions/LinqExpression.cs
@@ -38,5 +38,7 @@ public enum LinqExpression
     OrderDescending,
     SkipLast,
     TakeLast,
-    UnionBy
+    UnionBy,
+    Append,
+    Prepend
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
@@ -16,7 +16,7 @@ public class LinqMutatorTest : TestBase
     /// </summary>
     /// <param name="expression"></param>
     /// <returns></returns>
-    private ExpressionSyntax GenerateExpressions(string expression)
+    private static MemberAccessExpressionSyntax GenerateExpressions(string expression)
     {
         var tree = CSharpSyntaxTree.ParseText($@"
 using System;
@@ -91,6 +91,8 @@ namespace TestApplication
     [DataRow(LinqExpression.OrderDescending, LinqExpression.Order)]
     [DataRow(LinqExpression.UnionBy, LinqExpression.IntersectBy)]
     [DataRow(LinqExpression.IntersectBy, LinqExpression.UnionBy)]
+    [DataRow(LinqExpression.Append, LinqExpression.Prepend)]
+    [DataRow(LinqExpression.Prepend, LinqExpression.Append)]
     public void ShouldMutate(LinqExpression original, LinqExpression expected)
     {
         var target = new LinqMutator();

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -55,7 +55,9 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
             { LinqExpression.Order, LinqExpression.OrderDescending },
             { LinqExpression.OrderDescending, LinqExpression.Order },
             { LinqExpression.UnionBy, LinqExpression.IntersectBy },
-            { LinqExpression.IntersectBy, LinqExpression.UnionBy }
+            { LinqExpression.IntersectBy, LinqExpression.UnionBy },
+            { LinqExpression.Append, LinqExpression.Prepend },
+            { LinqExpression.Prepend, LinqExpression.Append }
         };
         RequireArguments = new HashSet<LinqExpression>
         {
@@ -73,7 +75,9 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
             LinqExpression.MaxBy,
             LinqExpression.MinBy,
             LinqExpression.IntersectBy,
-            LinqExpression.UnionBy
+            LinqExpression.UnionBy,
+            LinqExpression.Append,
+            LinqExpression.Prepend
         };
     }
     /// <summary> Apply mutations to an <see cref="InvocationExpressionSyntax"/> </summary>


### PR DESCRIPTION
Add LINQ mutation to change [`Append`](https://learn.microsoft.com/dotnet/api/system.linq.enumerable.append) to [`Prepend`](https://learn.microsoft.com/dotnet/api/system.linq.enumerable.prepend) and vice-versa.

Also fixes two IDE code analysis suggestions.
