### PR TITLE
fix(mutating): avoid uncompilable mutations in several edge cases

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using Stryker.Core.Helpers;
+
+namespace Stryker.Core.UnitTest.Helpers;
+
+[TestClass]
+public class RoslynHelperTests : TestBase
+{
+    [TestMethod]
+    [DataRow("s is { Length: > 0 } region")]
+    [DataRow("s is var captured")]
+    [DataRow("s is int n")]
+    public void ContainsDeclarationsShouldDetectPatternDesignations(string expression)
+    {
+        SyntaxFactory.ParseExpression(expression).ContainsDeclarations().ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void ContainsDeclarationsShouldDetectOutVarDeclaration()
+    {
+        SyntaxFactory.ParseExpression("int.TryParse(s, out var value)")
+            .ContainsDeclarations().ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("s.Length > 0")]
+    [DataRow("s is [_, _]")]
+    [DataRow("(a, b)")]
+    public void ContainsDeclarationsShouldReturnFalseWithoutDeclarations(string expression)
+    {
+        SyntaxFactory.ParseExpression(expression).ContainsDeclarations().ShouldBeFalse();
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -158,5 +159,64 @@ namespace TestApplication
         var result = target.ApplyMutations(memberAccessExpression, null);
 
         result.ShouldHaveSingleItem().ReplacementNode.ShouldBeOfType<MemberAccessExpressionSyntax>().Name.ToString().ShouldBe("Any");
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateAppendOnNonEnumerableReceiver()
+    {
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            namespace TestApp
+            {
+                interface IResponseCookies { void Append(string key, string value); }
+                class Program
+                {
+                    static void Run(IResponseCookies cookies) => cookies.Append("k", "v");
+                }
+            }
+            """,
+            "Append");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldMutateAppendOnEnumerableReceiver()
+    {
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+            namespace TestApp
+            {
+                class Program
+                {
+                    static void Run(IEnumerable<int> items) { var x = items.Append(1); }
+                }
+            }
+            """,
+            "Append");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel).ToList();
+
+        result.ShouldHaveSingleItem();
+    }
+
+    private static (SemanticModel semanticModel, MemberAccessExpressionSyntax expression) CreateSemanticModelForMemberAccess(string source, string memberName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create("TestAssembly")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(System.Collections.Generic.IEnumerable<>).Assembly.Location))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var memberAccess = syntaxTree.GetRoot().DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(x => x.Name.Identifier.ValueText == memberName);
+        return (semanticModel, memberAccess);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -68,5 +70,63 @@ public class ObjectCreationMutatorTests : TestBase
         var result = target.ApplyMutations(objectCreationExpression, null);
 
         result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("public required int Value { get; set; }")]
+    [DataRow("public required int Value;")]
+    [DataRow("public int Other { get; set; } public required int Value { get; set; }")]
+    public void ShouldNotMutateObjectInitializerWhenTypeHasRequiredMembers(string members)
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            $$"""
+              class Target { {{members}} }
+              class Caller { void M() { var t = new Target { Value = 1 }; } }
+              """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateObjectInitializerWhenBaseTypeHasRequiredMembers()
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            """
+            class Base { public required int Value { get; set; } }
+            class Derived : Base { public int Other { get; set; } }
+            class Caller { void M() { var t = new Derived { Value = 1, Other = 2 }; } }
+            """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldMutateObjectInitializerWhenTypeHasNoRequiredMembers()
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            """
+            class Target { public int Value { get; set; } }
+            class Caller { void M() { var t = new Target { Value = 1 }; } }
+            """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel).ToList();
+
+        result.ShouldHaveSingleItem().Type.ShouldBe(Mutator.Initializer);
+    }
+
+    private static (SemanticModel semanticModel, ObjectCreationExpressionSyntax expression) CreateSemanticModel(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create("TestAssembly")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var expression = syntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().Single();
+        return (semanticModel, expression);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -35,7 +35,13 @@ internal static class RoslynHelper
     /// <returns>true if it contains a declaration</returns>
     public static bool ContainsDeclarations(this SyntaxNode node) =>
         node.ContainsNodeThatVerifies(x =>
-            x.IsKind(SyntaxKind.DeclarationExpression) || x.IsKind(SyntaxKind.DeclarationPattern), true);
+            x.IsKind(SyntaxKind.DeclarationExpression)
+            || x.IsKind(SyntaxKind.DeclarationPattern)
+            // Recursive / var patterns can also introduce a variable via their
+            // SingleVariableDesignation, e.g. `s is { Length: > 0 } region`.
+            // Without this, expression-level mutations duplicate the declaration
+            // across ternary branches and produce CS0136.
+            || x.IsKind(SyntaxKind.SingleVariableDesignation), true);
 
     /// <summary>
     /// Gets the return the type of the method (incl. constructor, destructor...)

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -40,8 +40,11 @@ internal static class RoslynHelper
             // Recursive / var patterns can also introduce a variable via their
             // SingleVariableDesignation, e.g. `s is { Length: > 0 } region`.
             // Without this, expression-level mutations duplicate the declaration
-            // across ternary branches and produce CS0136.
-            || x.IsKind(SyntaxKind.SingleVariableDesignation), true);
+            // across ternary branches and produce CS0136. Scope to designations
+            // directly under a recursive/var pattern so unrelated designations
+            // (out var, tuple deconstruction) keep their previous behaviour.
+            || (x.IsKind(SyntaxKind.SingleVariableDesignation)
+                && x.Parent is RecursivePatternSyntax or VarPatternSyntax), true);
 
     /// <summary>
     /// Gets the return the type of the method (incl. constructor, destructor...)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -181,6 +181,14 @@ internal class MutationStore
             // never inject at member access level, there is no known control structure
             return mutatedNode;
         }
+        // If this expression introduces a declaration (e.g. `x is { … } v`),
+        // duplicating it via a ternary would re-declare the variable in each
+        // branch and trigger CS0136. Forward mutations to an enclosing block
+        // so they can be controlled by an if-statement instead.
+        if (sourceNode.ContainsDeclarations())
+        {
+            return mutatedNode;
+        }
         var store = _pendingMutations.Peek().Store;
         var result = _mutantPlacer.PlaceExpressionControlledMutations(mutatedNode,
              store.Select(m => (m, sourceNode.InjectMutation(m.Mutation))));

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -37,7 +37,17 @@ public class CsharpMutationProcess : IMutationProcess
         var projectInfo = input.SourceProjectInfo.ProjectContents;
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
-        var semanticModels = compilingProcess.GetSemanticModels(projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree));
+        // Include auto-generated compilation trees (e.g. GlobalUsings.g.cs,
+        // AssemblyInfo.cs) so the semantic model resolves implicit usings and
+        // attributes — otherwise mutators that consult the semantic model see
+        // unresolved types. Files have not yet been mutated, so use the
+        // original SyntaxTree for each file rather than CompilationSyntaxTrees
+        // (which would return null MutatedSyntaxTrees at this stage).
+        var fileTrees = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree);
+        var generatedTrees = ((ProjectComponent<SyntaxTree>)projectInfo).CompilationSyntaxTrees
+            .Where(t => t is not null)
+            .Except(fileTrees);
+        var semanticModels = compilingProcess.GetSemanticModels(fileTrees.Concat(generatedTrees));
 
         // Mutate source files
         foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -5,6 +5,7 @@ using Stryker.Abstractions;
 using Stryker.Core.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Stryker.Core.Mutators;
 
@@ -109,6 +110,11 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
                 yield break;
             }
 
+            if (!IsLinqInvocation(node, semanticModel))
+            {
+                yield break;
+            }
+
             yield return new Mutation
             {
                 DisplayName =
@@ -134,4 +140,86 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
         }
         return null;
     }
+
+    // Ensures we only mutate calls that are actually LINQ operations. Without this
+    // check, any method whose name happens to match a LINQ operator (e.g.
+    // IResponseCookies.Append) would be incorrectly rewritten.
+    private static bool IsLinqInvocation(ExpressionSyntax node, SemanticModel semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            // No semantic model available (e.g. unit tests) — preserve legacy
+            // name-only matching behaviour.
+            return true;
+        }
+
+        // `node` is the MemberAccess/MemberBinding being mutated; its parent is
+        // the enclosing InvocationExpression for a direct call (e.g.
+        // `x.Append(...)`). FindEnclosingInvocation only walks up through chained
+        // member access and returns null in the direct case.
+        var invocation = node.Parent as InvocationExpressionSyntax ?? FindEnclosingInvocation(node);
+        if (invocation is null)
+        {
+            return true;
+        }
+
+        if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
+        {
+            var containingType = methodSymbol.ContainingType?.ConstructedFrom ?? methodSymbol.ContainingType;
+            if (containingType is not null && IsLinqHostType(containingType))
+            {
+                return true;
+            }
+
+            var receiverType = methodSymbol.IsExtensionMethod
+                ? methodSymbol.ReducedFrom?.Parameters.FirstOrDefault()?.Type ?? methodSymbol.Parameters.FirstOrDefault()?.Type
+                : methodSymbol.ReceiverType;
+
+            return receiverType is not null && ImplementsGenericEnumerable(receiverType);
+        }
+
+        // Symbol couldn't be resolved from the invocation. Fall back to the
+        // receiver's syntactic expression — if its type binds and it isn't a LINQ
+        // shape, we can still skip the mutation. This catches cases like
+        // `httpContext.Response.Cookies.Append(...)` where the broader semantic
+        // resolution may have failed but the receiver's static type is still
+        // available.
+        if (node is MemberAccessExpressionSyntax memberAccess)
+        {
+            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+            if (receiverType is not null && receiverType.TypeKind != TypeKind.Error)
+            {
+                return ImplementsGenericEnumerable(receiverType);
+            }
+        }
+
+        // Receiver type could not be determined — preserve legacy behaviour.
+        return true;
+    }
+
+    private static bool IsLinqHostType(INamedTypeSymbol type) =>
+        type.ToDisplayString() is "System.Linq.Enumerable"
+            or "System.Linq.Queryable"
+            or "System.Linq.ParallelEnumerable";
+
+    private static bool ImplementsGenericEnumerable(ITypeSymbol type)
+    {
+        if (IsGenericIEnumerable(type))
+        {
+            return true;
+        }
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsGenericIEnumerable(iface))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsGenericIEnumerable(ITypeSymbol type) =>
+        type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T;
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -25,6 +25,13 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
         }
         if (node.Initializer?.Kind() == SyntaxKind.ObjectInitializerExpression && node.Initializer.Expressions.Count > 0)
         {
+            // Skip when the target type has any `required` members — an empty
+            // initializer would fail to compile with CS8852.
+            if (HasRequiredMembers(node, semanticModel))
+            {
+                yield break;
+            }
+
             yield return new Mutation()
             {
                 OriginalNode = node,
@@ -33,5 +40,33 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
                 Type = Mutator.Initializer,
             };
         }
+    }
+
+    private static bool HasRequiredMembers(ObjectCreationExpressionSyntax node, SemanticModel semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return false;
+        }
+
+        var typeSymbol = semanticModel.GetTypeInfo(node).Type as INamedTypeSymbol;
+        if (typeSymbol is null)
+        {
+            return false;
+        }
+
+        for (var current = typeSymbol; current is not null; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if ((member is IPropertySymbol prop && prop.IsRequired) ||
+                    (member is IFieldSymbol field && field.IsRequired))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -26,7 +26,7 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
         if (node.Initializer?.Kind() == SyntaxKind.ObjectInitializerExpression && node.Initializer.Expressions.Count > 0)
         {
             // Skip when the target type has any `required` members — an empty
-            // initializer would fail to compile with CS8852.
+            // initializer would fail to compile with CS9035.
             if (HasRequiredMembers(node, semanticModel))
             {
                 yield break;


### PR DESCRIPTION
## Summary
- Avoid CS0136 by skipping ternary mutation placement when the expression introduces a declaration (e.g. recursive patterns like `x is { } v`); mutations are forwarded to the enclosing block instead.
- Include auto-generated compilation trees (e.g. `GlobalUsings.g.cs`) when building semantic models so mutators that consult the semantic model see resolved types.
- Restrict `LinqMutator` to invocations whose receiver implements `IEnumerable<T>` (or whose containing type is `Enumerable`/`Queryable`/`ParallelEnumerable`), preventing incorrect rewrites of unrelated methods such as `IResponseCookies.Append`.
- Skip the `ObjectCreationMutator` initializer-removal mutation when the target type has any `required` members (CS9035).

Fixes #3594

## Test plan
- [ ] Run existing unit test suite
- [ ] Verify mutation runs against a project using ASP.NET Core (`IResponseCookies.Append`) no longer produce CS-failure mutants
- [ ] Verify mutation runs against a project using `required` members no longer produce CS9035 mutants
- [ ] Verify mutation runs against a project using recursive patterns no longer produce CS0136 mutants