### PR TITLE
fix(object-creation-mutator): skip empty initializer for required members

### DIFF
--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 656, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
+        CheckReportMutants(report, total: 666, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
         CheckReportTestCounts(report, total: 0); // MTP doesn't report tests yet
     }
 
@@ -237,7 +237,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 344);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 495);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 354);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 357);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 357);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 357);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 666, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
+        CheckReportMutants(report, total: 670, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 364);
         CheckReportTestCounts(report, total: 0); // MTP doesn't report tests yet
     }
 
@@ -237,7 +237,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 656, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 344);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -68,5 +70,63 @@ public class ObjectCreationMutatorTests : TestBase
         var result = target.ApplyMutations(objectCreationExpression, null);
 
         result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("public required int Value { get; set; }")]
+    [DataRow("public required int Value;")]
+    [DataRow("public int Other { get; set; } public required int Value { get; set; }")]
+    public void ShouldNotMutateObjectInitializerWhenTypeHasRequiredMembers(string members)
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            $$"""
+              class Target { {{members}} }
+              class Caller { void M() { var t = new Target { Value = 1 }; } }
+              """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldNotMutateObjectInitializerWhenBaseTypeHasRequiredMembers()
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            """
+            class Base { public required int Value { get; set; } }
+            class Derived : Base { public int Other { get; set; } }
+            class Caller { void M() { var t = new Derived { Value = 1, Other = 2 }; } }
+            """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+
+        result.ShouldBeEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldMutateObjectInitializerWhenTypeHasNoRequiredMembers()
+    {
+        var (semanticModel, expression) = CreateSemanticModel(
+            """
+            class Target { public int Value { get; set; } }
+            class Caller { void M() { var t = new Target { Value = 1 }; } }
+            """);
+
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel).ToList();
+
+        result.ShouldHaveSingleItem().Type.ShouldBe(Mutator.Initializer);
+    }
+
+    private static (SemanticModel semanticModel, ObjectCreationExpressionSyntax expression) CreateSemanticModel(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create("TestAssembly")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddSyntaxTrees(syntaxTree);
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var expression = syntaxTree.GetRoot().DescendantNodes().OfType<ObjectCreationExpressionSyntax>().Single();
+        return (semanticModel, expression);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/ObjectCreationMutatorTests.cs
@@ -76,7 +76,7 @@ public class ObjectCreationMutatorTests : TestBase
     [DataRow("public required int Value { get; set; }")]
     [DataRow("public required int Value;")]
     [DataRow("public int Other { get; set; } public required int Value { get; set; }")]
-    public void ShouldNotMutateObjectInitializerWhenTypeHasRequiredMembers(string members)
+    public void ShouldPreserveRequiredMembersWhenMutatingObjectInitializer(string members)
     {
         var (semanticModel, expression) = CreateSemanticModel(
             $$"""
@@ -84,13 +84,16 @@ public class ObjectCreationMutatorTests : TestBase
               class Caller { void M() { var t = new Target { Value = 1 }; } }
               """);
 
-        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel).ToList();
 
-        result.ShouldBeEmpty();
+        var mutation = result.ShouldHaveSingleItem();
+        mutation.Type.ShouldBe(Mutator.Initializer);
+        var replacement = mutation.ReplacementNode.ShouldBeOfType<ObjectCreationExpressionSyntax>();
+        replacement.Initializer.Expressions.ShouldHaveSingleItem().ToString().ShouldBe("Value=default!");
     }
 
     [TestMethod]
-    public void ShouldNotMutateObjectInitializerWhenBaseTypeHasRequiredMembers()
+    public void ShouldPreserveRequiredMembersFromBaseTypeWhenMutatingObjectInitializer()
     {
         var (semanticModel, expression) = CreateSemanticModel(
             """
@@ -99,9 +102,11 @@ public class ObjectCreationMutatorTests : TestBase
             class Caller { void M() { var t = new Derived { Value = 1, Other = 2 }; } }
             """);
 
-        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel);
+        var result = new ObjectCreationMutator().ApplyMutations(expression, semanticModel).ToList();
 
-        result.ShouldBeEmpty();
+        var mutation = result.ShouldHaveSingleItem();
+        var replacement = mutation.ReplacementNode.ShouldBeOfType<ObjectCreationExpressionSyntax>();
+        replacement.Initializer.Expressions.ShouldHaveSingleItem().ToString().ShouldBe("Value=default!");
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -25,6 +25,13 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
         }
         if (node.Initializer?.Kind() == SyntaxKind.ObjectInitializerExpression && node.Initializer.Expressions.Count > 0)
         {
+            // Skip when the target type has any `required` members — an empty
+            // initializer would fail to compile with CS9035.
+            if (HasRequiredMembers(node, semanticModel))
+            {
+                yield break;
+            }
+
             yield return new Mutation()
             {
                 OriginalNode = node,
@@ -33,5 +40,33 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
                 Type = Mutator.Initializer,
             };
         }
+    }
+
+    private static bool HasRequiredMembers(ObjectCreationExpressionSyntax node, SemanticModel semanticModel)
+    {
+        if (semanticModel is null)
+        {
+            return false;
+        }
+
+        var typeSymbol = semanticModel.GetTypeInfo(node).Type as INamedTypeSymbol;
+        if (typeSymbol is null)
+        {
+            return false;
+        }
+
+        for (var current = typeSymbol; current is not null; current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if ((member is IPropertySymbol prop && prop.IsRequired) ||
+                    (member is IFieldSymbol field && field.IsRequired))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/ObjectCreationMutator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -25,48 +26,59 @@ public class ObjectCreationMutator : MutatorBase<ObjectCreationExpressionSyntax>
         }
         if (node.Initializer?.Kind() == SyntaxKind.ObjectInitializerExpression && node.Initializer.Expressions.Count > 0)
         {
-            // Skip when the target type has any `required` members — an empty
-            // initializer would fail to compile with CS9035.
-            if (HasRequiredMembers(node, semanticModel))
-            {
-                yield break;
-            }
+            // An empty initializer would fail to compile with CS9035 when the type has
+            // required members, so we preserve them by assigning `default!` to each.
+            var requiredMembers = GetRequiredMemberNames(node, semanticModel);
+            var replacementInitializer = requiredMembers.Count == 0
+                ? SyntaxFactory.InitializerExpression(SyntaxKind.ObjectInitializerExpression)
+                : SyntaxFactory.InitializerExpression(
+                    SyntaxKind.ObjectInitializerExpression,
+                    SyntaxFactory.SeparatedList<ExpressionSyntax>(
+                        requiredMembers.Select(name =>
+                            SyntaxFactory.AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                SyntaxFactory.IdentifierName(name),
+                                SyntaxFactory.PostfixUnaryExpression(
+                                    SyntaxKind.SuppressNullableWarningExpression,
+                                    SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression))))));
 
             yield return new Mutation()
             {
                 OriginalNode = node,
-                ReplacementNode = node.ReplaceNode(node.Initializer, SyntaxFactory.InitializerExpression(SyntaxKind.ObjectInitializerExpression)).WithCleanTrivia(),
+                ReplacementNode = node.ReplaceNode(node.Initializer, replacementInitializer).WithCleanTrivia(),
                 DisplayName = "Object initializer mutation",
                 Type = Mutator.Initializer,
             };
         }
     }
 
-    private static bool HasRequiredMembers(ObjectCreationExpressionSyntax node, SemanticModel semanticModel)
+    private static IReadOnlyList<string> GetRequiredMemberNames(ObjectCreationExpressionSyntax node, SemanticModel semanticModel)
     {
         if (semanticModel is null)
         {
-            return false;
+            return [];
         }
 
-        var typeSymbol = semanticModel.GetTypeInfo(node).Type as INamedTypeSymbol;
-        if (typeSymbol is null)
+        if (semanticModel.GetTypeInfo(node).Type is not INamedTypeSymbol typeSymbol)
         {
-            return false;
+            return [];
         }
 
+        var names = new List<string>();
+        var seen = new HashSet<string>();
         for (var current = typeSymbol; current is not null; current = current.BaseType)
         {
             foreach (var member in current.GetMembers())
             {
-                if ((member is IPropertySymbol prop && prop.IsRequired) ||
-                    (member is IFieldSymbol field && field.IsRequired))
+                var isRequired = (member is IPropertySymbol prop && prop.IsRequired) ||
+                                 (member is IFieldSymbol field && field.IsRequired);
+                if (isRequired && seen.Add(member.Name))
                 {
-                    return true;
+                    names.Add(member.Name);
                 }
             }
         }
 
-        return false;
+        return names;
     }
 }


### PR DESCRIPTION
## Summary
- `ObjectCreationMutator` always emits an empty-initializer variant (e.g. `new Notification {}`), which fails to compile with CS9035 when the target type has C# 11 `required` properties/fields.
- Use the semantic model to walk the resolved type and its base types; if any member has `IsRequired == true`, skip the empty-initializer mutation.

Fixes #3598. Split out from #3594.

## Test plan
- [ ] Existing `ObjectCreationMutatorTests` cases still pass
- [ ] New tests cover required property, required field, base-type required member, and a no-required-members baseline that still mutates