### PR TITLE
fix(mtp): attribute error/timed-out/cancelled states as failures

### DIFF
--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
@@ -478,6 +478,177 @@ public class SingleMicrosoftTestPlatformRunnerTests
         result.ResultMessage.ShouldNotBeNull();
     }
 
+    // --- BuildTestRunResult / execution-state attribution tests ---
+    //
+    // Regression coverage for the MTP false-negative kill attribution bug:
+    // Microsoft Testing Platform emits seven execution states. The original
+    // adapter treated only "failed" as a test failure, so tests that ended in
+    // "error" (e.g. NSubstitute's ReceivedCallsException routed through
+    // TUnit's ErrorTestNode path), "timed-out" or "cancelled" were silently
+    // dropped and their mutants were reported as Survived.
+
+    private static TestNodeUpdate Update(string uid, string state) =>
+        new(new TestNode(uid, uid, "test", state), ParentUid: "root");
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_FailedState_IsReportedAsFailing()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.Failed)],
+            totalDiscoveredTests: 1,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.FailingTests.GetIdentifiers().ShouldBe(["t1"]);
+        result.TimedOutTests.IsEmpty.ShouldBeTrue();
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_ErrorState_IsReportedAsFailing()
+    {
+        // The regression: a non-assertion exception (e.g. NSubstitute's
+        // ReceivedCallsException) is routed by TUnit through ErrorTestNode,
+        // which serialises as "error" on the wire. Before the fix this was
+        // silently dropped and the mutant was reported as Survived.
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.Error)],
+            totalDiscoveredTests: 1,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.FailingTests.GetIdentifiers().ShouldBe(["t1"]);
+        result.TimedOutTests.IsEmpty.ShouldBeTrue();
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_TimedOutState_IsReportedAsTimedOut_NotFailing()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.TimedOut)],
+            totalDiscoveredTests: 1,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.TimedOutTests.GetIdentifiers().ShouldBe(["t1"]);
+        result.FailingTests.IsEmpty.ShouldBeTrue();
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_CancelledState_IsReportedAsFailing()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.Cancelled)],
+            totalDiscoveredTests: 1,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.FailingTests.GetIdentifiers().ShouldBe(["t1"]);
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_PassedAndSkippedStates_AreNeitherFailingNorTimedOut()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.Passed), Update("t2", TestNodeStates.Skipped)],
+            totalDiscoveredTests: 2,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.FailingTests.IsEmpty.ShouldBeTrue();
+        result.TimedOutTests.IsEmpty.ShouldBeTrue();
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_InProgressAndDiscoveredStates_AreExcludedFromExecutedTests()
+    {
+        // "in-progress" = still running, "discovered" = pre-run: neither counts
+        // as an executed test.
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [
+                Update("t1", TestNodeStates.Passed),
+                Update("t2", TestNodeStates.InProgress),
+                Update("t3", TestNodeStates.Discovered),
+            ],
+            totalDiscoveredTests: 3,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.ExecutedTests.GetIdentifiers().ShouldBe(["t1"]);
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_AllKnownStates_MapToExpectedBuckets()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [
+                Update("passed",    TestNodeStates.Passed),
+                Update("skipped",   TestNodeStates.Skipped),
+                Update("failed",    TestNodeStates.Failed),
+                Update("error",     TestNodeStates.Error),
+                Update("timed-out", TestNodeStates.TimedOut),
+                Update("cancelled", TestNodeStates.Cancelled),
+                Update("in-prog",   TestNodeStates.InProgress),
+                Update("disc",      TestNodeStates.Discovered),
+            ],
+            totalDiscoveredTests: 8,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        result.FailingTests.GetIdentifiers().ShouldBe(["failed", "error", "cancelled"], ignoreOrder: true);
+        result.TimedOutTests.GetIdentifiers().ShouldBe(["timed-out"]);
+        result.ExecutedTests.GetIdentifiers()
+            .ShouldBe(["passed", "skipped", "failed", "error", "timed-out", "cancelled"], ignoreOrder: true);
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_ExecutedTests_CollapsesToEveryTest_WhenAllFinished()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [Update("t1", TestNodeStates.Passed), Update("t2", TestNodeStates.Failed)],
+            totalDiscoveredTests: 2,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        // When every discovered test finished, ExecutedTests is the sentinel
+        // "every test" (IsEveryTest == true). Downstream Mutant.AnalyzeTestRun
+        // uses this sentinel to mark mutants as Survived when they weren't
+        // covered.
+        result.ExecutedTests.IsEveryTest.ShouldBeTrue();
+    }
+
+    [TestMethod, Timeout(1000)]
+    public void BuildTestRunResult_ErrorMessages_IncludeErrorAndTimedOutAndCancelledStates()
+    {
+        using var runner = CreateRunner();
+
+        var result = runner.BuildTestRunResult(
+            [
+                Update("passed",    TestNodeStates.Passed),
+                Update("failed",    TestNodeStates.Failed),
+                Update("error",     TestNodeStates.Error),
+                Update("timed-out", TestNodeStates.TimedOut),
+                Update("cancelled", TestNodeStates.Cancelled),
+            ],
+            totalDiscoveredTests: 5,
+            duration: TimeSpan.FromMilliseconds(10));
+
+        // The free-form error message surfaces every non-passing state so users
+        // can tell why the mutant was killed.
+        result.ResultMessage.ShouldContain("failed");
+        result.ResultMessage.ShouldContain("error");
+        result.ResultMessage.ShouldContain("timed-out");
+        result.ResultMessage.ShouldContain("cancelled");
+        result.ResultMessage.ShouldNotContain("passed");
+    }
+
     [TestCleanup]
     public void Cleanup()
     {

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/TestNodeStatesTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/TestNodeStatesTests.cs
@@ -1,0 +1,70 @@
+using Shouldly;
+
+namespace Stryker.TestRunner.MicrosoftTestPlatform.UnitTest;
+
+[TestClass]
+public class TestNodeStatesTests
+{
+    [TestMethod]
+    [DataRow(TestNodeStates.Passed, true)]
+    [DataRow(TestNodeStates.Skipped, true)]
+    [DataRow(TestNodeStates.Failed, true)]
+    [DataRow(TestNodeStates.Error, true)]
+    [DataRow(TestNodeStates.TimedOut, true)]
+    [DataRow(TestNodeStates.Cancelled, true)]
+    [DataRow(TestNodeStates.Discovered, false)]
+    [DataRow(TestNodeStates.InProgress, false)]
+    [DataRow(null, false)]
+    public void IsFinished_ReturnsExpected(string? state, bool expected) =>
+        TestNodeStates.IsFinished(state).ShouldBe(expected);
+
+    [TestMethod]
+    [DataRow(TestNodeStates.Failed, true)]
+    [DataRow(TestNodeStates.Error, true)]
+    [DataRow(TestNodeStates.Cancelled, true)]
+    [DataRow(TestNodeStates.Passed, false)]
+    [DataRow(TestNodeStates.Skipped, false)]
+    [DataRow(TestNodeStates.TimedOut, false)]
+    [DataRow(TestNodeStates.Discovered, false)]
+    [DataRow(TestNodeStates.InProgress, false)]
+    [DataRow(null, false)]
+    public void IsFailure_ReturnsExpected(string? state, bool expected) =>
+        TestNodeStates.IsFailure(state).ShouldBe(expected);
+
+    [TestMethod]
+    [DataRow(TestNodeStates.TimedOut, true)]
+    [DataRow(TestNodeStates.Failed, false)]
+    [DataRow(TestNodeStates.Error, false)]
+    [DataRow(TestNodeStates.Cancelled, false)]
+    [DataRow(TestNodeStates.Passed, false)]
+    [DataRow(TestNodeStates.Skipped, false)]
+    [DataRow(TestNodeStates.Discovered, false)]
+    [DataRow(TestNodeStates.InProgress, false)]
+    [DataRow(null, false)]
+    public void IsTimeout_ReturnsExpected(string? state, bool expected) =>
+        TestNodeStates.IsTimeout(state).ShouldBe(expected);
+
+    [TestMethod]
+    public void StateConstants_MatchWireFormat()
+    {
+        TestNodeStates.Discovered.ShouldBe("discovered");
+        TestNodeStates.InProgress.ShouldBe("in-progress");
+        TestNodeStates.Passed.ShouldBe("passed");
+        TestNodeStates.Skipped.ShouldBe("skipped");
+        TestNodeStates.Failed.ShouldBe("failed");
+        TestNodeStates.Error.ShouldBe("error");
+        TestNodeStates.TimedOut.ShouldBe("timed-out");
+        TestNodeStates.Cancelled.ShouldBe("cancelled");
+    }
+
+    [TestMethod]
+    public void StateClassification_IsCaseSensitive()
+    {
+        // Defence in depth: the MTP wire format is lowercase, so we don't
+        // normalise, but make that contract explicit so a future unintentional
+        // case-insensitive change is caught.
+        TestNodeStates.IsFailure("Failed").ShouldBeFalse();
+        TestNodeStates.IsFailure("ERROR").ShouldBeFalse();
+        TestNodeStates.IsTimeout("Timed-Out").ShouldBeFalse();
+    }
+}

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
@@ -112,7 +112,7 @@ internal sealed class AssemblyTestServer : IDisposable
         await discoverTestsResponse.WaitCompletionAsync().ConfigureAwait(false);
 
         return discoveredResults
-            .Where(x => x.Node.ExecutionState is "discovered")
+            .Where(x => x.Node.ExecutionState is TestNodeStates.Discovered)
             .Select(x => x.Node)
             .ToList();
     }

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -526,53 +526,7 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             var (testResults, timedOut) = await server.RunTestsAsync(testsToRun, timeout).ConfigureAwait(false);
 
             var duration = DateTime.UtcNow - startTime;
-            var finishedTests = testResults.Where(x => x.Node.ExecutionState is not "in-progress").ToList();
-            var failedTests = finishedTests.Where(x => x.Node.ExecutionState is "failed").Select(x => x.Node.Uid).ToList();
-
-            lock (_discoveryLock)
-            {
-                // MTP doesn't report per-test timing, so approximate with the average
-                var perTestDuration = finishedTests.Count > 0
-                    ? TimeSpan.FromTicks(duration.Ticks / finishedTests.Count)
-                    : TimeSpan.Zero;
-
-                foreach (var testResult in finishedTests.Where(tr => _testDescriptions.ContainsKey(tr.Node.Uid)))
-                {
-                    var testDescription = _testDescriptions[testResult.Node.Uid];
-                    testDescription.RegisterInitialTestResult(new MtpTestResult(perTestDuration));
-                }
-            }
-
-            var errorMessagesStr = string.Join(Environment.NewLine,
-                finishedTests.Where(x => x.Node.ExecutionState is "failed")
-                    .Select(x => $"{x.Node.DisplayName}{Environment.NewLine}{Environment.NewLine}Test failed"));
-
-            var messages = finishedTests.Select(x =>
-                $"{x.Node.DisplayName}{Environment.NewLine}{Environment.NewLine}State: {x.Node.ExecutionState}");
-
-            var totalDiscoveredTests = tests?.Count ?? 0;
-            var executedTestCount = finishedTests.Count;
-            var executedTests = totalDiscoveredTests > 0 && executedTestCount >= totalDiscoveredTests
-                ? TestIdentifierList.EveryTest()
-                : new TestIdentifierList(finishedTests.Select(x => x.Node.Uid));
-
-            var failedTestIds = new TestIdentifierList(failedTests);
-
-
-            IEnumerable<MtpTestDescription> testDescriptionValues;
-            lock (_discoveryLock)
-            {
-                testDescriptionValues = _testDescriptions.Values.ToList();
-            }
-
-            var result = new TestRunResult(
-                testDescriptionValues,
-                executedTests,
-                failedTestIds,
-                TestIdentifierList.NoTest(),
-                errorMessagesStr,
-                messages,
-                duration);
+            var result = BuildTestRunResult(testResults, tests?.Count ?? 0, duration);
 
             return (result, timedOut);
         }
@@ -580,6 +534,89 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         {
             return (new TestRunResult(false, ex.Message), false);
         }
+    }
+
+    /// <summary>
+    /// Maps a list of <see cref="TestNodeUpdate"/>s returned by the MTP server
+    /// to a <see cref="TestRunResult"/>. Exposed for unit testing.
+    /// </summary>
+    /// <remarks>
+    /// Classification of execution states goes through <see cref="TestNodeStates"/>
+    /// so that failure attribution (the bug this adapter originally had) stays in
+    /// one place:
+    /// <list type="bullet">
+    ///   <item><description><c>failed</c>/<c>error</c>/<c>cancelled</c> → failing tests (mutant killed)</description></item>
+    ///   <item><description><c>timed-out</c> → timed-out tests (mutant timeout)</description></item>
+    ///   <item><description><c>passed</c>/<c>skipped</c> → executed but neither failing nor timed-out</description></item>
+    ///   <item><description><c>in-progress</c>/<c>discovered</c> → excluded from executed tests</description></item>
+    /// </list>
+    /// </remarks>
+    internal TestRunResult BuildTestRunResult(
+        IReadOnlyCollection<TestNodeUpdate> testResults,
+        int totalDiscoveredTests,
+        TimeSpan duration)
+    {
+        var finishedTests = testResults
+            .Where(x => TestNodeStates.IsFinished(x.Node.ExecutionState))
+            .ToList();
+
+        var failedTests = finishedTests
+            .Where(x => TestNodeStates.IsFailure(x.Node.ExecutionState))
+            .Select(x => x.Node.Uid)
+            .ToList();
+
+        var timedOutTests = finishedTests
+            .Where(x => TestNodeStates.IsTimeout(x.Node.ExecutionState))
+            .Select(x => x.Node.Uid)
+            .ToList();
+
+        lock (_discoveryLock)
+        {
+            // MTP doesn't report per-test timing, so approximate with the average
+            var perTestDuration = finishedTests.Count > 0
+                ? TimeSpan.FromTicks(duration.Ticks / finishedTests.Count)
+                : TimeSpan.Zero;
+
+            foreach (var testResult in finishedTests.Where(tr => _testDescriptions.ContainsKey(tr.Node.Uid)))
+            {
+                var testDescription = _testDescriptions[testResult.Node.Uid];
+                testDescription.RegisterInitialTestResult(new MtpTestResult(perTestDuration));
+            }
+        }
+
+        var errorMessagesStr = string.Join(Environment.NewLine,
+            finishedTests
+                .Where(x => TestNodeStates.IsFailure(x.Node.ExecutionState)
+                         || TestNodeStates.IsTimeout(x.Node.ExecutionState))
+                .Select(x => $"{x.Node.DisplayName}{Environment.NewLine}{Environment.NewLine}State: {x.Node.ExecutionState}"));
+
+        var messages = finishedTests.Select(x =>
+            $"{x.Node.DisplayName}{Environment.NewLine}{Environment.NewLine}State: {x.Node.ExecutionState}");
+
+        var executedTestCount = finishedTests.Count;
+        var executedTests = totalDiscoveredTests > 0 && executedTestCount >= totalDiscoveredTests
+            ? TestIdentifierList.EveryTest()
+            : new TestIdentifierList(finishedTests.Select(x => x.Node.Uid));
+
+        var failedTestIds = new TestIdentifierList(failedTests);
+        var timedOutTestIds = timedOutTests.Count == 0
+            ? TestIdentifierList.NoTest()
+            : new TestIdentifierList(timedOutTests);
+
+        IEnumerable<MtpTestDescription> testDescriptionValues;
+        lock (_discoveryLock)
+        {
+            testDescriptionValues = _testDescriptions.Values.ToList();
+        }
+
+        return new TestRunResult(
+            testDescriptionValues,
+            executedTests,
+            failedTestIds,
+            timedOutTestIds,
+            errorMessagesStr,
+            messages,
+            duration);
     }
 
     public void Dispose()

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/TestNodeStates.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/TestNodeStates.cs
@@ -1,0 +1,50 @@
+namespace Stryker.TestRunner.MicrosoftTestPlatform;
+
+/// <summary>
+/// Canonical Microsoft Testing Platform <c>execution-state</c> string values and
+/// classification helpers used when mapping MTP test outcomes to Stryker mutant status.
+/// </summary>
+/// <remarks>
+/// The string values match Microsoft.Testing.Platform's wire format
+/// (see its <c>SerializerUtilities</c>). Keeping them in one place avoids the
+/// single-literal bug that caused tests ending in <c>"error"</c>, <c>"timed-out"</c>
+/// or <c>"cancelled"</c> to be silently dropped when only <c>"failed"</c> was
+/// treated as a failure — for example TUnit routes non-assertion exceptions
+/// (such as NSubstitute's <c>ReceivedCallsException</c>) through its
+/// <c>ErrorTestNode</c> path, producing <c>"error"</c> rather than <c>"failed"</c>.
+/// </remarks>
+internal static class TestNodeStates
+{
+    public const string Discovered = "discovered";
+    public const string InProgress = "in-progress";
+    public const string Passed = "passed";
+    public const string Skipped = "skipped";
+    public const string Failed = "failed";
+    public const string Error = "error";
+    public const string TimedOut = "timed-out";
+    public const string Cancelled = "cancelled";
+
+    /// <summary>
+    /// True when the test has reached a terminal state (i.e. not still running or
+    /// merely discovered). Used to decide which updates contribute to the
+    /// executed-tests set.
+    /// </summary>
+    public static bool IsFinished(string? state) =>
+        state is not (null or InProgress or Discovered);
+
+    /// <summary>
+    /// True when the test ended in a state that indicates the mutant changed
+    /// observable behaviour: an assertion failure, a non-assertion exception,
+    /// or explicit cancellation. Timeouts are reported separately via
+    /// <see cref="IsTimeout"/> so the resulting mutant is classified as
+    /// <c>Timeout</c> rather than <c>Killed</c>.
+    /// </summary>
+    public static bool IsFailure(string? state) =>
+        state is Failed or Error or Cancelled;
+
+    /// <summary>
+    /// True when the test reported a per-test timeout.
+    /// </summary>
+    public static bool IsTimeout(string? state) =>
+        state is TimedOut;
+}


### PR DESCRIPTION
closes #3570

## Summary

The Microsoft Testing Platform (MTP) adapter only treated the `"failed"`
execution-state as a test failure, silently dropping tests that ended in
`"error"` (non-assertion exceptions), `"timed-out"` (per-test timeouts), or
`"cancelled"`. Mutants that should have been **Killed** were reported as
**Survived**.

This is most visible when using TUnit + NSubstitute: `Received(N)`
assertions throw `ReceivedCallsException`, which TUnit — not recognising
it as a TUnit assertion — routes through its `ErrorTestNode` path and
serialises as `"error"` on the wire. The adapter's single-string filter
missed it.

## What changed

- New `TestNodeStates` helper holds the seven canonical MTP state strings
  (`passed`, `skipped`, `failed`, `error`, `timed-out`, `cancelled`,
  `in-progress`, plus `discovered`) and three classifiers (`IsFinished`,
  `IsFailure`, `IsTimeout`). One source of truth for every state literal.
- `SingleMicrosoftTestPlatformRunner` result-building logic is extracted
  into an `internal BuildTestRunResult` method using the classifiers.
- `TimedOutTests` is now populated from per-test `timed-out` states
  (previously always empty), so `Mutant.AnalyzeTestRun` can correctly
  classify mutants as `Timeout` rather than `Survived`.

Classification mapping:

| State | Bucket | Resulting `MutantStatus` |
|---|---|---|
| `failed` / `error` / `cancelled` | `FailingTests` | Killed |
| `timed-out` | `TimedOutTests` | Timeout |
| `passed` / `skipped` | executed, neither | Survived (if covered) |
| `in-progress` / `discovered` | excluded from executed | n/a |

## Tests

29 new tests across `TestNodeStatesTests.cs` and
`SingleMicrosoftTestPlatformRunnerTests.cs`. Reverting the classifier to
its original buggy form makes 8 of them fail, proving regression coverage.
Full MTP adapter suite: **185 passed, 0 failed, 0 skipped.**

## Real-world impact

Apples-to-apples scoped run on a downstream TUnit + NSubstitute project
(same mutation set, same tests, only the adapter changed):

|  | Baseline | Fixed | Delta |
|---|---:|---:|---:|
| Killed | 95 | 118 | **+23** |
| Survived | 126 | 103 | **-23** |
| Strict score | 42.99 % | **53.39 %** | **+10.40 pp** |

No drift in `CompileError`, `Ignored` or `NoCoverage` — exactly what an
adapter-only fix should look like.

Refs #3094

## Test plan

- [x] `dotnet test src/Stryker.slnx` — 1969 passed, 0 failed, 1 pre-existing skip
- [x] `dotnet test src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest` — 185 passed, 0 failed
- [x] Temporarily reverted the classifier to reproduce the original bug — 8 new tests fail
- [x] End-to-end verification on a downstream TUnit + NSubstitute project — +23 kills, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)