### PR TITLE
fix(mtp): Disable DiffEngine and the Verify clipboard feature 

### DIFF
--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -128,6 +128,8 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             ["STRYKER_MUTANT_FILE"] = _mutantFilePath
         };
 
+        ExternalEnvironmentVariables.Add(envVars);
+
         // Add coverage filename when in coverage mode (MutantControl will combine with temp path)
         if (_coverageMode)
         {

--- a/src/Stryker.TestRunner.VsTest/StrykerVstestHostLauncher.cs
+++ b/src/Stryker.TestRunner.VsTest/StrykerVstestHostLauncher.cs
@@ -44,18 +44,10 @@ public class StrykerVsTestHostLauncher : IStrykerTestHostLauncher
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
-                EnvironmentVariables =
-                {
-                    // Disable DiffEngine so that approval tests frameworks such as https://github.com/VerifyTests/Verify
-                    // or https://github.com/approvals/ApprovalTests.Net (which both use DiffEngine under the hood)
-                    // don't launch a diffing tool GUI on each failed test.
-                    // See https://github.com/VerifyTests/DiffEngine/blob/6.6.1/src/DiffEngine/DisabledChecker.cs#L8
-                    ["DiffEngine_Disabled"] = "true",
-                    // Disable copying the command to accept the received version to the clipboard when using Verify
-                    // See https://github.com/VerifyTests/Verify/blob/main/docs/clipboard.md
-                    ["Verify_DisableClipboard"] = "true",
-                },
             };
+
+        ExternalEnvironmentVariables.Add(processInfo.Environment);
+
         var currentProcess = new Process { StartInfo = processInfo, EnableRaisingEvents = true };
 
         if (_devMode)

--- a/src/Stryker.TestRunner/ExternalEnvironmentVariables.cs
+++ b/src/Stryker.TestRunner/ExternalEnvironmentVariables.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Stryker.TestRunner;
+
+public static class ExternalEnvironmentVariables
+{
+    public static void Add(IDictionary<string, string?> environmentVariables)
+    {
+        // Disable DiffEngine so that approval tests frameworks such as https://github.com/VerifyTests/Verify
+        // or https://github.com/approvals/ApprovalTests.Net (which both use DiffEngine under the hood)
+        // don't launch a diffing tool GUI on each failed test.
+        // See https://github.com/VerifyTests/DiffEngine#disable-for-a-machineprocess
+        environmentVariables["DiffEngine_Disabled"] = "true";
+        // Disable copying the command to accept the received version to the clipboard when using Verify
+        // See https://github.com/VerifyTests/Verify/blob/main/docs/clipboard.md#for-a-machine
+        environmentVariables["Verify_DisableClipboard"] = "true";
+    }
+}


### PR DESCRIPTION
The DiffEngine_Disabled and Verify_DisableClipboard environment variables are set for the VSTest runner. They should also be set for the MTP runner.