### PR TITLE
fix(mutating): avoid CS0136 from recursive/var pattern designations

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
@@ -29,6 +29,10 @@ public class RoslynHelperTests : TestBase
     [DataRow("s.Length > 0")]
     [DataRow("s is [_, _]")]
     [DataRow("(a, b)")]
+    // Recursive / var patterns without a SingleVariableDesignation introduce
+    // no variable, so they must not trigger ContainsDeclarations.
+    [DataRow("s is { Length: > 0 }")]
+    [DataRow("s is var _")]
     public void ContainsDeclarationsShouldReturnFalseWithoutDeclarations(string expression)
     {
         SyntaxFactory.ParseExpression(expression).ContainsDeclarations().ShouldBeFalse();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Helpers/RoslynHelperTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using Stryker.Core.Helpers;
+
+namespace Stryker.Core.UnitTest.Helpers;
+
+[TestClass]
+public class RoslynHelperTests : TestBase
+{
+    [TestMethod]
+    [DataRow("s is { Length: > 0 } region")]
+    [DataRow("s is var captured")]
+    [DataRow("s is int n")]
+    public void ContainsDeclarationsShouldDetectPatternDesignations(string expression)
+    {
+        SyntaxFactory.ParseExpression(expression).ContainsDeclarations().ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void ContainsDeclarationsShouldDetectOutVarDeclaration()
+    {
+        SyntaxFactory.ParseExpression("int.TryParse(s, out var value)")
+            .ContainsDeclarations().ShouldBeTrue();
+    }
+
+    [TestMethod]
+    [DataRow("s.Length > 0")]
+    [DataRow("s is [_, _]")]
+    [DataRow("(a, b)")]
+    public void ContainsDeclarationsShouldReturnFalseWithoutDeclarations(string expression)
+    {
+        SyntaxFactory.ParseExpression(expression).ContainsDeclarations().ShouldBeFalse();
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -35,7 +35,16 @@ internal static class RoslynHelper
     /// <returns>true if it contains a declaration</returns>
     public static bool ContainsDeclarations(this SyntaxNode node) =>
         node.ContainsNodeThatVerifies(x =>
-            x.IsKind(SyntaxKind.DeclarationExpression) || x.IsKind(SyntaxKind.DeclarationPattern), true);
+            x.IsKind(SyntaxKind.DeclarationExpression)
+            || x.IsKind(SyntaxKind.DeclarationPattern)
+            // Recursive / var patterns can also introduce a variable via their
+            // SingleVariableDesignation, e.g. `s is { Length: > 0 } region`.
+            // Without this, expression-level mutations duplicate the declaration
+            // across ternary branches and produce CS0136. Scope to designations
+            // directly under a recursive/var pattern so unrelated designations
+            // (out var, tuple deconstruction) keep their previous behaviour.
+            || (x.IsKind(SyntaxKind.SingleVariableDesignation)
+                && x.Parent is RecursivePatternSyntax or VarPatternSyntax), true);
 
     /// <summary>
     /// Gets the return the type of the method (incl. constructor, destructor...)

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -37,14 +37,17 @@ internal static class RoslynHelper
         node.ContainsNodeThatVerifies(x =>
             x.IsKind(SyntaxKind.DeclarationExpression)
             || x.IsKind(SyntaxKind.DeclarationPattern)
-            // Recursive / var patterns can also introduce a variable via their
-            // SingleVariableDesignation, e.g. `s is { Length: > 0 } region`.
-            // Without this, expression-level mutations duplicate the declaration
-            // across ternary branches and produce CS0136. Scope to designations
-            // directly under a recursive/var pattern so unrelated designations
-            // (out var, tuple deconstruction) keep their previous behaviour.
-            || (x.IsKind(SyntaxKind.SingleVariableDesignation)
-                && x.Parent is RecursivePatternSyntax or VarPatternSyntax), true);
+            || IsRecursiveOrVarPatternDesignation(x), true);
+
+    // Recursive / var patterns can introduce a variable via their
+    // SingleVariableDesignation, e.g. `s is { Length: > 0 } region`. Without
+    // this, expression-level mutations duplicate the declaration across
+    // ternary branches and produce CS0136. Scoped to designations directly
+    // under a recursive/var pattern so unrelated designations (out var, tuple
+    // deconstruction) keep their previous behaviour.
+    private static bool IsRecursiveOrVarPatternDesignation(SyntaxNode node) =>
+        node.IsKind(SyntaxKind.SingleVariableDesignation)
+        && node.Parent is RecursivePatternSyntax or VarPatternSyntax;
 
     /// <summary>
     /// Gets the return the type of the method (incl. constructor, destructor...)

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -181,6 +181,14 @@ internal class MutationStore
             // never inject at member access level, there is no known control structure
             return mutatedNode;
         }
+        // If this expression introduces a declaration (e.g. `x is { … } v`),
+        // duplicating it via a ternary would re-declare the variable in each
+        // branch and trigger CS0136. Forward mutations to an enclosing block
+        // so they can be controlled by an if-statement instead.
+        if (sourceNode.ContainsDeclarations())
+        {
+            return mutatedNode;
+        }
         var store = _pendingMutations.Peek().Store;
         var result = _mutantPlacer.PlaceExpressionControlledMutations(mutatedNode,
              store.Select(m => (m, sourceNode.InjectMutation(m.Mutation))));

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutationStore.cs
@@ -183,8 +183,10 @@ internal class MutationStore
         }
         // If this expression introduces a declaration (e.g. `x is { … } v`),
         // duplicating it via a ternary would re-declare the variable in each
-        // branch and trigger CS0136. Forward mutations to an enclosing block
-        // so they can be controlled by an if-statement instead.
+        // branch and trigger CS0136. Skip expression-level injection by
+        // returning without consuming the pending store; Leave() will forward
+        // the mutations to an enclosing level so they can be controlled by an
+        // if-statement instead.
         if (sourceNode.ContainsDeclarations())
         {
             return mutatedNode;


### PR DESCRIPTION
## Summary
- Mutating an expression that introduces a variable via a recursive or var pattern designation (e.g. `s is { Length: > 0 } region`) at expression level produced a ternary that duplicated the declaration across branches, triggering CS0136.
- Teach `ContainsDeclarations` to detect `SingleVariableDesignation` when its parent is a `RecursivePatternSyntax`/`VarPatternSyntax`. The scoping leaves other designations (`out var`, tuple deconstruction, list patterns) at their previous expression-level behavior.
- In `MutationStore.Inject`, when the source expression contains a declaration, skip ternary placement and forward the pending mutations to the enclosing block so they can be controlled by an if-statement.

Fixes #3597. Split out from #3594.

## Test plan
- [ ] New `RoslynHelperTests` cover recursive/var/declaration patterns
- [ ] Existing `Mutators` and `Mutants` test suites still pass
- [ ] Manual verification: mutation on a project using `s is { Length: > 0 } region` no longer produces CS0136 mutants