### PR TITLE
feat(build): Improve targetframework and msbuild-path options

### DIFF
--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/packages.lock.json
@@ -900,13 +900,13 @@
           "Serilog.Sinks.Console": "[6.0.0, )",
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.50.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Configuration": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Configuration": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
           "Stryker.Regex.Parser": "[1.0.0, )",
-          "Stryker.RegexMutators": "[4.6.0, )",
-          "Stryker.TestRunner.VsTest": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
+          "Stryker.TestRunner.VsTest": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
           "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
@@ -929,8 +929,8 @@
           "Microsoft.CodeAnalysis.CSharp": "[4.14.0, )",
           "Microsoft.CodeAnalysis.Common": "[4.14.0, )",
           "Serilog": "[4.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )"
         }
       },
       "stryker.datacollector": {
@@ -950,7 +950,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.testrunner.vstest": {
@@ -961,10 +961,11 @@
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
           "Microsoft.TestPlatform.Portable": "[17.14.1, )",
           "Microsoft.TestPlatform.TranslationLayer": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
-          "Stryker.TestRunner": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.TestRunner": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
+          "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
       "stryker.utilities": {
@@ -976,7 +977,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Azure.Storage.Files.Shares": {

--- a/src/Stryker.CLI/Stryker.CLI/packages.lock.json
+++ b/src/Stryker.CLI/Stryker.CLI/packages.lock.json
@@ -696,13 +696,13 @@
           "Serilog.Sinks.Console": "[6.0.0, )",
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.50.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Configuration": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Configuration": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
           "Stryker.Regex.Parser": "[1.0.0, )",
-          "Stryker.RegexMutators": "[4.6.0, )",
-          "Stryker.TestRunner.VsTest": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
+          "Stryker.TestRunner.VsTest": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
           "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
@@ -725,8 +725,8 @@
           "Microsoft.CodeAnalysis.CSharp": "[4.14.0, )",
           "Microsoft.CodeAnalysis.Common": "[4.14.0, )",
           "Serilog": "[4.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )"
         }
       },
       "stryker.datacollector": {
@@ -746,7 +746,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.testrunner.vstest": {
@@ -757,10 +757,11 @@
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
           "Microsoft.TestPlatform.Portable": "[17.14.1, )",
           "Microsoft.TestPlatform.TranslationLayer": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
-          "Stryker.TestRunner": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.TestRunner": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
+          "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
       "stryker.utilities": {
@@ -772,7 +773,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Azure.Storage.Files.Shares": {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -44,7 +44,8 @@ public class InitialBuildProcessTests : TestBase
 
         var target = new InitialBuildProcess(processMock.Object, _mockFileSystem);
 
-        Should.Throw<InputException>(() => target.InitialBuild(true, null, _cProjectsExampleCsproj, null, @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
+        Should.Throw<InputException>(() => target.InitialBuild(true, null, _cProjectsExampleCsproj, null, null,
+                @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
             .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
                               @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" " + Path.GetFileName(_cProjectsExampleCsproj) + "\"");
     }
@@ -61,7 +62,7 @@ public class InitialBuildProcessTests : TestBase
 
         Should.Throw<InputException>(() => target.InitialBuild(false, null, _cProjectsExampleCsproj, null, null, @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
             .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
-                              @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" " + Path.GetFileName(_cProjectsExampleCsproj) + "\"");
+                              @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" " + _mockFileSystem.Path.GetFileName(_cProjectsExampleCsproj) + "\"");
 
         processMock.Verify(x => x.Start(It.IsAny<string>(), It.Is<string>(app => app.Contains("dotnet")), It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), 0), Times.Once());
         processMock.Verify(x => x.Start(It.IsAny<string>(), It.Is<string>(app => app.Contains("MSBuild.exe")), It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), 0), Times.Exactly(2));

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -77,7 +77,7 @@ public class InitialisationProcessTests : TestBase
             }});
 
         inputFileResolverMock.SetupGet(x => x.FileSystem).Returns(new FileSystem());
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
         testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
         initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), It.IsAny<ITestRunner>())).Throws(new InputException("")); // failing test
@@ -114,7 +114,7 @@ public class InitialisationProcessTests : TestBase
             new[] { new SourceProjectInfo { AnalyzerResult = TestHelper.SetupProjectAnalyzerResult(references: Array.Empty<string>()).Object, TestProjectsInfo = new TestProjectsInfo(new MockFileSystem()) } });
 
         inputFileResolverMock.SetupGet(x => x.FileSystem).Returns(fileSystemMock);
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         var failedTest = "testid";
         var ranTests = new TestIdentifierList(failedTest, "othertest");
         var testSet = new TestSet();
@@ -166,7 +166,7 @@ public class InitialisationProcessTests : TestBase
             }});
 
         inputFileResolverMock.SetupGet(x => x.FileSystem).Returns(new FileSystem());
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         var failedTest = "testid";
         var ranTests = new TestIdentifierList(failedTest, "othertest", "anothertest");
         var testSet = new TestSet();
@@ -220,7 +220,7 @@ public class InitialisationProcessTests : TestBase
 
 
         inputFileResolverMock.SetupGet(x => x.FileSystem).Returns(new FileSystem());
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         var testSet = new TestSet();
         testSet.RegisterTest(new TestDescription("id", "name", "test.cs"));
         testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(true);
@@ -277,7 +277,7 @@ public class InitialisationProcessTests : TestBase
                 TestProjectsInfo = new TestProjectsInfo(new MockFileSystem()){TestProjects = new List<TestProject> {new(new MockFileSystem(), testProjectAnalyzerResult)}}
             }});
 
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(false);
         testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
         initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), It.IsAny<ITestRunner>()))
@@ -328,7 +328,7 @@ public class InitialisationProcessTests : TestBase
                 TestProjectsInfo = new TestProjectsInfo(new MockFileSystem()){TestProjects = new List<TestProject> {new(new MockFileSystem(), testProjectAnalyzerResult)}}
             }});
 
-        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null));
+        initialBuildProcessMock.Setup(x => x.InitialBuild(It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<string>()));
         testRunnerMock.Setup(x => x.DiscoverTests(It.IsAny<string>())).Returns(false);
         testRunnerMock.Setup(x => x.GetTests(It.IsAny<IProjectAndTests>())).Returns(new TestSet());
         initialTestProcessMock.Setup(x => x.InitialTest(It.IsAny<StrykerOptions>(), It.IsAny<IProjectAndTests>(), It.IsAny<ITestRunner>()))

--- a/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/packages.lock.json
@@ -887,13 +887,13 @@
           "Serilog.Sinks.Console": "[6.0.0, )",
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.50.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Configuration": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Configuration": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
           "Stryker.Regex.Parser": "[1.0.0, )",
-          "Stryker.RegexMutators": "[4.6.0, )",
-          "Stryker.TestRunner.VsTest": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
+          "Stryker.TestRunner.VsTest": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
           "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
@@ -916,8 +916,8 @@
           "Microsoft.CodeAnalysis.CSharp": "[4.14.0, )",
           "Microsoft.CodeAnalysis.Common": "[4.14.0, )",
           "Serilog": "[4.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )"
         }
       },
       "stryker.datacollector": {
@@ -937,7 +937,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.testrunner.vstest": {
@@ -948,10 +948,11 @@
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
           "Microsoft.TestPlatform.Portable": "[17.14.1, )",
           "Microsoft.TestPlatform.TranslationLayer": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
-          "Stryker.TestRunner": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.TestRunner": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
+          "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
       "stryker.utilities": {
@@ -963,7 +964,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Azure.Storage.Files.Shares": {

--- a/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
@@ -71,7 +71,8 @@ public class MsBuildHelper
         return _msBuildPath;
     }
 
-    public (ProcessResult result, string exe, string command) BuildProject(string path, string projectFile, bool usingMsBuild, string configuration = null, string options = null)
+    public (ProcessResult result, string exe, string command) BuildProject(string path, string projectFile, bool usingMsBuild
+        , string configuration = null, string options = null, string forcedFramework = null)
     {
         var (exe, command) = usingMsBuild ? GetMsBuildExeAndCommand() : ("dotnet", "build");
 

--- a/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
@@ -98,12 +98,12 @@ public class MsBuildHelper
     {
         foreach (var drive in Directory.GetLogicalDrives())
         {
-            var visualStudioPath = Path.Combine(drive, "Program Files (x86)", "Microsoft Visual Studio");
+            var visualStudioPath = _fileSystem.Path.Combine(drive, "Program Files (x86)", "Microsoft Visual Studio");
             if (!_fileSystem.Directory.Exists(visualStudioPath))
                 continue;
             _logger.LogDebug("Using vswhere.exe to locate msbuild");
 
-            var vsWherePath = Path.Combine(visualStudioPath, "Installer", "vswhere.exe");
+            var vsWherePath = _fileSystem.Path.Combine(visualStudioPath, "Installer", "vswhere.exe");
             var vsWhereCommand =
                 $@"-{version} -requires Microsoft.Component.MSBuild -products * -find MSBuild\**\Bin\MSBuild.exe";
             var vsWhereResult = _executor.Start(visualStudioPath, vsWherePath, vsWhereCommand);

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialBuildProcess.cs
@@ -12,7 +12,7 @@ namespace Stryker.Core.Initialisation;
 public interface IInitialBuildProcess
 {
     void InitialBuild(bool fullFramework, string projectPath, string solutionPath, string configuration = null,
-        string msbuildPath = null, string targetFramework = null);
+        string targetFramework = null, string msbuildPath = null);
 }
 
 public class InitialBuildProcess : IInitialBuildProcess

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -195,6 +195,7 @@ public class InputFileResolver : IInputFileResolver
             buildResult = [SelectAnalyzerResult(buildResult, entry.framework)];
         }
 
+        // apply project name filter (except for test projects)
         if (isTestProject || normalizedProjectUnderTestNameFilter == null ||
             project.ProjectFile.Path.Replace('\\', '/')
                 .Contains(normalizedProjectUnderTestNameFilter, StringComparison.InvariantCultureIgnoreCase))
@@ -278,6 +279,13 @@ public class InputFileResolver : IInputFileResolver
             // check the new status
             buildResultOverallSuccess = Array.TrueForAll(project.ProjectFile.TargetFrameworks, tf =>
                 buildResult.Any(br => IsValid(br) && br.TargetFramework == tf));
+
+            if (!buildResultOverallSuccess && !string.IsNullOrEmpty(options.TargetFramework))
+            {
+                // still failed, we can try using targeframework option
+               buildResult = project.Build(options.TargetFramework);
+               buildResultOverallSuccess = buildResult.Any( br => IsValid(br) && br.TargetFramework == options.TargetFramework);
+            }
         }
 
         LogAnalyzerResult(buildResult, options);

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -249,8 +249,6 @@ public class InputFileResolver : IInputFileResolver
         _logger.LogDebug("Analyzing {ProjectFilePath}", projectLogName);
 
 
-        IAnalyzerResults buildResult;
-
         var env = new EnvironmentOptions();
 
         if (!string.IsNullOrEmpty(options.MsBuildPath))
@@ -259,7 +257,7 @@ public class InputFileResolver : IInputFileResolver
             env.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH] = options.MsBuildPath;
         }
 
-        buildResult = project.Build(env);
+        var buildResult = project.Build(env);
 
         var buildResultOverallSuccess = buildResult.OverallSuccess || Array.
             TrueForAll(project.ProjectFile.TargetFrameworks, tf =>

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -247,7 +247,19 @@ public class InputFileResolver : IInputFileResolver
         }
         var projectLogName = Path.GetRelativePath(options.WorkingDirectory, project.ProjectFile.Path);
         _logger.LogDebug("Analyzing {ProjectFilePath}", projectLogName);
-        var buildResult = project.Build();
+
+
+        IAnalyzerResults buildResult;
+
+        var env = new EnvironmentOptions();
+
+        if (!string.IsNullOrEmpty(options.MsBuildPath))
+        {
+            // we need to forward this path to buildalyzer
+            env.EnvironmentVariables[EnvironmentVariables.MSBUILD_EXE_PATH] = options.MsBuildPath;
+        }
+
+        buildResult = project.Build(env);
 
         var buildResultOverallSuccess = buildResult.OverallSuccess || Array.
             TrueForAll(project.ProjectFile.TargetFrameworks, tf =>

--- a/src/Stryker.Core/Stryker.Core/packages.lock.json
+++ b/src/Stryker.Core/Stryker.Core/packages.lock.json
@@ -838,8 +838,8 @@
           "Microsoft.CodeAnalysis.CSharp": "[4.14.0, )",
           "Microsoft.CodeAnalysis.Common": "[4.14.0, )",
           "Serilog": "[4.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )"
         }
       },
       "stryker.datacollector": {
@@ -859,7 +859,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.testrunner.vstest": {
@@ -870,10 +870,11 @@
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
           "Microsoft.TestPlatform.Portable": "[17.14.1, )",
           "Microsoft.TestPlatform.TranslationLayer": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
-          "Stryker.TestRunner": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.TestRunner": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
+          "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
       "stryker.utilities": {
@@ -885,7 +886,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Microsoft.CodeAnalysis.VisualBasic": {

--- a/src/Stryker.Options/Stryker.Configuration.csproj
+++ b/src/Stryker.Options/Stryker.Configuration.csproj
@@ -6,13 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Glob" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Serilog" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Stryker.Abstractions\Stryker.Abstractions.csproj" />
     <ProjectReference Include="..\Stryker.Utilities\Stryker.Utilities.csproj" />
   </ItemGroup>

--- a/src/Stryker.Options/Stryker.Configuration.csproj
+++ b/src/Stryker.Options/Stryker.Configuration.csproj
@@ -6,6 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNet.Glob" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Serilog" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Stryker.Abstractions\Stryker.Abstractions.csproj" />
     <ProjectReference Include="..\Stryker.Utilities\Stryker.Utilities.csproj" />
   </ItemGroup>

--- a/src/Stryker.Options/packages.lock.json
+++ b/src/Stryker.Options/packages.lock.json
@@ -266,7 +266,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Buildalyzer": {

--- a/src/Stryker.TestRunner.VsTest.UnitTest/packages.lock.json
+++ b/src/Stryker.TestRunner.VsTest.UnitTest/packages.lock.json
@@ -831,13 +831,13 @@
           "Serilog.Sinks.Console": "[6.0.0, )",
           "ShellProgressBar": "[5.2.0, )",
           "Spectre.Console": "[0.50.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Configuration": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Configuration": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
           "Stryker.Regex.Parser": "[1.0.0, )",
-          "Stryker.RegexMutators": "[4.6.0, )",
-          "Stryker.TestRunner.VsTest": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )",
+          "Stryker.RegexMutators": "[1.0.0, )",
+          "Stryker.TestRunner.VsTest": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
           "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
@@ -860,8 +860,8 @@
           "Microsoft.CodeAnalysis.CSharp": "[4.14.0, )",
           "Microsoft.CodeAnalysis.Common": "[4.14.0, )",
           "Serilog": "[4.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )"
         }
       },
       "stryker.core.unittest": {
@@ -874,9 +874,9 @@
           "Moq": "[4.20.72, )",
           "Shouldly": "[4.3.0, )",
           "Spectre.Console.Testing": "[0.50.0, )",
-          "Stryker.Abstractions": "[4.6.0, )",
+          "Stryker.Abstractions": "[1.0.0, )",
           "Stryker.Regex.Parser": "[1.0.0, )",
-          "Stryker.Utilities": "[4.6.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
           "TestableIO.System.IO.Abstractions.TestingHelpers": "[22.0.14, )",
           "stryker": "[4.6.0, )"
         }
@@ -898,7 +898,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.testrunner.vstest": {
@@ -909,10 +909,11 @@
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
           "Microsoft.TestPlatform.Portable": "[17.14.1, )",
           "Microsoft.TestPlatform.TranslationLayer": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )",
-          "Stryker.DataCollector": "[4.6.0, )",
-          "Stryker.TestRunner": "[4.6.0, )",
-          "Stryker.Utilities": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )",
+          "Stryker.DataCollector": "[1.0.0, )",
+          "Stryker.TestRunner": "[1.0.0, )",
+          "Stryker.Utilities": "[1.0.0, )",
+          "TestableIO.System.IO.Abstractions.Wrappers": "[22.0.14, )"
         }
       },
       "stryker.utilities": {
@@ -924,7 +925,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Azure.Storage.Files.Shares": {

--- a/src/Stryker.TestRunner.VsTest/Stryker.TestRunner.VsTest.csproj
+++ b/src/Stryker.TestRunner.VsTest/Stryker.TestRunner.VsTest.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="Microsoft.TestPlatform.Portable" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stryker.TestRunner.VsTest/Stryker.TestRunner.VsTest.csproj
+++ b/src/Stryker.TestRunner.VsTest/Stryker.TestRunner.VsTest.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" />
     <PackageReference Include="Microsoft.TestPlatform.Portable" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" />
-    <PackageReference Include="System.IO.Abstractions" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stryker.TestRunner.VsTest/packages.lock.json
+++ b/src/Stryker.TestRunner.VsTest/packages.lock.json
@@ -48,6 +48,15 @@
           "NETStandard.Library": "2.0.0"
         }
       },
+      "TestableIO.System.IO.Abstractions.Wrappers": {
+        "type": "Direct",
+        "requested": "[22.0.14, )",
+        "resolved": "22.0.14",
+        "contentHash": "w8VwX0jiDSfj5bM+BopyZszvvEnQKDTNDp9pUKYwSOj34P9GAllmJ6kcGyye2IrzctdQs3xFpg8Vdsm8TrWfgQ==",
+        "dependencies": {
+          "Testably.Abstractions.FileSystem.Interface": "9.0.0"
+        }
+      },
       "Buildalyzer.Logger": {
         "type": "Transitive",
         "resolved": "7.1.0",
@@ -286,7 +295,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.TestPlatform.ObjectModel": "[17.14.1, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "stryker.utilities": {
@@ -298,7 +307,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.6, )",
           "Mono.Cecil": "[0.11.6, )",
           "ResXResourceReader.NetStandard": "[1.3.0, )",
-          "Stryker.Abstractions": "[4.6.0, )"
+          "Stryker.Abstractions": "[1.0.0, )"
         }
       },
       "Buildalyzer": {
@@ -398,15 +407,6 @@
         "requested": "[4.3.0, )",
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
-      },
-      "TestableIO.System.IO.Abstractions.Wrappers": {
-        "type": "CentralTransitive",
-        "requested": "[22.0.14, )",
-        "resolved": "22.0.14",
-        "contentHash": "w8VwX0jiDSfj5bM+BopyZszvvEnQKDTNDp9pUKYwSOj34P9GAllmJ6kcGyye2IrzctdQs3xFpg8Vdsm8TrWfgQ==",
-        "dependencies": {
-          "Testably.Abstractions.FileSystem.Interface": "9.0.0"
-        }
       }
     }
   }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -207,10 +207,17 @@ Generated source code may be missing.", analyzer);
     public static bool IsSignedAssembly(this IAnalyzerResult analyzerResult) =>
         analyzerResult.GetPropertyOrDefault("SignAssembly", false);
 
-    public static string GetAssemblyOriginatorKeyFile(this IAnalyzerResult analyzerResult)
+    public static string? GetAssemblyOriginatorKeyFile(this IAnalyzerResult analyzerResult)
     {
         var assemblyKeyFileProp = analyzerResult.GetPropertyOrDefault("AssemblyOriginatorKeyFile");
-        return assemblyKeyFileProp is null ? null : Path.Combine(Path.GetDirectoryName(analyzerResult.ProjectFilePath) ?? ".", assemblyKeyFileProp);
+        if (assemblyKeyFileProp is not null)
+        {
+            return Path.Combine(Path.GetDirectoryName(analyzerResult.ProjectFilePath) ?? ".", assemblyKeyFileProp);
+        }
+        else
+        {
+            return null;
+        }
     }
 
     public static ImmutableDictionary<string, ReportDiagnostic> GetDiagnosticOptions(


### PR DESCRIPTION
This PR aims at improving Stryker support for complex setup/project situations. As such it:
1. Add a project analysis attempt forcing the target framework when normal attempts failed. This works only when a target framework is defined
2. Ensure Buildalyzer uses the msbuild executable set via the `--msbuild-path` option. This is useful when buildalyzer fails to automatically select the most suitable msbuild version

Issues:
Fixes: #3260
Fixes: #3144

Note: there is unit test for (2) (Buildalyzer using the --msbuild-path`) as its difficult to add. But code is straightforward and I performed manual end-to-end tests on this feature