### PR TITLE
fix: adjust RegexMutator to handle new parsing orchestration. fix rel…

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/RegexMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/RegexMutatorTest.cs
@@ -29,12 +29,8 @@ public class RegexMutatorTest : TestBase
         var mutation = result.ShouldHaveSingleItem();
 
         mutation.DisplayName.ShouldBe("Regex anchor removal mutation");
-        var replacementNode = mutation.ReplacementNode as InvocationExpressionSyntax;
+        var replacementNode = mutation.ReplacementNode as ObjectCreationExpressionSyntax;
         replacementNode.ShouldNotBeNull();
-        var memberAccess = replacementNode.Expression as MemberAccessExpressionSyntax;
-        memberAccess.ShouldBeNull(); // Ensure it's a simple invocation, not a member access
-        var identifier = (replacementNode.Expression as IdentifierNameSyntax)?.Identifier.Text;
-        identifier.ShouldBe("Regex");
         var argument = replacementNode.ArgumentList.Arguments.First().Expression as LiteralExpressionSyntax;
         argument.ShouldNotBeNull();
         argument.Token.ValueText.ShouldBe("abc");
@@ -115,7 +111,7 @@ public class RegexMutatorTest : TestBase
         var mutation = result.ShouldHaveSingleItem();
 
         mutation.DisplayName.ShouldBe("Regex anchor removal mutation");
-        var replacementNode = mutation.ReplacementNode as InvocationExpressionSyntax;
+        var replacementNode = mutation.ReplacementNode as ObjectCreationExpressionSyntax;
         replacementNode.ShouldNotBeNull();
 
         var argumentList = replacementNode.ArgumentList;

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/RegexMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/RegexMutatorTest.cs
@@ -29,8 +29,7 @@ public class RegexMutatorTest : TestBase
         var mutation = result.ShouldHaveSingleItem();
 
         mutation.DisplayName.ShouldBe("Regex anchor removal mutation");
-        var replacement = mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>();
-        replacement.Token.ValueText.ShouldBe("abc");
+        mutation.ReplacementNode.ToString().ShouldBe("new Regex(\"abc\")");
     }
 
     [TestMethod]
@@ -44,8 +43,7 @@ public class RegexMutatorTest : TestBase
         var mutation = result.ShouldHaveSingleItem();
 
         mutation.DisplayName.ShouldBe("Regex anchor removal mutation");
-        var replacement = mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>();
-        replacement.Token.ValueText.ShouldBe("abc");
+        mutation.ReplacementNode.ToString().ShouldBe("new System.Text.RegularExpressions.Regex(\"abc\")");
     }
 
 
@@ -79,10 +77,9 @@ public class RegexMutatorTest : TestBase
 
         result.Count().ShouldBe(2);
         result.ShouldAllBe(mutant => mutant.DisplayName == "Regex anchor removal mutation");
-        var first = result.First().ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>();
-        var last = result.Last().ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>();
-        first.Token.ValueText.ShouldBe("abc$");
-        last.Token.ValueText.ShouldBe("^abc");
+
+        result.First().ReplacementNode.ToString().ShouldBe("new Regex(\"abc$\")");
+        result.Last().ReplacementNode.ToString().ShouldBe("new Regex(\"^abc\")");
     }
 
     [TestMethod]
@@ -96,7 +93,6 @@ public class RegexMutatorTest : TestBase
         var mutation = result.ShouldHaveSingleItem();
 
         mutation.DisplayName.ShouldBe("Regex anchor removal mutation");
-        var replacement = mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>();
-        replacement.Token.ValueText.ShouldBe("abc");
+        mutation.ReplacementNode.ToString().ShouldBe("new Regex(options: RegexOptions.None, pattern: \"abc\")");
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/RegexMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/RegexMutator.cs
@@ -58,9 +58,9 @@ public class RegexMutator : MutatorBase<ObjectCreationExpressionSyntax>
 
                     yield return new Mutation()
                     {
-                        OriginalNode = patternExpression,
-                        ReplacementNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
-                            SyntaxFactory.Literal(regexMutation.ReplacementPattern)),
+                        OriginalNode = node,
+                        ReplacementNode =  node.ReplaceNode(patternExpression, SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                            SyntaxFactory.Literal(regexMutation.ReplacementPattern))),
                         DisplayName = regexMutation.DisplayName,
                         Type = Mutator.Regex,
                         Description = regexMutation.Description


### PR DESCRIPTION
Ensure RegexMutator generates correct mutations. See below for explanation
Fixes #3241.

#### Details
PR #3116 implied an important change for mutators: now they must provide a mutated version of the full node that they received for evaluation. This change should have been applied to RegexMutator as well, but it was not done and this was not detected by existing tests.