### PR TITLE
Almost fixes #3572.  Issue with the new test that I haven't sorted out yet.

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantPlacerTests.cs
@@ -177,7 +177,6 @@ public class MutantPlacerTests : TestBase
         CheckMutantPlacerProperlyPlaceAndRemoveHelpers<PropertyDeclarationSyntax>(source, expected, placer.ConvertToBlockBody);
     }
 
-
     [TestMethod]
     public void ShouldInjectInitializersAndRestore()
     {
@@ -188,6 +187,61 @@ public class MutantPlacerTests : TestBase
             (n) => MutantPlacer.InjectOutParametersInitialization(n,
                 new[]{SyntaxFactory.Parameter(SyntaxFactory.Identifier("x")).WithModifiers(SyntaxFactory.TokenList(new[] {SyntaxFactory.Token(SyntaxKind.OutKeyword)})).WithType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword))
                 )}));
+    }
+
+    [TestMethod]
+    public void ShouldNotInjectWithAnonymousLambda()
+    {
+        var codeInjection = new CodeInjection();
+        var placer = new MutantPlacer(codeInjection);
+
+        const string source = """
+                              public static class Foo
+                              {
+                                  private delegate bool ExceptionResultDelegate(out bool result);
+
+                                  public static void Thing()
+                                  {
+                                      var results = new List<ExceptionResultDelegate>();
+
+                                      results.Add((out result) =>
+                                      {
+                                          result = false;
+                                          return false;
+                                      });
+                                  }
+                              }
+                              """;
+        const string expected = """
+                                public static class Foo
+                                {
+                                    private delegate bool ExceptionResultDelegate(out bool result);
+
+                                    public static void Thing()
+                                {    if(StrykerNamespace.MutantControl.IsActive(0))    {}
+                                else{
+                                        var results = new List<ExceptionResultDelegate>();
+
+                                        if(StrykerNamespace.MutantControl.IsActive(1)){;}else{results.Add((out result) =>
+                                {        if(StrykerNamespace.MutantControl.IsActive(2))        {}else{
+                                            result = (StrykerNamespace.MutantControl.IsActive(3)?true:false);
+                                            return (StrykerNamespace.MutantControl.IsActive(4)?true:false);
+                                        }return default;});}
+                                    }
+                                }}
+                                """;
+        var expectedSyntax = CSharpSyntaxTree.ParseText(expected.Replace("StrykerNamespace", codeInjection.HelperNamespace));
+
+        var orchestrator = new CsharpMutantOrchestrator(placer, options: new StrykerOptions
+        {
+            OptimizationMode = OptimizationModes.CoverageBasedTest,
+            MutationLevel = MutationLevel.Complete
+        });
+
+        var actualNode = orchestrator.Mutate(CSharpSyntaxTree.ParseText(source), null);
+
+        actualNode.ShouldBeSemantically(expectedSyntax);
+        actualNode.ShouldNotContainErrors();
     }
 
 

--- a/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
+++ b/src/Stryker.Core/Stryker.Core/Instrumentation/DefaultInitializationEngine.cs
@@ -32,7 +32,11 @@ internal class DefaultInitializationEngine : BaseEngine<BlockSyntax>
                 "Can't add default initializer(s) to expression bodied or virtual method.");
         }
         parameters = parameters.Where(p => p.Modifiers.Any(m => m.IsKind(SyntaxKind.OutKeyword))).ToList();
-        if (!parameters.Any())
+
+
+        // The BlockSyntax may not have the type information available, it may not even be available to the SemanticModel, this can happen
+        // when there is a lambda expression as a parameter.
+        if (!parameters.Any() || parameters.Any(x => x.Type == null))
         {
             return body;
         }


### PR DESCRIPTION
Digging through https://github.com/stryker-mutator/stryker-net/issues/3572 it appears that there may not be a way to actually get the property type in the scenario of the lambda function in that scenario.  Even looking through the `SemanticModel` that is up in the `BaseFunctionOrchestrator` doesn't help, it still resolves the symbol as a `ErrorTypeSymbol (?)`.  So in this scenario, I think the only viable option is to bail out if any of the parameters' types are null. 

This is that change.  However the unit test I added for this doesn't work yet.  Getting weird results when trying to compare the before/after.  They are identical as far as I can tell, but the comparison says they are different.  Will continue to dig into this tomorrow. 