### PR TITLE
feat(mutating): Support static using references for Math mutations

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
@@ -159,7 +159,7 @@ namespace TestApplication
     }
 
     /// <summary>
-    /// Test Method to check, if different expressions aren't mutated (in case of non-Math classes)
+    ///     Test Method to check, if different expressions aren't mutated (in case of non-Math classes)
     /// </summary>
     [TestMethod]
     [DataRow("MyClass")]
@@ -240,6 +240,36 @@ namespace TestApplication
         }
     }
 
+    /// <summary>
+    ///     Explicit test: verifies that using static import, Floor(5.0) is mutated to Ceiling(5.0).
+    /// </summary>
+    [TestMethod]
+    public void ShouldMutateStaticFloorToCeiling()
+    {
+        var target = new MathMutator();
+        var expression = GenerateStaticCallExpression("Floor");
+        var result = target.ApplyMutations(expression, null).ToList();
+
+        result.Count.ShouldBe(1);
+        var mutatedMethodName = ((IdentifierNameSyntax)((InvocationExpressionSyntax)result[0].ReplacementNode).Expression).Identifier.ValueText;
+        Enum.Parse<MathExpression>(mutatedMethodName).ShouldBe(MathExpression.Ceiling);
+    }
+
+    /// <summary>
+    ///     Explicit test: verifies that using static import, Exp(5.0) is mutated to Log(5.0).
+    /// </summary>
+    [TestMethod]
+    public void ShouldMutateStaticExpToLog()
+    {
+        var target = new MathMutator();
+        var expression = GenerateStaticCallExpression("Exp");
+        var result = target.ApplyMutations(expression, null).ToList();
+
+        result.Count.ShouldBe(1);
+        var mutatedMethodName = ((IdentifierNameSyntax)((InvocationExpressionSyntax)result[0].ReplacementNode).Expression).Identifier.ValueText;
+        Enum.Parse<MathExpression>(mutatedMethodName).ShouldBe(MathExpression.Log);
+    }
+
     private static IEnumerable<object[]> TrigonometricHyperbolicTestData
     {
         get
@@ -276,4 +306,6 @@ namespace TestApplication
             }
         }
     }
+
+
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
@@ -246,9 +246,29 @@ namespace TestApplication
     [TestMethod]
     public void ShouldMutateStaticFloorToCeiling()
     {
+        var sourceCode = @"
+using System;
+using static System.Math;
+namespace TestApplication
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Floor(5.0);
+        }
+    }
+}";
+        var tree = CSharpSyntaxTree.ParseText(sourceCode);
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .AddReferences(
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Math).Assembly.Location))
+            .AddSyntaxTrees(tree);
+        var semanticModel = compilation.GetSemanticModel(tree);
+        var expression = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
         var target = new MathMutator();
-        var expression = GenerateStaticCallExpression("Floor");
-        var result = target.ApplyMutations(expression, null).ToList();
+        var result = target.ApplyMutations(expression, semanticModel).ToList();
 
         result.Count.ShouldBe(1);
         var mutatedMethodName = ((IdentifierNameSyntax)((InvocationExpressionSyntax)result[0].ReplacementNode).Expression).Identifier.ValueText;
@@ -261,9 +281,29 @@ namespace TestApplication
     [TestMethod]
     public void ShouldMutateStaticExpToLog()
     {
+        var sourceCode = @"
+using System;
+using static System.Math;
+namespace TestApplication
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Exp(5.0);
+        }
+    }
+}";
+        var tree = CSharpSyntaxTree.ParseText(sourceCode);
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .AddReferences(
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Math).Assembly.Location))
+            .AddSyntaxTrees(tree);
+        var semanticModel = compilation.GetSemanticModel(tree);
+        var expression = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single();
         var target = new MathMutator();
-        var expression = GenerateStaticCallExpression("Exp");
-        var result = target.ApplyMutations(expression, null).ToList();
+        var result = target.ApplyMutations(expression, semanticModel).ToList();
 
         result.Count.ShouldBe(1);
         var mutatedMethodName = ((IdentifierNameSyntax)((InvocationExpressionSyntax)result[0].ReplacementNode).Expression).Identifier.ValueText;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/MathMutatorTest.cs
@@ -174,72 +174,6 @@ namespace TestApplication
         result.ShouldBeEmpty();
     }
 
-    public static IEnumerable<object[]> MethodSwapsTestData
-    {
-        get
-        {
-            foreach (var trigonometricHyperbolicTestData in TrigonometricHyperbolicTestData)
-            {
-                yield return trigonometricHyperbolicTestData;
-            }
-
-            yield return new object[]
-            {
-                MathExpression.BitDecrement, new[] { MathExpression.BitIncrement }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.BitIncrement, new[] { MathExpression.BitDecrement }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.Ceiling, new[] { MathExpression.Floor }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.Exp, new[] { MathExpression.Log }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.Floor, new[] { MathExpression.Ceiling }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.Log, new[] { MathExpression.Exp, MathExpression.Pow }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.MaxMagnitude, new[] { MathExpression.MinMagnitude }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.MinMagnitude, new[] { MathExpression.MaxMagnitude }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.Pow, new[] { MathExpression.Log }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.ReciprocalEstimate, new[] { MathExpression.ReciprocalSqrtEstimate }
-            };
-
-            yield return new object[]
-            {
-                MathExpression.ReciprocalSqrtEstimate, new[] { MathExpression.ReciprocalEstimate, MathExpression.Sqrt }
-            };
-        }
-    }
-
     /// <summary>
     ///     Explicit test: verifies that using static import, Floor(5.0) is mutated to Ceiling(5.0).
     /// </summary>
@@ -309,6 +243,74 @@ namespace TestApplication
         var mutatedMethodName = ((IdentifierNameSyntax)((InvocationExpressionSyntax)result[0].ReplacementNode).Expression).Identifier.ValueText;
         Enum.Parse<MathExpression>(mutatedMethodName).ShouldBe(MathExpression.Log);
     }
+
+
+    public static IEnumerable<object[]> MethodSwapsTestData
+    {
+        get
+        {
+            foreach (var trigonometricHyperbolicTestData in TrigonometricHyperbolicTestData)
+            {
+                yield return trigonometricHyperbolicTestData;
+            }
+
+            yield return new object[]
+            {
+                MathExpression.BitDecrement, new[] { MathExpression.BitIncrement }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.BitIncrement, new[] { MathExpression.BitDecrement }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.Ceiling, new[] { MathExpression.Floor }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.Exp, new[] { MathExpression.Log }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.Floor, new[] { MathExpression.Ceiling }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.Log, new[] { MathExpression.Exp, MathExpression.Pow }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.MaxMagnitude, new[] { MathExpression.MinMagnitude }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.MinMagnitude, new[] { MathExpression.MaxMagnitude }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.Pow, new[] { MathExpression.Log }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.ReciprocalEstimate, new[] { MathExpression.ReciprocalSqrtEstimate }
+            };
+
+            yield return new object[]
+            {
+                MathExpression.ReciprocalSqrtEstimate, new[] { MathExpression.ReciprocalEstimate, MathExpression.Sqrt }
+            };
+        }
+    }
+
 
     private static IEnumerable<object[]> TrigonometricHyperbolicTestData
     {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj
@@ -48,7 +48,7 @@
       <Aliases>StrykerRegexParser</Aliases>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\Stryker.Abstractions\Stryker.Abstractions.csproj" />
     <ProjectReference Include="..\..\Stryker.Utilities\Stryker.Utilities.csproj" />

--- a/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
@@ -16,16 +16,6 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
     /// <summary> Dictionary which maps original Math expressions to the target mutation </summary>
     private static Dictionary<MathExpression, IEnumerable<MathExpression>> KindsToMutate { get; }
 
-    // Known Math method names used for preliminary filtering to improve performance.
-    private static readonly HashSet<string> KnownMathMethodNames = new HashSet<string>(StringComparer.Ordinal)
-    {
-        "Acos", "Acosh", "Asin", "Asinh", "Atan", "Atanh",
-        "BitDecrement", "BitIncrement", "Ceiling", "Cos", "Cosh",
-        "Exp", "Floor", "Log", "MaxMagnitude", "MinMagnitude",
-        "Pow", "ReciprocalEstimate", "ReciprocalSqrtEstimate",
-        "Sin", "Sinh", "Sqrt", "Tan", "Tanh"
-    };
-
     static MathMutator() => KindsToMutate = new()
     {
         [MathExpression.Acos] = [MathExpression.Acosh, MathExpression.Asin, MathExpression.Atan],
@@ -64,7 +54,7 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
     private static IEnumerable<Mutation> ApplyMutationsToMemberCall(InvocationExpressionSyntax node, MemberAccessExpressionSyntax memberAccessExpressionSyntax, SemanticModel semanticModel)
     {
         var methodNameText = memberAccessExpressionSyntax.Name.Identifier.Text;
-        if (!KnownMathMethodNames.Contains(methodNameText))
+        if (!Enum.TryParse(methodNameText, out MathExpression _))
         {
             yield break;
         }
@@ -84,7 +74,7 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
     private static IEnumerable<Mutation> ApplyMutationsToDirectCall(InvocationExpressionSyntax node, IdentifierNameSyntax methodName, SemanticModel semanticModel)
     {
         var methodNameText = methodName.Identifier.Text;
-        if (!KnownMathMethodNames.Contains(methodNameText))
+        if (!Enum.TryParse(methodNameText, out MathExpression _))
         {
             yield break;
         }

--- a/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
@@ -46,15 +46,15 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
     /// <summary> Apply mutations to an <see cref="InvocationExpressionSyntax"/> </summary>
     public override IEnumerable<Mutation> ApplyMutations(InvocationExpressionSyntax node, SemanticModel semanticModel) => node.Expression switch
     {
-        MemberAccessExpressionSyntax memberAccess => ApplyMutationsToMemberCall(node, memberAccess),
+        MemberAccessExpressionSyntax memberAccess => ApplyMutationsToMemberCall(node, memberAccess, semanticModel),
         IdentifierNameSyntax methodName => ApplyMutationsToDirectCall(node, methodName),
         _ => []
     };
 
-    private static IEnumerable<Mutation> ApplyMutationsToMemberCall(InvocationExpressionSyntax node, MemberAccessExpressionSyntax memberAccessExpressionSyntax)
+    private static IEnumerable<Mutation> ApplyMutationsToMemberCall(InvocationExpressionSyntax node, MemberAccessExpressionSyntax memberAccessExpressionSyntax, SemanticModel semanticModel)
     {
-        if (memberAccessExpressionSyntax.Expression is not IdentifierNameSyntax memberName ||
-            !memberName.Identifier.ValueText.StartsWith("Math"))
+        var symbol = semanticModel.GetSymbolInfo(memberAccessExpressionSyntax.Expression).Symbol;
+        if (symbol?.ContainingType?.ToString() != "System.Math")
         {
             yield break;
         }

--- a/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/MathMutator.cs
@@ -47,7 +47,7 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
     public override IEnumerable<Mutation> ApplyMutations(InvocationExpressionSyntax node, SemanticModel semanticModel) => node.Expression switch
     {
         MemberAccessExpressionSyntax memberAccess => ApplyMutationsToMemberCall(node, memberAccess, semanticModel),
-        IdentifierNameSyntax methodName => ApplyMutationsToDirectCall(node, methodName),
+        IdentifierNameSyntax methodName => ApplyMutationsToDirectCall(node, methodName, semanticModel),
         _ => []
     };
 
@@ -65,8 +65,14 @@ public class MathMutator : MutatorBase<InvocationExpressionSyntax>
         }
     }
 
-    private static IEnumerable<Mutation> ApplyMutationsToDirectCall(InvocationExpressionSyntax node, IdentifierNameSyntax methodName)
+    private static IEnumerable<Mutation> ApplyMutationsToDirectCall(InvocationExpressionSyntax node, IdentifierNameSyntax methodName, SemanticModel semanticModel)
     {
+        var symbol = semanticModel.GetSymbolInfo(methodName).Symbol;
+        if (symbol?.ContainingType?.ToString() != "System.Math")
+        {
+            yield break;
+        }
+
         foreach (var mutation in ApplyMutationsToMethod(node, methodName))
         {
             yield return mutation;


### PR DESCRIPTION
### Summary
Fixes #2933 by using the semantic model to detect calls to System.Math when using `static using`. This ensures `Floor(5.5)` is correctly mutated, just like `Math.Floor(5.5)`.

### Changes
- Added semantic model checks in both member access and direct call branches.
- Updated MathMutator to handle IdentifierNameSyntax calls to Math methods.

### Testing
- Verified with a sample C# project using static imports (`FloorValue`, `MixedFloorValue`, etc.).
- Mutation score increased and static calls now generate mutants.