### PR TITLE
fix(mutating): include generated trees when building semantic models

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/CSharpMutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/CSharpMutationTestProcessTests.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Shouldly;
 using Stryker.Abstractions;
 using Stryker.Configuration.Options;
 using Stryker.Core.Mutants;
@@ -96,5 +97,32 @@ public class CSharpMutationTestProcessTests : TestBase
         // Verify the created assembly is written to disk on the right location
         var expectedPath = Path.Combine(FilesystemRoot, "TestProject", "bin", "Debug", "netcoreapp2.0", "ProjectUnderTest.dll");
         fileSystem.ShouldContainFile(expectedPath);
+    }
+
+    [TestMethod]
+    public void GatherSemanticModelTreesShouldIncludeGeneratedCompilationTrees()
+    {
+        var folder = new CsharpFolderComposite();
+        var fileTree = CSharpSyntaxTree.ParseText(SourceFile);
+        folder.Add(new CsharpFileLeaf
+        {
+            SourceCode = SourceFile,
+            SyntaxTree = fileTree
+        });
+
+        // Auto-generated trees that aren't mutated but must participate in
+        // the semantic model so implicitly-imported types resolve.
+        var globalUsingsTree = CSharpSyntaxTree.ParseText("global using System.Collections.Generic;", path: "GlobalUsings.g.cs");
+        var assemblyInfoTree = CSharpSyntaxTree.ParseText("[assembly: System.Reflection.AssemblyTitle(\"x\")]", path: "AssemblyInfo.cs");
+        folder.AddCompilationSyntaxTree(globalUsingsTree);
+        folder.AddCompilationSyntaxTree(assemblyInfoTree);
+
+        var trees = CsharpMutationProcess.GatherSemanticModelTrees(folder);
+
+        trees.ShouldContain(fileTree);
+        trees.ShouldContain(globalUsingsTree);
+        trees.ShouldContain(assemblyInfoTree);
+        // Nulls from unset MutatedSyntaxTree must not leak through.
+        trees.ShouldNotContain((SyntaxTree)null);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -37,17 +37,8 @@ public class CsharpMutationProcess : IMutationProcess
         var projectInfo = input.SourceProjectInfo.ProjectContents;
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
-        // Include auto-generated compilation trees (e.g. GlobalUsings.g.cs,
-        // AssemblyInfo.cs) so the semantic model resolves implicit usings and
-        // attributes — otherwise mutators that consult the semantic model see
-        // unresolved types. Files have not yet been mutated, so use the
-        // original SyntaxTree for each file rather than CompilationSyntaxTrees
-        // (which would return null MutatedSyntaxTrees at this stage).
-        var fileTrees = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree);
-        var generatedTrees = ((ProjectComponent<SyntaxTree>)projectInfo).CompilationSyntaxTrees
-            .Where(t => t is not null)
-            .Except(fileTrees);
-        var semanticModels = compilingProcess.GetSemanticModels(fileTrees.Concat(generatedTrees));
+        var semanticModelTrees = GatherSemanticModelTrees((ProjectComponent<SyntaxTree>)projectInfo);
+        var semanticModels = compilingProcess.GetSemanticModels(semanticModelTrees);
 
         // Mutate source files
         foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())
@@ -131,5 +122,22 @@ public class CsharpMutationProcess : IMutationProcess
             var mutantsToFilter = file.Mutants.Where(x => x.ResultStatus != MutantStatus.CompileError);
             _mutantFilter.FilterMutants(mutantsToFilter, file, _options);
         }
+    }
+
+    // Gather the syntax trees that need to participate in the semantic model:
+    // every file tree plus any auto-generated compilation tree (e.g.
+    // GlobalUsings.g.cs, AssemblyInfo.cs) added via AddCompilationSyntaxTree.
+    // Files have not yet been mutated at this stage, so use each file's
+    // original SyntaxTree; CompilationSyntaxTrees on file leaves yields
+    // MutatedSyntaxTrees, whose entries are still null because
+    // MutatedSyntaxTree has not been assigned yet.
+    internal static SyntaxTree[] GatherSemanticModelTrees(ProjectComponent<SyntaxTree> projectInfo)
+    {
+        var fileTrees = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree).ToArray();
+        var generatedTrees = projectInfo.CompilationSyntaxTrees
+            .Where(t => t is not null)
+            .Except(fileTrees)
+            .ToArray();
+        return [.. fileTrees, .. generatedTrees];
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -37,7 +37,17 @@ public class CsharpMutationProcess : IMutationProcess
         var projectInfo = input.SourceProjectInfo.ProjectContents;
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
-        var semanticModels = compilingProcess.GetSemanticModels(projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree));
+        // Include auto-generated compilation trees (e.g. GlobalUsings.g.cs,
+        // AssemblyInfo.cs) so the semantic model resolves implicit usings and
+        // attributes — otherwise mutators that consult the semantic model see
+        // unresolved types. Files have not yet been mutated, so use the
+        // original SyntaxTree for each file rather than CompilationSyntaxTrees
+        // (which would return null MutatedSyntaxTrees at this stage).
+        var fileTrees = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree);
+        var generatedTrees = ((ProjectComponent<SyntaxTree>)projectInfo).CompilationSyntaxTrees
+            .Where(t => t is not null)
+            .Except(fileTrees);
+        var semanticModels = compilingProcess.GetSemanticModels(fileTrees.Concat(generatedTrees));
 
         // Mutate source files
         foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -135,7 +135,7 @@ public class CsharpMutationProcess : IMutationProcess
     {
         var fileTrees = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree).ToArray();
         var generatedTrees = projectInfo.CompilationSyntaxTrees
-            .Where(t => t is not null)
+            .OfType<SyntaxTree>()
             .Except(fileTrees)
             .ToArray();
         return [.. fileTrees, .. generatedTrees];


### PR DESCRIPTION
## Summary
- `CsharpMutationProcess.Mutate` was building semantic models from `projectInfo.GetAllFiles()` only, so auto-generated trees added via `AddCompilationSyntaxTree` (most importantly `*.GlobalUsings.g.cs`) were missing — any mutator consulting the semantic model silently saw `IErrorTypeSymbol` for types brought in by implicit usings.
- Include the project's `CompilationSyntaxTrees` alongside file trees. Files have not yet been mutated at this stage, so each file's original `SyntaxTree` is used rather than `CompilationSyntaxTrees` (which would surface null `MutatedSyntaxTrees`).

Fixes #3599. Split out from #3594.

## Test plan
- [ ] Existing unit tests still pass
- [ ] Run mutation against an ASP.NET Core project using `<ImplicitUsings>enable` and verify semantic-model-consuming mutators (e.g. `LinqMutator`, `StringMethodMutator`) see resolved types