### PR TITLE
feat(compilation): Support projects using DelaySign

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/SourceProjects/SourceProjectInfoTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/SourceProjects/SourceProjectInfoTests.cs
@@ -55,4 +55,40 @@ public class SourceProjectInfoTests : TestBase
         options.OutputKind.ShouldBe(output);
         options.NullableContextOptions.ShouldBe(NullableContextOptions.Annotations);
     }
+
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public void ShouldGenerateProperSigningCompilationOptions(bool signAssembly, bool delaySign)
+    {
+        var target = new SourceProjectInfo()
+        {
+            AnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                properties: new Dictionary<string, string>() {
+                    { "TargetDir", "/test/bin/Debug/" },
+                    { "TargetFileName", "TestName.dll" },
+                    { "AssemblyName", "AssemblyName" },
+                    { "SignAssembly", signAssembly.ToString() },
+                    { "DelaySign", delaySign.ToString() },
+                    { "AssemblyOriginatorKeyFile", "test/keyfile.snk" }
+                }).Object
+        };
+
+        var options = target.AnalyzerResult.GetCompilationOptions();
+
+        options.AllowUnsafe.ShouldBe(true);
+        options.OutputKind.ShouldBe(OutputKind.DynamicallyLinkedLibrary);
+        options.NullableContextOptions.ShouldBe(NullableContextOptions.Enable);
+        if (signAssembly)
+        {
+            options.CryptoKeyFile.ShouldEndWith("test/keyfile.snk");
+        }
+        else
+        {
+            options.CryptoKeyFile.ShouldBeNull();
+        }
+        options.DelaySign.ShouldBe(signAssembly ? delaySign : null);
+    }
 }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -23,7 +23,8 @@ public static class IAnalyzerResultCSharpExtensions
         if (analyzerResult.IsSignedAssembly() && analyzerResult.GetAssemblyOriginatorKeyFile() is var keyFile && keyFile is not null)
         {
             compilationOptions = compilationOptions.WithCryptoKeyFile(keyFile)
-                .WithStrongNameProvider(new DesktopStrongNameProvider());
+                .WithStrongNameProvider(new DesktopStrongNameProvider())
+                .WithDelaySign(analyzerResult.IsDelayedSignedAssembly());
         }
         return compilationOptions;
     }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -207,6 +207,9 @@ Generated source code may be missing.", analyzer);
     public static bool IsSignedAssembly(this IAnalyzerResult analyzerResult) =>
         analyzerResult.GetPropertyOrDefault("SignAssembly", false);
 
+    public static bool IsDelayedSignedAssembly(this IAnalyzerResult analyzerResult) =>
+            analyzerResult.GetPropertyOrDefault("DelaySign", false);
+
     public static string? GetAssemblyOriginatorKeyFile(this IAnalyzerResult analyzerResult)
     {
         var assemblyKeyFileProp = analyzerResult.GetPropertyOrDefault("AssemblyOriginatorKeyFile");


### PR DESCRIPTION
Add support for `<DelaySign>` (https://learn.microsoft.com/en-us/cpp/build/reference/delaysign-partially-sign-an-assembly?view=msvc-170) during post-mutation build.

fixes #3272