### PR TITLE
Fix #3284

### DIFF
--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -269,8 +269,14 @@ Generated source code may be missing.", analyzer);
     public static string GetRootNamespace(this IAnalyzerResult analyzerResult) =>
         analyzerResult.GetPropertyOrDefault("RootNamespace") ?? analyzerResult.GetAssemblyName();
 
-    public static bool GetPropertyOrDefault(this IAnalyzerResult analyzerResult, string name, bool defaultBoolean) =>
-        bool.Parse(analyzerResult.GetPropertyOrDefault(name, defaultBoolean.ToString()));
+    public static bool GetPropertyOrDefault(this IAnalyzerResult analyzerResult, string name, bool defaultBoolean)
+    {
+        if (analyzerResult.Properties.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value))
+        {
+            return bool.Parse(value);
+        }
+        return defaultBoolean;
+    }
 
     public static string GetPropertyOrDefault(this IAnalyzerResult analyzerResult, string name,
         string defaultValue = default) =>


### PR DESCRIPTION
When trying to read a boolean property, handle the case where it could evaluate to an empty string.

Fixes #3284