### PR TITLE
fix: Safe parsing of implicit new in IgnoreMutantFilter

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/IgnoredMethodMutantFilterTests.cs
@@ -265,6 +265,35 @@ public class IgnoredMethodMutantFilter_NestedMethodCalls
     }
 
     [TestMethod]
+    public void MutantFilter_WorksWithImplicitNew()
+    {
+        // Arrange
+        var source = @"
+public class IgnoredMethodMutantFilter_NestedMethodCalls
+{
+    private void TestMethod()
+    {
+        Dispose(new(""anchor""));
+    }
+}";
+        var options = new StrykerOptions
+        {
+            IgnoredMethods = new IgnoreMethodsInput { SuppliedInput = new[] { "*.ctor" } }.Validate()
+        };
+
+        var sut = new IgnoredMethodMutantFilter();
+
+            foreach (var (mutant, label) in BuildMutantsToFilter(source, "anchor"))
+            {
+                // Act
+                var filteredMutants = sut.FilterMutants(new[] { mutant }, null, options);
+
+            // Assert
+            filteredMutants.ShouldContain(mutant, $"{label} should have not been filtered out.");
+        }
+    }
+
+    [TestMethod]
     [DataRow("Dispose")]
     [DataRow("Dispose*")]
     [DataRow("*Dispose")]

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/IgnoredMethodMutantFilter.cs
@@ -26,60 +26,60 @@ public sealed class IgnoredMethodMutantFilter : IMutantFilter
                     mutants.Where(m => !IsPartOfIgnoredMethodCall(m.Mutation.OriginalNode, options)) :
                     mutants;
 
-    private bool IsPartOfIgnoredMethodCall(SyntaxNode syntaxNode, IStrykerOptions options, bool canGoUp = true) =>
-        syntaxNode switch
-        {
-            // Check if the current node is an invocation. This will also ignore invokable properties like `Func<bool> MyProp { get;}`
-            // follow the invocation chain to see if it ends with a filtered one
-            InvocationExpressionSyntax invocation => MatchesAnIgnoredMethod(
-                                                         _triviaRemover.Visit(invocation.Expression).ToString(),
-                                                         options)
-                                                     || (invocation.Parent is MemberAccessExpressionSyntax &&
-                                                         invocation.Parent.Parent is InvocationExpressionSyntax &&
-                                                         IsPartOfIgnoredMethodCall(invocation.Parent.Parent, options,
-                                                             false)) || (canGoUp &&
-                                                                         IsPartOfIgnoredMethodCall(invocation.Parent,
-                                                                             options)),
+    private bool IsPartOfIgnoredMethodCall(SyntaxNode syntaxNode, IStrykerOptions options, bool canGoUp = true) => syntaxNode switch
+    {
+        // Check if the current node is an invocation. This will also ignore invokable properties like `Func<bool> MyProp { get;}`
+        // follow the invocation chain to see if it ends with a filtered one
+        InvocationExpressionSyntax invocation => MatchesAnIgnoredMethod(
+                                                     _triviaRemover.Visit(invocation.Expression).ToString(),
+                                                     options)
+                                                 || (invocation.Parent is MemberAccessExpressionSyntax &&
+                                                     invocation.Parent.Parent is InvocationExpressionSyntax &&
+                                                     IsPartOfIgnoredMethodCall(invocation.Parent.Parent, options,
+                                                         false)) || (canGoUp &&
+                                                                     IsPartOfIgnoredMethodCall(invocation.Parent,
+                                                                         options)),
 
-            // Check if the current node is an object creation syntax (constructor invocation).
-            ObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(
-                _triviaRemover.Visit(creation.Type) + ".ctor", options),
+        // Check if the current node is an object creation syntax (constructor invocation).
+        ObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(
+            _triviaRemover.Visit(creation.Type) + ".ctor", options),
 
-            ImplicitObjectCreationExpressionSyntax creation => MatchesAnIgnoredMethod(
-                _triviaRemover.Visit(creation.FirstAncestorOrSelf<VariableDeclarationSyntax>().Type) + ".ctor", options),
+        ImplicitObjectCreationExpressionSyntax creation => creation.FirstAncestorOrSelf<VariableDeclarationSyntax>() != null
+            && MatchesAnIgnoredMethod(
+                        _triviaRemover.Visit(creation.FirstAncestorOrSelf<VariableDeclarationSyntax>().Type) + ".ctor", options),
 
-            ConditionalAccessExpressionSyntax conditional => IsPartOfIgnoredMethodCall(conditional.WhenNotNull, options,
-                false),
+        ConditionalAccessExpressionSyntax conditional => IsPartOfIgnoredMethodCall(conditional.WhenNotNull, options,
+            false),
 
-            ConditionalExpressionSyntax conditionalExpression =>
-                (IsPartOfIgnoredMethodCall(conditionalExpression.WhenTrue, options, false) &&
-                 IsPartOfIgnoredMethodCall(conditionalExpression.WhenFalse, options, false))
-                || (canGoUp && IsPartOfIgnoredMethodCall(conditionalExpression.Parent, options)),
+        ConditionalExpressionSyntax conditionalExpression =>
+            (IsPartOfIgnoredMethodCall(conditionalExpression.WhenTrue, options, false) &&
+             IsPartOfIgnoredMethodCall(conditionalExpression.WhenFalse, options, false))
+            || (canGoUp && IsPartOfIgnoredMethodCall(conditionalExpression.Parent, options)),
 
-            ExpressionStatementSyntax expressionStatement => IsPartOfIgnoredMethodCall(expressionStatement.Expression,
-                options, false),
+        ExpressionStatementSyntax expressionStatement => IsPartOfIgnoredMethodCall(expressionStatement.Expression,
+            options, false),
 
-            AssignmentExpressionSyntax assignmentExpression => IsPartOfIgnoredMethodCall(assignmentExpression.Right,
-                options, false),
+        AssignmentExpressionSyntax assignmentExpression => IsPartOfIgnoredMethodCall(assignmentExpression.Right,
+            options, false),
 
-            AwaitExpressionSyntax awaitExpression => IsPartOfIgnoredMethodCall(awaitExpression.Expression, options,
-                false),
+        AwaitExpressionSyntax awaitExpression => IsPartOfIgnoredMethodCall(awaitExpression.Expression, options,
+            false),
 
-            LocalDeclarationStatementSyntax localDeclaration => localDeclaration.Declaration.Variables.All(v =>
-                IsPartOfIgnoredMethodCall(v.Initializer?.Value, options, false)),
+        LocalDeclarationStatementSyntax localDeclaration => localDeclaration.Declaration.Variables.All(v =>
+            IsPartOfIgnoredMethodCall(v.Initializer?.Value, options, false)),
 
-            BlockSyntax { Statements.Count: > 0 } block => block.Statements.All(s =>
-                IsPartOfIgnoredMethodCall(s, options, false)),
+        BlockSyntax { Statements.Count: > 0 } block => block.Statements.All(s =>
+            IsPartOfIgnoredMethodCall(s, options, false)),
 
-            ConstructorInitializerSyntax constructorInitializer => MatchesAnIgnoredMethod(
-                _triviaRemover.Visit(constructorInitializer) + ".ctor", options),
+        ConstructorInitializerSyntax constructorInitializer => MatchesAnIgnoredMethod(
+            _triviaRemover.Visit(constructorInitializer) + ".ctor", options),
 
-            MemberDeclarationSyntax => false,
+        MemberDeclarationSyntax => false,
 
-            // Traverse the tree upwards.
-            { Parent: not null } => canGoUp && IsPartOfIgnoredMethodCall(syntaxNode.Parent, options),
-            _ => false,
-        };
+        // Traverse the tree upwards.
+        { Parent: not null } => canGoUp && IsPartOfIgnoredMethodCall(syntaxNode.Parent, options),
+        _ => false,
+    };
 
     private static bool MatchesAnIgnoredMethod(string expressionString, IStrykerOptions options) => options.IgnoredMethods.Any(r => r.IsMatch(expressionString));
 


### PR DESCRIPTION
IgnoreMutantFilter assumes any implicit new construct is part of variable declaration which leads to NRE when this is not the case.
This PR fixes this problem and regression test for this.

Fixes #3257 