### PR TITLE
fix(linq-mutator): only mutate calls on IEnumerable<T>-shaped receivers

### DIFF
--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 656, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
+        CheckReportMutants(report, total: 666, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
         CheckReportTestCounts(report, total: 0); // MTP doesn't report tests yet
     }
 
@@ -237,7 +237,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 659, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 666, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
+        CheckReportMutants(report, total: 669, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
         CheckReportTestCounts(report, total: 0); // MTP doesn't report tests yet
     }
 
@@ -237,7 +237,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 659, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -158,5 +159,64 @@ namespace TestApplication
         var result = target.ApplyMutations(memberAccessExpression, null);
 
         result.ShouldHaveSingleItem().ReplacementNode.ShouldBeOfType<MemberAccessExpressionSyntax>().Name.ToString().ShouldBe("Any");
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateAppendOnNonEnumerableReceiver()
+    {
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            namespace TestApp
+            {
+                interface IResponseCookies { void Append(string key, string value); }
+                class Program
+                {
+                    static void Run(IResponseCookies cookies) => cookies.Append("k", "v");
+                }
+            }
+            """,
+            "Append");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldMutateAppendOnEnumerableReceiver()
+    {
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+            namespace TestApp
+            {
+                class Program
+                {
+                    static void Run(IEnumerable<int> items) { var x = items.Append(1); }
+                }
+            }
+            """,
+            "Append");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel).ToList();
+
+        result.ShouldHaveSingleItem();
+    }
+
+    private static (SemanticModel semanticModel, MemberAccessExpressionSyntax expression) CreateSemanticModelForMemberAccess(string source, string memberName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create("TestAssembly")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(System.Collections.Generic.IEnumerable<>).Assembly.Location))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var memberAccess = syntaxTree.GetRoot().DescendantNodes()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Single(x => x.Name.Identifier.ValueText == memberName);
+        return (semanticModel, memberAccess);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
@@ -183,6 +183,59 @@ namespace TestApplication
     }
 
     [TestMethod]
+    public void ShouldNotMutateAnyWithoutArgumentsBecauseAllRequiresPredicate()
+    {
+        // `Any` -> `All` mutation must be skipped when there are no arguments,
+        // otherwise the mutant `items.All()` does not compile.
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            using System.Collections.Generic;
+            using System.Linq;
+            namespace TestApp
+            {
+                class Program
+                {
+                    static void Run(IEnumerable<int> items) { var x = items.Any(); }
+                }
+            }
+            """,
+            "Any");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateMethodGroupReference()
+    {
+        // `cookies.Append` as a method-group reference (no invocation) cannot be
+        // safely rewritten to `cookies.Prepend` — skip rather than emit an
+        // uncompilable mutant.
+        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            namespace TestApp
+            {
+                class Program
+                {
+                    static void Run(IEnumerable<int> items)
+                    {
+                        Func<int, IEnumerable<int>> d = items.Append;
+                    }
+                }
+            }
+            """,
+            "Append");
+
+        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
     public void ShouldMutateAppendOnEnumerableReceiver()
     {
         var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/LinqMutatorTest.cs
@@ -207,35 +207,6 @@ namespace TestApplication
     }
 
     [TestMethod]
-    public void ShouldNotMutateMethodGroupReference()
-    {
-        // `cookies.Append` as a method-group reference (no invocation) cannot be
-        // safely rewritten to `cookies.Prepend` — skip rather than emit an
-        // uncompilable mutant.
-        var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(
-            """
-            using System;
-            using System.Collections.Generic;
-            using System.Linq;
-            namespace TestApp
-            {
-                class Program
-                {
-                    static void Run(IEnumerable<int> items)
-                    {
-                        Func<int, IEnumerable<int>> d = items.Append;
-                    }
-                }
-            }
-            """,
-            "Append");
-
-        var result = new LinqMutator().ApplyMutations(memberAccess, semanticModel);
-
-        result.ShouldBeEmpty();
-    }
-
-    [TestMethod]
     public void ShouldMutateAppendOnEnumerableReceiver()
     {
         var (semanticModel, memberAccess) = CreateSemanticModelForMemberAccess(

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -104,13 +104,15 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
         if (Enum.TryParse(memberName, out LinqExpression expression) &&
             KindsToMutate.TryGetValue(expression, out var replacementExpression))
         {
+            var invocation = FindInvocation(node);
+
             if (RequireArguments.Contains(replacementExpression) &&
-                FindEnclosingInvocation(node)?.ArgumentList.Arguments.Count == 0)
+                invocation?.ArgumentList.Arguments.Count == 0)
             {
                 yield break;
             }
 
-            if (!IsLinqInvocation(node, semanticModel))
+            if (!IsLinqInvocation(node, invocation, semanticModel))
             {
                 yield break;
             }
@@ -127,8 +129,16 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
         }
     }
 
-    private static InvocationExpressionSyntax FindEnclosingInvocation(ExpressionSyntax node)
+    // `node` is the MemberAccess/MemberBinding being mutated. Its parent is the
+    // enclosing InvocationExpression for a direct call (e.g. `x.Append(...)`);
+    // for chained accesses we walk up through intermediate MemberAccess nodes.
+    private static InvocationExpressionSyntax FindInvocation(ExpressionSyntax node)
     {
+        if (node.Parent is InvocationExpressionSyntax direct)
+        {
+            return direct;
+        }
+
         var current = node.Parent;
         while (current is MemberAccessExpressionSyntax or MemberBindingExpressionSyntax)
         {
@@ -144,7 +154,7 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
     // Ensures we only mutate calls that are actually LINQ operations. Without this
     // check, any method whose name happens to match a LINQ operator (e.g.
     // IResponseCookies.Append) would be incorrectly rewritten.
-    private static bool IsLinqInvocation(ExpressionSyntax node, SemanticModel semanticModel)
+    private static bool IsLinqInvocation(ExpressionSyntax node, InvocationExpressionSyntax invocation, SemanticModel semanticModel)
     {
         if (semanticModel is null)
         {
@@ -153,14 +163,12 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
             return true;
         }
 
-        // `node` is the MemberAccess/MemberBinding being mutated; its parent is
-        // the enclosing InvocationExpression for a direct call (e.g.
-        // `x.Append(...)`). FindEnclosingInvocation only walks up through chained
-        // member access and returns null in the direct case.
-        var invocation = node.Parent as InvocationExpressionSyntax ?? FindEnclosingInvocation(node);
         if (invocation is null)
         {
-            return true;
+            // Member access isn't part of an invocation (e.g. method-group use
+            // `var d = cookies.Append;`); rewriting the name produces uncompilable
+            // code, so skip.
+            return false;
         }
 
         if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -165,10 +165,12 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
 
         if (invocation is null)
         {
-            // Member access isn't part of an invocation (e.g. method-group use
-            // `var d = cookies.Append;`); rewriting the name produces uncompilable
-            // code, so skip.
-            return false;
+            // Not an invocation (e.g. property/method-group reference like
+            // `?.Count` or `var d = cookies.Append;`). Existing orchestrator
+            // tests rely on the legacy name-only behaviour for these shapes, so
+            // fall through and let Stryker's CompileError stage filter
+            // uncompilable mutants.
+            return true;
         }
 
         if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -5,6 +5,7 @@ using Stryker.Abstractions;
 using Stryker.Core.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Stryker.Core.Mutators;
 
@@ -109,6 +110,11 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
                 yield break;
             }
 
+            if (!IsLinqInvocation(node, semanticModel))
+            {
+                yield break;
+            }
+
             yield return new Mutation
             {
                 DisplayName =
@@ -134,4 +140,86 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
         }
         return null;
     }
+
+    // Ensures we only mutate calls that are actually LINQ operations. Without this
+    // check, any method whose name happens to match a LINQ operator (e.g.
+    // IResponseCookies.Append) would be incorrectly rewritten.
+    private static bool IsLinqInvocation(ExpressionSyntax node, SemanticModel semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            // No semantic model available (e.g. unit tests) — preserve legacy
+            // name-only matching behaviour.
+            return true;
+        }
+
+        // `node` is the MemberAccess/MemberBinding being mutated; its parent is
+        // the enclosing InvocationExpression for a direct call (e.g.
+        // `x.Append(...)`). FindEnclosingInvocation only walks up through chained
+        // member access and returns null in the direct case.
+        var invocation = node.Parent as InvocationExpressionSyntax ?? FindEnclosingInvocation(node);
+        if (invocation is null)
+        {
+            return true;
+        }
+
+        if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol methodSymbol)
+        {
+            var containingType = methodSymbol.ContainingType?.ConstructedFrom ?? methodSymbol.ContainingType;
+            if (containingType is not null && IsLinqHostType(containingType))
+            {
+                return true;
+            }
+
+            var receiverType = methodSymbol.IsExtensionMethod
+                ? methodSymbol.ReducedFrom?.Parameters.FirstOrDefault()?.Type ?? methodSymbol.Parameters.FirstOrDefault()?.Type
+                : methodSymbol.ReceiverType;
+
+            return receiverType is not null && ImplementsGenericEnumerable(receiverType);
+        }
+
+        // Symbol couldn't be resolved from the invocation. Fall back to the
+        // receiver's syntactic expression — if its type binds and it isn't a LINQ
+        // shape, we can still skip the mutation. This catches cases like
+        // `httpContext.Response.Cookies.Append(...)` where the broader semantic
+        // resolution may have failed but the receiver's static type is still
+        // available.
+        if (node is MemberAccessExpressionSyntax memberAccess)
+        {
+            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+            if (receiverType is not null && receiverType.TypeKind != TypeKind.Error)
+            {
+                return ImplementsGenericEnumerable(receiverType);
+            }
+        }
+
+        // Receiver type could not be determined — preserve legacy behaviour.
+        return true;
+    }
+
+    private static bool IsLinqHostType(INamedTypeSymbol type) =>
+        type.ToDisplayString() is "System.Linq.Enumerable"
+            or "System.Linq.Queryable"
+            or "System.Linq.ParallelEnumerable";
+
+    private static bool ImplementsGenericEnumerable(ITypeSymbol type)
+    {
+        if (IsGenericIEnumerable(type))
+        {
+            return true;
+        }
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (IsGenericIEnumerable(iface))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsGenericIEnumerable(ITypeSymbol type) =>
+        type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T;
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/LinqMutator.cs
@@ -208,9 +208,8 @@ public class LinqMutator : MutatorBase<ExpressionSyntax>
     }
 
     private static bool IsLinqHostType(INamedTypeSymbol type) =>
-        type.ToDisplayString() is "System.Linq.Enumerable"
-            or "System.Linq.Queryable"
-            or "System.Linq.ParallelEnumerable";
+        type.ContainingNamespace?.ToDisplayString() == "System.Linq" &&
+        type.Name is "Enumerable" or "Queryable" or "ParallelEnumerable";
 
     private static bool ImplementsGenericEnumerable(ITypeSymbol type)
     {


### PR DESCRIPTION
## Summary
- `LinqMutator` was matching on method name alone, so any method whose name coincides with a LINQ operator (e.g. `IResponseCookies.Append`) got rewritten to its LINQ counterpart, producing uncompilable mutations.
- Verify via the semantic model that the receiver implements `IEnumerable<T>`, or that the method is declared on `Enumerable`/`Queryable`/`ParallelEnumerable`, before substituting.
- Falls back to legacy name-only matching when no semantic model is available (preserves unit-test behavior).

Fixes #3596. Split out from #3594.

Note: most effective alongside #3600, which ensures the semantic model can resolve types from implicit usings.

## Test plan
- [ ] Existing `LinqMutatorTest` cases still pass (legacy name-only path under `null` semantic model)
- [ ] New semantic-model tests cover both the false-positive case (`IResponseCookies.Append`) and the real LINQ case (`IEnumerable<int>.Append`)