### PR TITLE
chore: Fix integration test

### DIFF
--- a/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
@@ -175,10 +175,10 @@ public class CSharp11
         var value = 0b_1111_0000_0000_0000_0000_0000_0000_0000;
         Console.WriteLine($"Before: {Convert.ToString(value, toBase: 2)}");
 
-        value >>= 4;
+        value >>>= 4;
         Console.WriteLine($"After: {Convert.ToString(value, toBase: 2)}");
 
-        var mutated = value >> 4;
+        var mutated = value >>> 4;
         Console.WriteLine($"Mutated: {Convert.ToString(mutated, toBase: 2)}");
     }
 }


### PR DESCRIPTION
Fix typo in #3200 that meant that **signed** right shift operators were being tested instead of the _unsigned_ right shift operators 🤦
