### PR TITLE
fix(mutating): out var in lambdas triggering NRE

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -1029,11 +1029,46 @@ static Mutator_Flag_MutatedStatics()
     [TestMethod]
     public void ShouldInitializeOutVars()
     {
-        var source = @"public void SomeMethod(out int x, out string text) { x = 1; text = ""hello"";}";
-        var expected = @"public void SomeMethod(out int x, out string text) {{x= default(int);text= default(string);}if(StrykerNamespace.MutantControl.IsActive(0)){}else{ x = 1; text = (StrykerNamespace.MutantControl.IsActive(1)?"""":""hello"");
-        }}";
+        const string Source = """public void SomeMethod(out int x, out string text) { x = 1; text = "hello";}""";
+        const string Expected = """
+                                public void SomeMethod(out int x, out string text) {{x= default(int);text= default(string);}if(StrykerNamespace.MutantControl.IsActive(0)){}else{ x = 1; text = (StrykerNamespace.MutantControl.IsActive(1)?"":"hello");
+                                        }}
+                                """;
 
-        ShouldMutateSourceInClassToExpected(source, expected);
+        ShouldMutateSourceInClassToExpected(Source, Expected);
+    }
+
+    [TestMethod]
+    public void ShouldInitializeOutVarsForLambdas()
+    {
+        const string Source = """
+                              public static void Thing()
+                              {
+                                  var results = new List<ExceptionResultDelegate>();
+
+                                  results.Add((out result) =>
+                                  {
+                                      result = false;
+                                      return false;
+                                  });
+                              }
+                              """;
+        const string Expected = """
+                                public static void Thing()
+                                {if(StrykerNamespace.MutantControl.IsActive(0)){}
+                                else{
+                                    var results = new List<ExceptionResultDelegate>();
+
+                                    if(StrykerNamespace.MutantControl.IsActive(1)){;}else{results.Add((out result) =>
+                                {{result= default;}    if(StrykerNamespace.MutantControl.IsActive(2))    {}else{
+                                        result = (StrykerNamespace.MutantControl.IsActive(3)?true:false);
+                                        return (StrykerNamespace.MutantControl.IsActive(4)?true:false);
+                                    }return default;});}
+                                }
+                                }
+                                """;
+
+        ShouldMutateSourceInClassToExpected(Source, Expected);
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -148,13 +148,17 @@ internal static class RoslynHelper
     /// </summary>
     /// <param name="type">Type used in the resulting default expression.</param>
     /// <returns>An expression representing `default(<paramref name="type"/>'.</returns>
-    public static ExpressionSyntax BuildDefaultExpression(this TypeSyntax type) => SyntaxFactory.DefaultExpression(type.WithoutTrivia()).WithLeadingTrivia(SyntaxFactory.Space);
+    public static ExpressionSyntax BuildDefaultExpression(this TypeSyntax type) =>
+        (type == null
+            ? (ExpressionSyntax) SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+            : SyntaxFactory.DefaultExpression(type.WithoutTrivia())).WithLeadingTrivia(SyntaxFactory.Space);
 
     /// <summary>
     /// Check if a statements (or one of its child statements, if any) verifies some given predicate.
     /// </summary>
     /// <param name="syntax">initial statements</param>
     /// <param name="predicate">predicate to verify</param>
+    /// <param name="skipBlocks">true to skip syntablocks</param>
     /// <returns>true if any of the child statements verify the predicate</returns>
     /// <remarks>scanning stops as soon as one child matches the predicate</remarks>
     public static bool ScanChildStatements(this StatementSyntax syntax, Func<StatementSyntax, bool> predicate, bool skipBlocks = false)
@@ -187,7 +191,7 @@ internal static class RoslynHelper
     /// <param name="skipBlock">set to true to avoid scan into block statements</param>
     /// <returns></returns>
     public static bool ContainsNodeThatVerifies(this SyntaxNode node, Func<SyntaxNode, bool> predicate, bool skipBlock = true) =>
-        // scan 
+        // scan
         node.DescendantNodes((child) =>
         {
             if (skipBlock && child is BlockSyntax)

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -147,7 +147,7 @@ internal static class RoslynHelper
     /// Return a default(type) expression.
     /// </summary>
     /// <param name="type">Type used in the resulting default expression.</param>
-    /// <returns>An expression representing `default(<paramref name="type"/>'.</returns>
+    ///  <returns>An expression representing `default(<paramref name="type"/>`.</returns>
     public static ExpressionSyntax BuildDefaultExpression(this TypeSyntax type) =>
         (type == null
             ? (ExpressionSyntax) SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression)
@@ -158,7 +158,7 @@ internal static class RoslynHelper
     /// </summary>
     /// <param name="syntax">initial statements</param>
     /// <param name="predicate">predicate to verify</param>
-    /// <param name="skipBlocks">true to skip syntablocks</param>
+    /// <param name="skipBlocks">true to skip syntax blocks</param>
     /// <returns>true if any of the child statements verify the predicate</returns>
     /// <remarks>scanning stops as soon as one child matches the predicate</remarks>
     public static bool ScanChildStatements(this StatementSyntax syntax, Func<StatementSyntax, bool> predicate, bool skipBlocks = false)

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
@@ -49,7 +49,7 @@ internal class DefaultInitializationEngine : BaseEngine<BlockSyntax>
         else
         {
             // this is the first initializer helper, no pre existing ones
-            initializers = Array.Empty<StatementSyntax>();
+            initializers = [];
             // keep all statements
             originalStatements = body.Statements;
         }
@@ -59,7 +59,7 @@ internal class DefaultInitializationEngine : BaseEngine<BlockSyntax>
                 p.Type.BuildDefaultExpression())))))
             .WithAdditionalAnnotations(BlockMarker);
 
-        return body.WithStatements(new(originalStatements.Prepend(initializersBlock))).WithAdditionalAnnotations(Marker);
+        return body.WithStatements(new SyntaxList<StatementSyntax>(originalStatements.Prepend(initializersBlock))).WithAdditionalAnnotations(Marker);
     }
 
     /// <summary>


### PR DESCRIPTION
Improve `out` variables initialization to default to handle situation where type is not explicitly defined in function signatures, such as in lambdas.
It then uses the `default` keyword instead of `default(type)` format. Note this will fail if project uses C# version 7 or less.

Fixes #3572 