### PR TITLE
Skip --open-report hint in CI

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -51,7 +52,7 @@ public class DashboardReporter : IReporter
             {
                 _browser.Open(reportUri);
             }
-            else
+            else if(!string.Equals(Environment.GetEnvironmentVariable("CI"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
             {
                 var aqua = new Style(Color.Aqua);
                 _console.WriteLine(

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/HtmlReporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -7,7 +8,6 @@ using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
 using Stryker.Abstractions.ProjectComponents;
 using Stryker.Abstractions.Reporting;
-using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters.Html.RealTime;
 using Stryker.Core.Reporters.Json;
 using Stryker.Core.Reporters.WebBrowserOpener;
@@ -77,8 +77,11 @@ public class HtmlReporter : IReporter
             return;
         }
 
-        var aqua = new Style(Color.Aqua);
-        _console.WriteLine("Hint: by passing \"--open-report or -o\" the report will open automatically and update the report in real-time.", aqua);
+        if (!string.Equals(Environment.GetEnvironmentVariable("CI"), bool.TrueString, StringComparison.OrdinalIgnoreCase))
+        {
+            var aqua = new Style(Color.Aqua);
+            _console.WriteLine("Hint: by passing \"--open-report or -o\" the report will open automatically and update the report in real-time.", aqua);
+        }
     }
 
     public void OnMutantTested(IReadOnlyMutant result)


### PR DESCRIPTION
Do not output the hint for `--open-report` when `CI=true`.
