### PR TITLE
feat(mutating): Mutate unsigned right-shift operator

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -3,12 +3,6 @@ run-name: e2e ${{ github.head_ref }} on m1 macos
 
 on: [pull_request]
 
-env:
-  NUGET_FEED: https://f.feedz.io/stryker/stryker-net/nuget/index.json
-  FEEDZ_NUGET_API_KEY: T-9O45ZZZ5lwQ6ptrGpDuoX8tdZLliNkScn9k
-  RestoreLockedMode: true
-  VERSION: "0.0.0-github-${{ github.run_number }}"
-
 jobs:
   integration-test:
     runs-on: macos-14
@@ -16,18 +10,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 9.x
-      - name: Pack integration test package
-        run: dotnet pack ${{ github.workspace }}/src/Stryker.CLI/Stryker.CLI/Stryker.CLI.csproj -p:PackageVersion=$VERSION --output ${{ github.workspace }}/publish
-      - name: Publish integration test package
-        run: dotnet nuget push ${{ github.workspace }}/publish/*.nupkg -s $NUGET_FEED -k "$FEEDZ_NUGET_API_KEY"
-      - name: Install integration test package from feed
-        run: dotnet tool install dotnet-stryker --tool-path ${{ github.workspace }}/.nuget/tools --version $VERSION --add-source $NUGET_FEED
-      - name: Run integration test
-        run: ${{ github.workspace }}/.nuget/tools/dotnet-stryker --dev-mode
-        working-directory: ${{ github.workspace }}/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit
-      - name: Validate integration test result
-        run: dotnet test ${{ github.workspace }}/integrationtest/Validation/ValidationProject --filter Category=SingleTestProject
+          dotnet-version: |
+            8.x
+            9.x
+      - name: Run integration tests
+        shell: pwsh
+        run: .\integration-tests.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ StrykerLogs/
 *.DotSettings
 /src/Stryker.CLI/TestStatisticsAnalyzer/test-stats-report.json
 .DS_Store
+.nuget/

--- a/integration-tests.ps1
+++ b/integration-tests.ps1
@@ -1,0 +1,83 @@
+#! /usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7
+
+param()
+
+$ErrorActionPreference = "Stop"
+
+${env:RestoreLockedMode} = "true"
+
+$repoRoot = ${env:GITHUB_WORKSPACE} ?? $PSScriptRoot
+
+$publishPath = Join-Path $repoRoot "publish"
+
+$netCoreTargetPath = Join-Path $repoRoot "integrationtest" "TargetProjects" "NetCore" "NetCoreTestProject.XUnit"
+$netfxTargetPath = Join-Path $repoRoot "integrationtest" "TargetProjects" "NetFramework" "FullFrameworkApp.Test"
+
+$testPath = Join-Path $repoRoot "integrationtest" "Validation" "ValidationProject"
+$testFilter = "Category=SingleTestProject"
+
+$toolPath = Join-Path $repoRoot ".nuget" "tools"
+$toolProject = Join-Path $repoRoot "src" "Stryker.CLI" "Stryker.CLI" "Stryker.CLI.csproj"
+
+$toolVersion = "0.0.0-"
+
+if (${env:GITHUB_ACTIONS} -eq "true") {
+  $toolVersion += "github-${env:GITHUB_RUN_NUMBER}"
+} else {
+  $toolVersion += "localdev"
+}
+
+$stryker = Join-Path $toolPath "dotnet-stryker"
+
+dotnet pack $toolProject "-p:PackageVersion=${toolVersion}" --output $publishPath
+
+if ($LASTEXITCODE -ne 0) {
+  throw "dotnet pack failed with exit code ${LASTEXITCODE}"
+}
+
+dotnet tool install dotnet-stryker --add-source $publishPath --allow-downgrade --tool-path $toolPath --version $toolVersion
+
+if ($LASTEXITCODE -ne 0) {
+  throw "dotnet tool install failed with exit code ${LASTEXITCODE}"
+}
+
+pushd $netCoreTargetPath
+
+try {
+  & $stryker --dev-mode
+} finally {
+  popd
+}
+
+if ($LASTEXITCODE -ne 0) {
+  throw "dotnet-stryker failed for .NET with exit code ${LASTEXITCODE}"
+}
+
+if ($IsWindows) {
+  pushd $netfxTargetPath
+
+  try {
+    dotnet msbuild -t:restore
+
+    if ($LASTEXITCODE -ne 0) {
+      throw "dotnet msbuild failed to restore NuGet packages with exit code ${LASTEXITCODE}"
+    }
+
+    & $stryker --dev-mode
+
+    if ($LASTEXITCODE -ne 0) {
+      throw "dotnet-stryker failed for .NET Framework with exit code ${LASTEXITCODE}"
+    }
+  } finally {
+    popd
+  }
+}
+
+dotnet test $testPath --filter $testFilter
+
+if ($LASTEXITCODE -ne 0) {
+  throw "dotnet test failed with exit code ${LASTEXITCODE}"
+}

--- a/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
@@ -168,6 +168,19 @@ public class CSharp11
             Console.WriteLine($"Record: {string.Join(", ", transaction)}, New balance: {balance:C}");
         }
     }
+
+    // unsigned right-shift
+    public static void UnsignedRightShift()
+    {
+        var value = 0b_1111_0000_0000_0000_0000_0000_0000_0000;
+        Console.WriteLine($"Before: {Convert.ToString(value, toBase: 2)}");
+
+        value >>= 4;
+        Console.WriteLine($"After: {Convert.ToString(value, toBase: 2)}");
+
+        var mutated = value >> 4;
+        Console.WriteLine($"Mutated: {Convert.ToString(mutated, toBase: 2)}");
+    }
 }
 
 // file type

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -83,7 +83,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 638, ignored: 262, survived: 4, killed: 9, timeout: 2, nocoverage: 324);
+        CheckReportMutants(report, total: 649, ignored: 266, survived: 4, killed: 9, timeout: 2, nocoverage: 331);
         CheckReportTestCounts(report, total: 11);
     }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -102,7 +102,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
          
-        CheckReportMutants(report, total: 638, ignored: 112, survived: 5, killed: 11, timeout: 2, nocoverage: 471);
+        CheckReportMutants(report, total: 649, ignored: 113, survived: 5, killed: 11, timeout: 2, nocoverage: 481);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 638, ignored: 262, survived: 4, killed: 9, timeout: 2, nocoverage: 324);
+        CheckReportMutants(report, total: 649, ignored: 266, survived: 4, killed: 9, timeout: 2, nocoverage: 331);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/AssignmentStatementMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/AssignmentStatementMutatorTests.cs
@@ -25,12 +25,13 @@ public class AssignmentStatementMutatorTests : TestBase
     [DataRow(SyntaxKind.MultiplyAssignmentExpression, SyntaxKind.DivideAssignmentExpression)]
     [DataRow(SyntaxKind.DivideAssignmentExpression, SyntaxKind.MultiplyAssignmentExpression)]
     [DataRow(SyntaxKind.ModuloAssignmentExpression, SyntaxKind.MultiplyAssignmentExpression)]
-    [DataRow(SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.RightShiftAssignmentExpression)]
-    [DataRow(SyntaxKind.RightShiftAssignmentExpression, SyntaxKind.LeftShiftAssignmentExpression)]
+    [DataRow(SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.RightShiftAssignmentExpression, SyntaxKind.UnsignedRightShiftAssignmentExpression)]
+    [DataRow(SyntaxKind.RightShiftAssignmentExpression, SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.UnsignedRightShiftAssignmentExpression)]
     [DataRow(SyntaxKind.AndAssignmentExpression, SyntaxKind.OrAssignmentExpression, SyntaxKind.ExclusiveOrAssignmentExpression)]
     [DataRow(SyntaxKind.OrAssignmentExpression, SyntaxKind.AndAssignmentExpression, SyntaxKind.ExclusiveOrAssignmentExpression)]
     [DataRow(SyntaxKind.ExclusiveOrAssignmentExpression, SyntaxKind.OrAssignmentExpression, SyntaxKind.AndAssignmentExpression)]
     [DataRow(SyntaxKind.CoalesceAssignmentExpression, SyntaxKind.SimpleAssignmentExpression)]
+    [DataRow(SyntaxKind.UnsignedRightShiftAssignmentExpression, SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.RightShiftAssignmentExpression)]
     public void AssignmentMutator_ShouldMutate(SyntaxKind input, SyntaxKind expectedOutput, SyntaxKind? additionalOutput = null)
     {
         var target = new AssignmentExpressionMutator();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BinaryExpressionMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/BinaryExpressionMutatorTests.cs
@@ -35,8 +35,9 @@ public class BinaryExpressionMutatorTests : TestBase
     [DataRow(Mutator.Logical, SyntaxKind.LogicalOrExpression, SyntaxKind.LogicalAndExpression)]
     [DataRow(Mutator.Bitwise, SyntaxKind.BitwiseAndExpression, SyntaxKind.BitwiseOrExpression)]
     [DataRow(Mutator.Bitwise, SyntaxKind.BitwiseOrExpression, SyntaxKind.BitwiseAndExpression)]
-    [DataRow(Mutator.Bitwise, SyntaxKind.RightShiftExpression, SyntaxKind.LeftShiftExpression)]
-    [DataRow(Mutator.Bitwise, SyntaxKind.LeftShiftExpression, SyntaxKind.RightShiftExpression)]
+    [DataRow(Mutator.Bitwise, SyntaxKind.RightShiftExpression, SyntaxKind.LeftShiftExpression, SyntaxKind.UnsignedRightShiftExpression)]
+    [DataRow(Mutator.Bitwise, SyntaxKind.LeftShiftExpression, SyntaxKind.RightShiftExpression, SyntaxKind.UnsignedRightShiftExpression)]
+    [DataRow(Mutator.Bitwise, SyntaxKind.UnsignedRightShiftExpression, SyntaxKind.LeftShiftExpression, SyntaxKind.RightShiftExpression)]
     public void ShouldMutate(Mutator expectedKind, SyntaxKind input, params SyntaxKind[] expectedOutput)
     {
         var target = new BinaryExpressionMutator();

--- a/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/AssignmentStatementMutator.cs
@@ -19,9 +19,10 @@ public class AssignmentExpressionMutator : MutatorBase<AssignmentExpressionSynta
         { SyntaxKind.AndAssignmentExpression, new [] { SyntaxKind.OrAssignmentExpression, SyntaxKind.ExclusiveOrAssignmentExpression } },
         { SyntaxKind.OrAssignmentExpression, new [] { SyntaxKind.AndAssignmentExpression, SyntaxKind.ExclusiveOrAssignmentExpression} },
         { SyntaxKind.ExclusiveOrAssignmentExpression, new [] { SyntaxKind.OrAssignmentExpression, SyntaxKind.AndAssignmentExpression } },
-        { SyntaxKind.LeftShiftAssignmentExpression, new [] { SyntaxKind.RightShiftAssignmentExpression } },
-        { SyntaxKind.RightShiftAssignmentExpression, new [] { SyntaxKind.LeftShiftAssignmentExpression } },
+        { SyntaxKind.LeftShiftAssignmentExpression, new [] { SyntaxKind.RightShiftAssignmentExpression, SyntaxKind.UnsignedRightShiftAssignmentExpression } },
+        { SyntaxKind.RightShiftAssignmentExpression, new [] { SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.UnsignedRightShiftAssignmentExpression } },
         { SyntaxKind.CoalesceAssignmentExpression, new [] { SyntaxKind.SimpleAssignmentExpression } },
+        { SyntaxKind.UnsignedRightShiftAssignmentExpression, new [] { SyntaxKind.LeftShiftAssignmentExpression, SyntaxKind.RightShiftAssignmentExpression } },
     };
 
     public override MutationLevel MutationLevel => MutationLevel.Standard;

--- a/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BinaryExpressionMutator.cs
@@ -36,10 +36,11 @@ public class BinaryExpressionMutator : MutatorBase<BinaryExpressionSyntax>
         { SyntaxKind.NotEqualsExpression, new MutationData(Mutator.Equality, SyntaxKind.EqualsExpression) },
         { SyntaxKind.LogicalAndExpression, new MutationData(Mutator.Logical, SyntaxKind.LogicalOrExpression) },
         { SyntaxKind.LogicalOrExpression, new MutationData(Mutator.Logical, SyntaxKind.LogicalAndExpression) },
-        { SyntaxKind.LeftShiftExpression, new MutationData(Mutator.Bitwise, SyntaxKind.RightShiftExpression) },
-        { SyntaxKind.RightShiftExpression, new MutationData(Mutator.Bitwise, SyntaxKind.LeftShiftExpression) },
+        { SyntaxKind.LeftShiftExpression, new MutationData(Mutator.Bitwise, SyntaxKind.RightShiftExpression, SyntaxKind.UnsignedRightShiftExpression) },
+        { SyntaxKind.RightShiftExpression, new MutationData(Mutator.Bitwise, SyntaxKind.LeftShiftExpression, SyntaxKind.UnsignedRightShiftExpression) },
         { SyntaxKind.BitwiseOrExpression, new MutationData(Mutator.Bitwise, SyntaxKind.BitwiseAndExpression) },
         { SyntaxKind.BitwiseAndExpression, new MutationData(Mutator.Bitwise, SyntaxKind.BitwiseOrExpression) },
+        { SyntaxKind.UnsignedRightShiftExpression, new MutationData(Mutator.Bitwise, SyntaxKind.LeftShiftExpression, SyntaxKind.RightShiftExpression) },
     };
 
     public override MutationLevel MutationLevel => MutationLevel.Basic;


### PR DESCRIPTION
Add support for mutating to/from the [unsigned right-shift operator (`>>>`)](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators#unsigned-right-shift-operator-).

| **Original** | **Mutations** |
|:-------------|:--------------|
| `>>`         | `<<`, `>>>`   |
| `<<`         | `>>`, `>>>`   |
| `>>>`        | `<<`, `>>`    |
| `>>=`        | `<<=`, `>>>=` |
| `<<=`        | `>>=`, `>>>=` |
| `>>>=`       | `<<=`, `>>=`  |
