### PR TITLE
feat(testrunner): Improve detection of test projects for MTP

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/BuildAnalyzerTestsBase.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/BuildAnalyzerTestsBase.cs
@@ -255,6 +255,7 @@ public class BuildAnalyzerTestsBase : TestBase, ISolutionProvider
             }
 
             projectAnalyzerResultMock.Setup(x => x.SourceFiles).Returns(sourceFiles);
+            projectAnalyzerResultMock.Setup(x => x.PackageReferences).Returns(new Dictionary<string, IReadOnlyDictionary<string, string>>());
             projectAnalyzerResultMock.Setup(x => x.PreprocessorSymbols).Returns(["NET"]);
             specificProperties.Add("TargetRefPath", projectBin);
             specificProperties.Add("TargetDir", projectUnderTestBin);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
@@ -143,4 +143,35 @@ public class AnalyzerResultExtensionsTests
         diagOptions.ShouldContain(new KeyValuePair<string, ReportDiagnostic>("EXTEXP0003", reportDiagnostic));
         diagOptions.ShouldContain(new KeyValuePair<string, ReportDiagnostic>("EXTEXP0004", reportDiagnostic));
     }
+
+    [TestMethod]
+    [DataRow("IsTestProject", "true", true)]
+    [DataRow("IsTestProject", "True", true)]
+    [DataRow("IsTestProject", "false", false)]
+    [DataRow("IsTestProject", "False", false)]
+    [DataRow("IsTestProject", "NotABoolean", false)]
+    [DataRow("IsTestProject", null, false)]
+    [DataRow("IsTestingPlatformApplication", "true", true)]
+    [DataRow("IsTestingPlatformApplication", "True", true)]
+    [DataRow("IsTestingPlatformApplication", "false", false)]
+    [DataRow("IsTestingPlatformApplication", "False", false)]
+    [DataRow("IsTestingPlatformApplication", "NotABoolean", false)]
+    [DataRow("IsTestingPlatformApplication", null, false)]
+    public void IsTestProject(string property, string value, bool expected)
+    {
+        // Arrange
+        var analyzerResult = Mock.Of<IAnalyzerResult>();
+        Mock.Get(analyzerResult)
+            .SetupGet(g => g.Properties)
+            .Returns(value == null ? [] : new Dictionary<string, string> { { property, value } });
+        Mock.Get(analyzerResult)
+            .SetupGet(g => g.PackageReferences)
+            .Returns(new Dictionary<string, IReadOnlyDictionary<string, string>>());
+
+        // Act
+        var isTestProject = IAnalyzerResultExtensions.IsTestProject([analyzerResult]);
+
+        // Assert
+        isTestProject.ShouldBe(expected);
+    }
 }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -172,9 +172,9 @@ public static class IAnalyzerResultExtensions
 
     private static bool IsTestProject(this IAnalyzerResult analyzerResult)
     {
-        if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestProject"), out var isTestProject))
+        if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestingPlatformApplication"), out var isTestProject))
         {
-            if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestingPlatformApplication"), out isTestProject))
+            if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestProject"), out isTestProject))
             {
                 isTestProject = Array.Exists(KnownTestPackages, n => analyzerResult.PackageReferences.ContainsKey(n));
             }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -174,7 +174,10 @@ public static class IAnalyzerResultExtensions
     {
         if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestProject"), out var isTestProject))
         {
-            isTestProject = Array.Exists(KnownTestPackages, n => analyzerResult.PackageReferences.ContainsKey(n));
+            if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestingPlatformApplication"), out isTestProject))
+            {
+                isTestProject = Array.Exists(KnownTestPackages, n => analyzerResult.PackageReferences.ContainsKey(n));
+            }
         }
 
         var hasTestProjectTypeGuid = analyzerResult

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -172,19 +172,25 @@ public static class IAnalyzerResultExtensions
 
     private static bool IsTestProject(this IAnalyzerResult analyzerResult)
     {
-        if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestingPlatformApplication"), out var isTestProject))
+        if (bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestingPlatformApplication"), out var isTestingPlatformApplication) && isTestingPlatformApplication)
         {
-            if (!bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestProject"), out isTestProject))
-            {
-                isTestProject = Array.Exists(KnownTestPackages, n => analyzerResult.PackageReferences.ContainsKey(n));
-            }
+            return true;
         }
 
-        var hasTestProjectTypeGuid = analyzerResult
-            .GetPropertyOrDefault("ProjectTypeGuids", "")
-            .Contains("{3AC096D0-A1C2-E12C-1390-A8335801FDAB}");
+        if (bool.TryParse(analyzerResult.GetPropertyOrDefault("IsTestProject"), out var isTestProject) && isTestProject)
+        {
+            return true;
+        }
 
-        return isTestProject || hasTestProjectTypeGuid;
+        if (Array.Exists(KnownTestPackages, n => analyzerResult.PackageReferences.ContainsKey(n)))
+        {
+            return true;
+        }
+
+        const string TestProjectTypeGuid = "{3AC096D0-A1C2-E12C-1390-A8335801FDAB}";
+        return analyzerResult
+            .GetPropertyOrDefault("ProjectTypeGuids", "")
+            .Contains(TestProjectTypeGuid);
     }
 
     public static OutputKind GetOutputKind(this IAnalyzerResult analyzerResult) =>


### PR DESCRIPTION
When you create a new xUnit.net v3 project, the `IsTestProject` MSBuild property is not defined. It was defined for xUnit.net v2.

```shell
dotnet new update
dotnet new xunit3
```

This creates a new xUnit.net v3 project based on MTP v2.

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <OutputType>Exe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
  </PropertyGroup>

  <ItemGroup>
    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
  </ItemGroup>

  <ItemGroup>
    <Using Include="Xunit" />
  </ItemGroup>

  <ItemGroup>
    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
  </ItemGroup>

</Project>
```

In this project, the `IsTestProject` MSBuild property is not defined.

```shell
dotnet build --getProperty:IsTestProject

```

This returns an empty line.

But a new property, [IsTestingPlatformApplication](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro#msbuild-integration) is defined.

```shell
dotnet build --getProperty:IsTestingPlatformApplication
true
```