### PR TITLE
Support filtering of implicit constructors

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -501,6 +501,74 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
     }
 
     [TestMethod]
+    [DataRow("Foo.MyType.ctor", true)]
+    [DataRow("MyType.ctor", true)]
+    [DataRow("Foo.MyType*.ctor", true)]
+    [DataRow("Foo*.MyType*.ctor", true)]
+    [DataRow("*.MyType*.ctor", true)]
+    [DataRow("F*.My*ype*.ctor", true)]
+    [DataRow("MyType*.ctor", true)]
+    [DataRow("*MyType.ctor", true)]
+    [DataRow("*MyType*.ctor", true)]
+    [DataRow("*Type.ctor", true)]
+    [DataRow("My*.ctor", true)]
+    [DataRow("*.ctor", true)]
+    [DataRow("*.*.ctor", true)]
+    [DataRow("MyType.constructor", false)]
+    [DataRow("Type.ctor", false)]
+    [DataRow("Foo.ctor", false)]
+    public void MutantFilter_ShouldIgnoreImplicitConstructor(string ignoredMethodName, bool shouldSkipMutant)
+    {
+        // Arrange
+        var source = @"
+public class Foo
+{
+    public class MyType
+    {
+        public MyType(string test) {}
+    }
+}
+
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        Foo.MyType t = new(""Param"");
+    }
+}";
+        var baseSyntaxTree = CSharpSyntaxTree.ParseText(source).GetRoot();
+        var originalNode = FindEnclosingNode<SyntaxNode>(baseSyntaxTree, "Param");
+
+        var mutant = new Mutant
+        {
+            Mutation = new Mutation
+            {
+                OriginalNode = originalNode,
+            }
+        };
+
+        var options = new StrykerOptions
+        {
+            IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { ignoredMethodName } }.Validate()
+        };
+
+        var sut = new IgnoredMethodMutantFilter();
+
+        // Act
+        var filteredMutants = sut.FilterMutants(new[] { mutant }, null, options);
+
+        // Assert
+        if (shouldSkipMutant)
+        {
+            filteredMutants.ShouldNotContain(mutant);
+        }
+        else
+        {
+            filteredMutants.ShouldContain(mutant);
+        }
+    }
+
+    [TestMethod]
     public void MutantFilters_ShouldNotApplyWithoutIgnoredMethod()
     {
         // Arrange

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
@@ -45,6 +45,9 @@ public sealed class IgnoredMethodMutantFilter : IMutantFilter
             ObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(
                 _triviaRemover.Visit(creation.Type) + ".ctor", options),
 
+            ImplicitObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(
+                _triviaRemover.Visit(creation.FirstAncestorOrSelf<VariableDeclarationSyntax>().Type) + ".ctor", options),
+
             ConditionalAccessExpressionSyntax conditional => IsPartOfIgnoredMethodCall(conditional.WhenNotNull, options,
                 false),
 


### PR DESCRIPTION
Currently constructors are filtered using the following syntax in the "method-filters" config: "*{TypeGlob}.ctor". However, this only matches constructors which are called using the full type name in the call, i.e. `var x = new string("asdf")`.

This PR enables filtering of constructors which use the implicit object creation expression syntax: `string x = new("asdf")`.