### PR TITLE
feat(compilation): Improve code generation support 

### DIFF
--- a/src/Stryker.Abstractions/ProjectComponents/IFileLeaf.cs
+++ b/src/Stryker.Abstractions/ProjectComponents/IFileLeaf.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+
 namespace Stryker.Abstractions.ProjectComponents;
 
 public interface IReadOnlyFileLeaf : IReadOnlyProjectComponent
@@ -5,14 +7,11 @@ public interface IReadOnlyFileLeaf : IReadOnlyProjectComponent
     string SourceCode { get; }
 }
 
-public interface IFileLeaf<T> : IFileLeaf
-{
-    T SyntaxTree { get; set; }
-
-    T MutatedSyntaxTree { get; set; }
-}
-
 public interface IFileLeaf : IReadOnlyFileLeaf
 {
     new string SourceCode { get; set; }
+
+    SyntaxTree SyntaxTree { get; set; }
+
+    SyntaxTree MutatedSyntaxTree { get; set; }
 }

--- a/src/Stryker.Abstractions/ProjectComponents/IProjectComponent.cs
+++ b/src/Stryker.Abstractions/ProjectComponents/IProjectComponent.cs
@@ -9,8 +9,8 @@ public interface IReadOnlyProjectComponent
     IEnumerable<IMutant> Mutants { get; }
     IFolderComposite Parent { get; }
     string RelativePath { get; set; }
-    public Display DisplayFile { get; set; }
-    public Display DisplayFolder { get; set; }
+    Display DisplayFile { get; set; }
+    Display DisplayFolder { get; set; }
     IEnumerable<IReadOnlyMutant> TotalMutants();
     IEnumerable<IReadOnlyMutant> ValidMutants();
     IEnumerable<IReadOnlyMutant> UndetectedMutants();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -18,6 +18,7 @@ using Stryker.Abstractions.Testing;
 using Stryker.Configuration.Options;
 using Stryker.Core.Compiling;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -516,7 +517,7 @@ public class Calculator
 
             TestRunner = new Mock<ITestRunner>(MockBehavior.Default).Object
         };
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         var injector = input.SourceProjectInfo.CodeInjector;
         folder.Add(inputFile);
         foreach (var (name, code) in injector.MutantHelpers)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
@@ -62,11 +61,11 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees:[syntaxTree]);
 
         using var ms = new MemoryStream();
         using var symbol = new MemoryStream();
-        var result = target.Compile(new Collection<SyntaxTree> { syntaxTree }, ms, symbol);
+        var result = target.Compile(ms, symbol);
         result.Success.ShouldBe(true);
         ms.Length.ShouldBeGreaterThan(100, "No value was written to the MemoryStream by the compiler");
     }
@@ -113,11 +112,11 @@ public class Calculator
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees:[syntaxTree]);
 
         using (var ms = new MemoryStream())
         {
-            var result = target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null);
+            var result = target.Compile(ms, null);
             result.Success.ShouldBe(true);
             ms.Length.ShouldBeGreaterThan(100, "No value was written to the MemoryStream by the compiler");
         }
@@ -156,17 +155,16 @@ public class Calculator
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
-        rollbackProcessMock.Setup(x => x.Start(It.IsAny<Compilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
-                        .Returns((Compilation compilation, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) =>
-                        new CSharpRollbackProcessResult(compilation, null));
+        rollbackProcessMock.Setup(x => x.Start(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
+                        .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) => null);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions());
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions(), [syntaxTree]);
 
         using (var ms = new MemoryStream())
         {
-            Should.Throw<CompilationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null));
+            Should.Throw<CompilationException>(() => target.Compile(ms, null));
         }
-        rollbackProcessMock.Verify(x => x.Start(It.IsAny<Compilation>(), It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
+        rollbackProcessMock.Verify(x => x.Start(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
             Times.AtLeast(2));
     }
 
@@ -204,10 +202,10 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees:[syntaxTree]);
 
         using var ms = new MemoryStream();
-        target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null);
+        target.Compile(ms, null);
 
         ms.Length.ShouldBeGreaterThan(100, "No value was written to the MemoryStream by the compiler");
     }
@@ -247,10 +245,10 @@ public class Calculator
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees:[syntaxTree]);
 
         using var ms = new MemoryStream();
-        var result = target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null);
+        var result = target.Compile(ms, null);
         result.Success.ShouldBe(true);
 
         var key = Assembly.Load(ms.ToArray()).GetName().GetPublicKey();
@@ -273,7 +271,7 @@ public class Calculator
     }
 }
 }");
-        var input = new MutationTestInput()
+        var input = new MutationTestInput
         {
             SourceProjectInfo = new SourceProjectInfo
             {
@@ -294,10 +292,10 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees: [syntaxTree]);
 
         using var ms = new MemoryStream();
-        var result = target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null);
+        var result = target.Compile(ms, null);
         result.Success.ShouldBe(true);
 
         var key = Assembly.Load(ms.ToArray()).GetName().GetPublicKey();
@@ -341,10 +339,10 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees: [syntaxTree]);
 
         using var ms = new MemoryStream();
-        Should.Throw<CompilationException>(() => target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null));
+        Should.Throw<CompilationException>(() => target.Compile(ms, null));
     }
 
     [TestMethod]
@@ -381,11 +379,11 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees:[syntaxTree]);
 
         using (var ms = new MemoryStream())
         {
-            var result = target.Compile(new Collection<SyntaxTree>() { syntaxTree }, ms, null);
+            var result = target.Compile(ms, null);
             result.Success.ShouldBe(true);
 
             Assembly.Load(ms.ToArray()).GetName().Version.ToString().ShouldBe("0.0.0.0");
@@ -517,7 +515,7 @@ public class Calculator
 
             TestRunner = new Mock<ITestRunner>(MockBehavior.Default).Object
         };
-        var folder = new FolderComposite();
+         var folder = new FolderComposite();
         var injector = input.SourceProjectInfo.CodeInjector;
         folder.Add(inputFile);
         foreach (var (name, code) in injector.MutantHelpers)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -155,7 +155,7 @@ public class Calculator
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
-        rollbackProcessMock.Setup(x => x.Start(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
+        rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
                         .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) => null);
 
         var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions(), [syntaxTree]);
@@ -164,7 +164,7 @@ public class Calculator
         {
             Should.Throw<CompilationException>(() => target.Compile(ms, null));
         }
-        rollbackProcessMock.Verify(x => x.Start(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
+        rollbackProcessMock.Verify(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
             Times.AtLeast(2));
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -27,7 +27,7 @@ internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationCont
 {
     private CSharpCompilation _compilation = compilation;
 
-    public IEnumerable<SyntaxTree> SyntaxTrees => compilation.SyntaxTrees;
+    public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
 
     public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
 
@@ -36,6 +36,7 @@ internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationCont
     public bool RestoreOriginal(SyntaxTree original) => false;
 }
 
+[TestClass]
 public class CSharpRollbackProcessTests : TestBase
 {
     private readonly SyntaxAnnotation _ifEngineMarker = new("Injector", "IfInstrumentationEngine");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 using Stryker.Abstractions;
@@ -22,7 +23,19 @@ using Stryker.Core.ProjectComponents.SourceProjects;
 
 namespace Stryker.Core.UnitTest.Compiling;
 
-[TestClass]
+internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationContent
+{
+    private CSharpCompilation _compilation = compilation;
+
+    public IEnumerable<SyntaxTree> SyntaxTrees => compilation.SyntaxTrees;
+
+    public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
+
+    public EmitResult Emit(Stream stream) => _compilation.Emit(stream);
+
+    public bool RestoreOriginal(SyntaxTree original) => false;
+}
+
 public class CSharpRollbackProcessTests : TestBase
 {
     private readonly SyntaxAnnotation _ifEngineMarker = new("Injector", "IfInstrumentationEngine");
@@ -79,10 +92,10 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
+        target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-
-        var rolledBackResult = fixedCompilation.Compilation.Emit(ms);
+        var rolledBackResult = compilerWrapper.Emit(ms);
 
         rolledBackResult.Success.ShouldBeTrue();
     }
@@ -156,11 +169,11 @@ public class CSharpRollbackProcessTests : TestBase
 
         var rollbackProcess = new CSharpRollbackProcess();
 
-        var target = new CsharpCompilingProcess(input, rollbackProcess, options);
+        var target = new CsharpCompilingProcess(input, rollbackProcess, options, syntaxTrees: helpers);
 
         using var ms = new MemoryStream();
-        var result = target.Compile(helpers, ms, null);
-        result.RollbackedIds.Count().ShouldBe(2); // should actually be 1 but thanks to issue #1745 rollback doesn't work
+        var result = target.Compile(ms, null);
+        result.RolledbackIds.Count().ShouldBe(2); // should actually be 1 but thanks to issue #1745 rollback doesn't work
     }
 
     [TestMethod]
@@ -242,11 +255,11 @@ public class CSharpRollbackProcessTests : TestBase
 
         var rollbackProcess = new CSharpRollbackProcess();
 
-        var target = new CsharpCompilingProcess(input, rollbackProcess, options);
+        var target = new CsharpCompilingProcess(input, rollbackProcess, options, helpers);
 
         using var ms = new MemoryStream();
 
-        Action test = () => target.Compile(helpers, ms, null);
+        Action test = () => target.Compile(ms, null);
         test.ShouldThrow<CompilationException>();
     }
 
@@ -318,12 +331,14 @@ public class CSharpRollbackProcessTests : TestBase
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+
+        var rollbackedResult = compilerWrapper.Emit(ms);
 
         rollbackedResult.Success.ShouldBeTrue();
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 6, 7 });
+        ids.ShouldBe(new Collection<int> { 6, 7 });
     }
 
     [TestMethod]
@@ -413,14 +428,15 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
-        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var rollbackedResult = compilerWrapper.Emit(ms);
 
         rollbackedResult.Success.ShouldBeTrue();
         // validate that only mutation 8 and 7 were rollbacked
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+        ids.ShouldBe(new Collection<int> { 8, 7 });
     }
 
     [TestMethod]
@@ -480,14 +496,15 @@ public class CSharpRollbackProcessTests : TestBase
 
         compileResult.Success.ShouldBeFalse();
         compileResult.Diagnostics.ShouldHaveSingleItem();
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
-        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var rollbackedResult = compilerWrapper.Emit(ms);
 
         rollbackedResult.Success.ShouldBeTrue();
         // validate that only the block mutation was rolled back
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 1 });
+        ids.ShouldBe(new Collection<int> { 1 });
     }
 
     [TestMethod]
@@ -579,19 +596,20 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
-        var rollbackedResult = fixedCompilation.Compilation.Emit(ms);
+        var result = compilerWrapper.Emit(ms);
 
-        rollbackedResult.Success.ShouldBeFalse();
-        rollbackedResult.Diagnostics.ShouldHaveSingleItem();
-        fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackedResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        result.Success.ShouldBeFalse();
+        result.Diagnostics.ShouldHaveSingleItem();
+        ids = target.Start(compilerWrapper, result.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
-        rollbackedResult = fixedCompilation.Compilation.Emit(ms);
-        rollbackedResult.Success.ShouldBeTrue();
+        result = compilerWrapper.Emit(ms);
+        result.Success.ShouldBeTrue();
         // validate that all mutations are rolled back
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7, 6 });
+        ids.ShouldBe(new Collection<int> { 8, 7, 6 });
     }
 
     [TestMethod]
@@ -686,18 +704,19 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-        var rollbackResult = fixedCompilation.Compilation.Emit(ms);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var rollbackResult = compilerWrapper.Emit(ms);
         rollbackResult.Success.ShouldBeFalse();
         // rollback a single assignment erasing mutation
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> {8});
+        ids.ShouldBe(new Collection<int> {8});
 
-        fixedCompilation = target.Start(fixedCompilation.Compilation, rollbackResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-        rollbackResult = fixedCompilation.Compilation.Emit(ms);
+        ids = target.Start(compilerWrapper, rollbackResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        rollbackResult = compilerWrapper.Emit(ms);
         rollbackResult.Success.ShouldBeTrue();
         // validate that mutations 8 and 7 were rolled back
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+        ids.ShouldBe(new Collection<int> { 8, 7 });
     }
 
     [TestMethod]
@@ -792,13 +811,14 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-        var rollbackResult = fixedCompilation.Compilation.Emit(ms);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var rollbackResult = compilerWrapper.Emit(ms);
 
         rollbackResult.Success.ShouldBeTrue();
         // validate that mutations 8 and 7 were rolled back
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+        ids.ShouldBe(new Collection<int> { 8, 7 });
     }
 
     [TestMethod]
@@ -893,13 +913,14 @@ public class CSharpRollbackProcessTests : TestBase
 
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
 
-        var fixedCompilation = target.Start(compiler, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-        var rollbackResult = fixedCompilation.Compilation.Emit(ms);
+        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var rollbackResult = compilerWrapper.Emit(ms);
 
         rollbackResult.Success.ShouldBeTrue();
         // validate that mutations 8 and 7 were rolled back
-        fixedCompilation.RollbackedIds.ShouldBe(new Collection<int> { 8, 7 });
+        ids.ShouldBe(new Collection<int> { 8, 7 });
     }
 
     [TestMethod]
@@ -951,13 +972,14 @@ public class CSharpRollbackProcessTests : TestBase
             });
 
         var target = new CSharpRollbackProcess();
+        var compilerWrapper = new CompilerWrapper(compiler);
 
         using var ms = new MemoryStream();
-        var fixedCompilation = target.Start(compiler, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
-        fixedCompilation.Compilation.Emit(ms).Success.ShouldBeTrue();
+        var ids = target.Start(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        compilerWrapper.Emit(ms).Success.ShouldBeTrue();
 
         // validate that only one of the compile errors marked the mutation as rolled back.
-        fixedCompilation.RollbackedIds.ShouldBe([1]);
+        ids.ShouldBe([1]);
     }
 
     [TestMethod]
@@ -1012,10 +1034,12 @@ public class CSharpRollbackProcessTests : TestBase
         var target = new CSharpRollbackProcess();
 
         using var ms = new MemoryStream();
+        var compilerWrapper = new CompilerWrapper(compiler);
+
         // first compilation will roll back the mutation
-        var fixedCompilation = target.Start(compiler, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var fixedCompilation = target.Start(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         // next attempt cannot roll back anything, so it assumes this is not fixable
-        Should.Throw<CompilationException>(() => target.Start(fixedCompilation.Compilation, fixedCompilation.Compilation.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false));
+        Should.Throw<CompilationException>(() => target.Start(compilerWrapper, compilerWrapper.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false));
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -32,8 +32,6 @@ internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationCont
     public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
 
     public EmitResult Emit(Stream stream) => _compilation.Emit(stream);
-
-    public bool RestoreOriginal(SyntaxTree original) => false;
 }
 
 [TestClass]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -92,7 +92,7 @@ public class CSharpRollbackProcessTests : TestBase
         using var ms = new MemoryStream();
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
-        target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         var rolledBackResult = compilerWrapper.Emit(ms);
 
@@ -332,7 +332,7 @@ public class CSharpRollbackProcessTests : TestBase
 
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         var rollbackedResult = compilerWrapper.Emit(ms);
 
@@ -429,7 +429,7 @@ public class CSharpRollbackProcessTests : TestBase
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         var rollbackedResult = compilerWrapper.Emit(ms);
 
@@ -497,7 +497,7 @@ public class CSharpRollbackProcessTests : TestBase
         compileResult.Diagnostics.ShouldHaveSingleItem();
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         var rollbackedResult = compilerWrapper.Emit(ms);
 
@@ -597,13 +597,13 @@ public class CSharpRollbackProcessTests : TestBase
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         var result = compilerWrapper.Emit(ms);
 
         result.Success.ShouldBeFalse();
         result.Diagnostics.ShouldHaveSingleItem();
-        ids = target.Start(compilerWrapper, result.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        ids = target.RollbackMutationsInError(compilerWrapper, result.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         result = compilerWrapper.Emit(ms);
         result.Success.ShouldBeTrue();
@@ -705,13 +705,13 @@ public class CSharpRollbackProcessTests : TestBase
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
         var rollbackResult = compilerWrapper.Emit(ms);
         rollbackResult.Success.ShouldBeFalse();
         // rollback a single assignment erasing mutation
         ids.ShouldBe(new Collection<int> {8});
 
-        ids = target.Start(compilerWrapper, rollbackResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        ids = target.RollbackMutationsInError(compilerWrapper, rollbackResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
         rollbackResult = compilerWrapper.Emit(ms);
         rollbackResult.Success.ShouldBeTrue();
         // validate that mutations 8 and 7 were rolled back
@@ -812,7 +812,7 @@ public class CSharpRollbackProcessTests : TestBase
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
         var rollbackResult = compilerWrapper.Emit(ms);
 
         rollbackResult.Success.ShouldBeTrue();
@@ -914,7 +914,7 @@ public class CSharpRollbackProcessTests : TestBase
         var compileResult = compiler.Emit(ms);
         var compilerWrapper = new CompilerWrapper(compiler);
 
-        var ids = target.Start(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
         var rollbackResult = compilerWrapper.Emit(ms);
 
         rollbackResult.Success.ShouldBeTrue();
@@ -974,7 +974,7 @@ public class CSharpRollbackProcessTests : TestBase
         var compilerWrapper = new CompilerWrapper(compiler);
 
         using var ms = new MemoryStream();
-        var ids = target.Start(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var ids = target.RollbackMutationsInError(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
         compilerWrapper.Emit(ms).Success.ShouldBeTrue();
 
         // validate that only one of the compile errors marked the mutation as rolled back.
@@ -1036,9 +1036,9 @@ public class CSharpRollbackProcessTests : TestBase
         var compilerWrapper = new CompilerWrapper(compiler);
 
         // first compilation will roll back the mutation
-        var fixedCompilation = target.Start(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var fixedCompilation = target.RollbackMutationsInError(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
 
         // next attempt cannot roll back anything, so it assumes this is not fixable
-        Should.Throw<CompilationException>(() => target.Start(compilerWrapper, compilerWrapper.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false));
+        Should.Throw<CompilationException>(() => target.RollbackMutationsInError(compilerWrapper, compilerWrapper.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false));
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialisationProcessTests.cs
@@ -15,6 +15,7 @@ using Stryker.Abstractions.ProjectComponents;
 using Stryker.Abstractions.Testing;
 using Stryker.Configuration.Options;
 using Stryker.Core.Initialisation;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -32,9 +33,9 @@ public class InitialisationProcessTests : TestBase
     {
         var inputFileResolverMock = new Mock<IInputFileResolver>(MockBehavior.Strict);
 
-        var projectContents = new CsharpFolderComposite();
+        var projectContents = new FolderComposite();
         projectContents.Add(new CsharpFileLeaf());
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.AddRange(new Mono.Collections.Generic.Collection<IProjectComponent>
         {
             new CsharpFileLeaf()
@@ -70,7 +71,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
         inputFileResolverMock.Setup(x => x.ResolveSourceProjectInfos(It.IsAny<StrykerOptions>())).Returns(
@@ -110,7 +111,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
 
@@ -158,7 +159,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
 
@@ -215,7 +216,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
         inputFileResolverMock.Setup(x => x.ResolveSourceProjectInfos(It.IsAny<StrykerOptions>())).Returns(
@@ -259,7 +260,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
 
@@ -305,7 +306,7 @@ public class InitialisationProcessTests : TestBase
         var initialBuildProcessMock = new Mock<IInitialBuildProcess>(MockBehavior.Strict);
         var initialTestProcessMock = new Mock<IInitialTestProcess>(MockBehavior.Strict);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf());
 
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -19,7 +19,6 @@ using Stryker.Configuration.Options;
 using Stryker.Core.Initialisation;
 using Stryker.Utilities.Buildalyzer;
 using Stryker.Core.ProjectComponents;
-using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Solutions;
 using Stryker.Utilities;
@@ -461,7 +460,7 @@ using System.Reflection;
         var result = target.ResolveSourceProjectInfos(_options).First();
 
         result.ProjectContents.GetAllFiles().Count().ShouldBe(3);
-        var mutatedFile = ((ProjectComponent<SyntaxTree>)result.ProjectContents).CompilationSyntaxTrees.First(s => s != null && s.FilePath.Contains("AssemblyInfo.cs"));
+        var mutatedFile = ((ProjectComponent)result.ProjectContents).CompilationSyntaxTrees.First(s => s != null && s.FilePath.Contains("AssemblyInfo.cs"));
 
         var node = ((CompilationUnitSyntax)mutatedFile.GetRoot()).AttributeLists
             .SelectMany(al => al.Attributes).FirstOrDefault(n => n.Name.Kind() == SyntaxKind.QualifiedName
@@ -517,7 +516,7 @@ using System.Reflection;
 
         var result = target.ResolveSourceProjectInfos(_options).First();
 
-        ((ProjectComponent<SyntaxTree>)result.ProjectContents).CompilationSyntaxTrees.FirstOrDefault(s => s != null && s.FilePath.Contains("AssemblyInfo.cs")).
+        ((ProjectComponent)result.ProjectContents).CompilationSyntaxTrees.FirstOrDefault(s => s != null && s.FilePath.Contains("AssemblyInfo.cs")).
              ShouldBeSemantically(CSharpSyntaxTree.ParseText(textContents));
     }
 
@@ -902,11 +901,11 @@ using System.Reflection;
 
         var result = target.ResolveSourceProjectInfos(_options).First();
 
-        ((CsharpFolderComposite)result.ProjectContents).Children.Count().ShouldBe(1);
+        ((FolderComposite)result.ProjectContents).Children.Count().ShouldBe(1);
 
-        var sub = (CsharpFolderComposite)((CsharpFolderComposite)result.ProjectContents).Children.First();
+        var sub = (FolderComposite)((FolderComposite)result.ProjectContents).Children.First();
         // here sub is the root folder of the project
-        sub = (CsharpFolderComposite)sub.Children.First();
+        sub = (FolderComposite)sub.Children.First();
         sub.Children.Count().ShouldBe(2);
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -4,16 +4,15 @@ using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
-using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
 using Stryker.Abstractions.Reporting;
 using Stryker.Configuration.Options;
 using Stryker.Core.Initialisation;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.TestRunner.Results;
@@ -72,7 +71,7 @@ namespace ExtraProject.XUnit
             projectReferences: Array.Empty<string>(),
             sourceFiles: Array.Empty<string>()).Object;
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
             FullPath = "c:\\TestClass.cs",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectOrchestratorTests.cs
@@ -110,7 +110,7 @@ public class ProjectOrchestratorTests : BuildAnalyzerTestsBase
         var result = (await target.MutateProjectsAsync(options, _reporterMock.Object, mockRunner.Object)).ToList();
 
         // assert we see the content file
-        var scan = ((ProjectComponent<SyntaxTree>)result.First().Input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees;
+        var scan = ((ProjectComponent)result.First().Input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees;
         scan.Count(f => f?.FilePath == contentFile).ShouldBe(1);
     }
 
@@ -302,7 +302,7 @@ public class ProjectOrchestratorTests : BuildAnalyzerTestsBase
 
         // act
         var result = async() => (await target.MutateProjectsAsync(options, _reporterMock.Object, mockRunner.Object)).ToList();
-        
+
         // assert
         result.ShouldThrow<InputException>();
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/CSharpMutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/CSharpMutationTestProcessTests.cs
@@ -7,10 +7,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Stryker.Abstractions;
 using Stryker.Configuration.Options;
 using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -35,7 +35,7 @@ public class CSharpMutationTestProcessTests : TestBase
     [TestMethod]
     public void MutateShouldWriteToDisk_IfCompilationIsSuccessful()
     {
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
             SourceCode = SourceFile,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -17,6 +17,7 @@ using Stryker.Core.CoverageAnalysis;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -30,7 +31,7 @@ public class MutationTestProcessTests : TestBase
     private string FilesystemRoot { get; }
     private string SourceFile { get; }
     private MockFileSystem FileSystemMock { get; } = new MockFileSystem();
-    private CsharpFolderComposite Folder { get; } = new CsharpFolderComposite();
+    private FolderComposite Folder { get; } = new FolderComposite();
     private FullRunScenario TestScenario { get; } = new FullRunScenario();
 
     private MutationTestInput Input { get; }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/CollectionExpressionMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/CollectionExpressionMutatorTests.cs
@@ -43,7 +43,7 @@ public class CollectionExpressionMutatorTests : TestBase
         var expressionSyntax = SyntaxFactory.ParseExpression(expression) as CollectionExpressionSyntax;
         var target = new CollectionExpressionMutator();
         var result = target.ApplyMutations(expressionSyntax, null);
-        
+
         var mutation = result.ShouldHaveSingleItem();
         mutation.DisplayName.ShouldBe("Collection expression mutation");
         var replacement = mutation.ReplacementNode.ShouldBeOfType<CollectionExpressionSyntax>();
@@ -151,7 +151,7 @@ public class CollectionExpressionMutatorTests : TestBase
 
                                  class ClassName {
                                      public IEnumerable<int> M() => Iter([ 1 ]);
-                                 
+
                                      public IEnumerable<T> Iter<T>(IList<T> list) {
                                          foreach (var l in list) {
                                              yield return l;
@@ -168,25 +168,25 @@ public class CollectionExpressionMutatorTests : TestBase
 
                                  class ClassName {
                                      public IEnumerable<int> M() => Iter([ 1 ]);
-                                 
+
                                      public IEnumerable<T> Iter<T>(IList<T> list) {
                                          foreach (var l in list) {
                                              yield return l;
                                          }
                                      }
-                                 
+
                                      public IEnumerable<T> Iter<T>(IReadOnlyCollection<T> list) {
                                          foreach (var l in list) {
                                              yield return l;
                                          }
                                      }
-                                 
+
                                      public IEnumerable<T> Iter<T>(T[] list) {
                                          foreach (var l in list) {
                                              yield return l;
                                          }
                                      }
-                                 
+
                                      public IEnumerable<T> Iter<T>(ReadOnlyMemory<T> list) {
                                          for (var i = 0; i < list.Length; i++) {
                                              yield return list.Span[i];
@@ -317,7 +317,7 @@ public class CollectionExpressionMutatorTests : TestBase
                                      {
                                          return [1, 2, 3]; // ok: span refers to assembly data section
                                      }
-                                     
+
                                      static ReadOnlySpan<T> AsSpan3<T>(T x, T y, T z)
                                      {
                                          return (T[])[x, y, z]; // ok: span refers to T[] on heap
@@ -340,7 +340,7 @@ public class CollectionExpressionMutatorTests : TestBase
                                      public static void Method() {
                                         var a = AsArray([1, 2, 3]);          // AsArray<int>(int[])
                                         var b = AsListOfArray([[4, 5], []]); // AsListOfArray<int>(List<int[]>)
-                                 
+
                                         static T[] AsArray<T>(T[] arg) => arg;
                                         static List<T[]> AsListOfArray<T>(List<T[]> arg) => arg;
                                      }
@@ -360,19 +360,19 @@ public class CollectionExpressionMutatorTests : TestBase
                                  class ClassName {
                                      static void Generic<T>(Span<T> value) { }
                                      static void Generic<T>(T[] value) { }
-                                     
+
                                      static void SpanDerived(Span<string> value) { }
                                      static void SpanDerived(object[] value) { }
-                                     
+
                                      static void ArrayDerived(Span<object> value) { }
                                      static void ArrayDerived(string[] value) { }
-                                     
+
                                      // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#overload-resolution
                                      public static void Method() {
                                          // Array initializers
                                          Generic(new[] { "" });      // string[]
                                          ArrayDerived(new[] { "" }); // string[]
-                                         
+
                                          // Collection expressions
                                          Generic([""]);              // Span<string>
                                          SpanDerived([""]);          // Span<string>
@@ -393,13 +393,13 @@ public class CollectionExpressionMutatorTests : TestBase
                                  class ClassName {
                                      static void Generic<T>(Span<T> value) { }
                                      static void Generic<T>(T[] value) { }
-                                     
+
                                      static void SpanDerived(Span<string> value) { }
                                      static void SpanDerived(object[] value) { }
-                                     
+
                                      static void ArrayDerived(Span<object> value) { }
                                      static void ArrayDerived(string[] value) { }
-                                     
+
                                      // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#syntax-ambiguities
                                      public static void Method() {
                                          Range range1 = default;
@@ -423,13 +423,13 @@ public class CollectionExpressionMutatorTests : TestBase
                                  class ClassName {
                                      static void Generic<T>(Span<T> value) { }
                                      static void Generic<T>(T[] value) { }
-                                     
+
                                      static void SpanDerived(Span<string> value) { }
                                      static void SpanDerived(object[] value) { }
-                                     
+
                                      static void ArrayDerived(Span<object> value) { }
                                      static void ArrayDerived(string[] value) { }
-                                     
+
                                      // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#resolved-questions
                                      public static void Method() {
                                          void DoWork(IEnumerable<long> values) { }
@@ -493,19 +493,18 @@ public class CollectionExpressionMutatorTests : TestBase
             }
         };
 
-        var target = new CsharpCompilingProcess(input);
+        var target = new CsharpCompilingProcess(input, syntaxTrees:[
+            syntaxTree,
+            ..injector.MutantHelpers.Select(a => CSharpSyntaxTree.ParseText(a.Value, path: a.Key,
+                encoding: Encoding.UTF32))
+        ]);
 
         try
         {
             var result =
-                target.Compile([
-                                   syntaxTree,
-                                   ..injector.MutantHelpers.Select(a => CSharpSyntaxTree.ParseText(a.Value, path: a.Key,
-                                                                    encoding: Encoding.UTF32))
-                               ],
-                               Stream.Null, Stream.Null);
+                target.Compile(Stream.Null, Stream.Null);
             result.Success.ShouldBe(true);
-            result.RollbackedIds.ShouldBeEmpty();
+            result.RolledbackIds.ShouldBeEmpty();
         }
         catch (CompilationException)
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/CsharpProjectComponentTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/CsharpProjectComponentTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Stryker.Configuration.Options;
 using Stryker.Core.Mutants;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 
 namespace Stryker.Core.UnitTest.ProjectComponents;
@@ -109,7 +110,7 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScoreNaN_NoMutations()
     {
-        var target = new CsharpFolderComposite();
+        var target = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { } });
 
         var result = target.GetMutationScore();
@@ -119,7 +120,7 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScore_OneMutation()
     {
-        var target = new CsharpFolderComposite();
+        var target = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Killed } } });
 
         var result = target.GetMutationScore();
@@ -129,7 +130,7 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScore_TwoFolders()
     {
-        var target = new CsharpFolderComposite();
+        var target = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Killed } } });
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Survived } } });
 
@@ -140,8 +141,8 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScore_Recursive()
     {
-        var target = new CsharpFolderComposite();
-        var subFolder = new CsharpFolderComposite();
+        var target = new FolderComposite();
+        var subFolder = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Killed } } });
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Survived } } });
         target.Add(subFolder);
@@ -154,8 +155,8 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScore_Recursive2()
     {
-        var target = new CsharpFolderComposite();
-        var subFolder = new CsharpFolderComposite();
+        var target = new FolderComposite();
+        var subFolder = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Survived } } });
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.Survived } } });
         target.Add(subFolder);
@@ -176,7 +177,7 @@ public class CsharpProjectComponentTests : TestBase
     [DataRow(MutantStatus.Pending, double.NaN)]
     public void ReportComponent_ShouldCalculateMutationScore_OnlyKilledIsSuccessful(MutantStatus status, double expectedScore)
     {
-        var target = new CsharpFolderComposite();
+        var target = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = status } } });
 
         var result = target.GetMutationScore();
@@ -186,7 +187,7 @@ public class CsharpProjectComponentTests : TestBase
     [TestMethod]
     public void ReportComponent_ShouldCalculateMutationScore_BuildErrorIsNull()
     {
-        var target = new CsharpFolderComposite();
+        var target = new FolderComposite();
         target.Add(new CsharpFileLeaf() { Mutants = new Collection<Mutant>() { new Mutant() { ResultStatus = MutantStatus.CompileError } } });
 
         var result = target.GetMutationScore();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextReporterTests.cs
@@ -9,6 +9,7 @@ using Spectre.Console.Testing;
 using Stryker.Abstractions;
 using Stryker.Configuration.Options;
 using Stryker.Core.Mutants;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters;
@@ -25,9 +26,9 @@ public class ClearTextReporterTests : TestBase
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(new StrykerOptions(), console);
 
-        var rootFolder = new CsharpFolderComposite();
+        var rootFolder = new FolderComposite();
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "FolderA",
             FullPath = "C://Project/FolderA",
@@ -73,9 +74,9 @@ All mutants have been tested, and your mutation score has been calculated
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(new StrykerOptions(), console);
 
-        var rootFolder = new CsharpFolderComposite();
+        var rootFolder = new FolderComposite();
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "FolderA",
             FullPath = "C://Project/FolderA",
@@ -126,9 +127,9 @@ All mutants have been tested, and your mutation score has been calculated
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(new StrykerOptions(), console);
 
-        var rootFolder = new CsharpFolderComposite();
+        var rootFolder = new FolderComposite();
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "FolderA",
             FullPath = "C://Project/FolderA",
@@ -180,7 +181,7 @@ All mutants have been tested, and your mutation score has been calculated
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(options, console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -222,7 +223,7 @@ All mutants have been tested, and your mutation score has been calculated
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(options, console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -263,7 +264,7 @@ All mutants have been tested, and your mutation score has been calculated
         var console = new TestConsole().EmitAnsiSequences().Width(160);
         var target = new ClearTextReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextTreeReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ClearTextTreeReporterTests.cs
@@ -9,6 +9,7 @@ using Spectre.Console.Testing;
 using Stryker.Abstractions;
 using Stryker.Configuration.Options;
 using Stryker.Core.Mutants;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters;
@@ -34,7 +35,7 @@ public class ClearTextTreeReporterTests : TestBase
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             FullPath = "C://ProjectFolder",
         };
@@ -47,7 +48,7 @@ public class ClearTextTreeReporterTests : TestBase
                 new Mutant() { ResultStatus = MutantStatus.Killed, Mutation = mutation }
             }
         });
-        var folder2 = new CsharpFolderComposite()
+        var folder2 = new FolderComposite()
         {
             RelativePath = "Subdir",
             FullPath = "C://ProjectFolder/SubDir",
@@ -112,7 +113,7 @@ All files [4/5 ({4.0 / 5.0:P2})]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -152,7 +153,7 @@ All files [0/0 (N/A)]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -198,7 +199,7 @@ All files [1/1 ({1:P2})]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -245,7 +246,7 @@ All files [0/1 ({0:P2})]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(options, console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -287,7 +288,7 @@ All files [0/1 ({0:P2})]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(options, console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",
@@ -328,7 +329,7 @@ All files [0/1 ({0:P2})]
         var console = new TestConsole().EmitAnsiSequences();
         var target = new ClearTextTreeReporter(new StrykerOptions(), console);
 
-        var folder = new CsharpFolderComposite()
+        var folder = new FolderComposite()
         {
             RelativePath = "RootFolder",
             FullPath = "C://RootFolder",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -13,9 +13,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
-using Stryker.Abstractions;
-using Stryker.Abstractions.Testing;
 using Stryker.Configuration.Options;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.Reporters.Json;
@@ -78,7 +77,7 @@ namespace ExtraProject.XUnit
     public void JsonReportFileComponent_ShouldHaveLanguageSet()
     {
         var folderComponent = ReportTestHelper.CreateProjectWith();
-        var fileComponent = (CsharpFileLeaf)(folderComponent as CsharpFolderComposite).GetAllFiles().First();
+        var fileComponent = (CsharpFileLeaf)(folderComponent as FolderComposite).GetAllFiles().First();
 
         new SourceFile(fileComponent).Language.ShouldBe("cs");
     }
@@ -87,7 +86,7 @@ namespace ExtraProject.XUnit
     public void JsonReportFileComponent_ShouldContainOriginalSource()
     {
         var folderComponent = ReportTestHelper.CreateProjectWith();
-        var fileComponent = (CsharpFileLeaf)(folderComponent as CsharpFolderComposite).GetAllFiles().First();
+        var fileComponent = (CsharpFileLeaf)(folderComponent as FolderComposite).GetAllFiles().First();
 
         new SourceFile(fileComponent).Source.ShouldBe(fileComponent.SourceCode);
     }
@@ -96,7 +95,7 @@ namespace ExtraProject.XUnit
     public void JsonReportFileComponents_ShouldContainMutants()
     {
         var folderComponent = ReportTestHelper.CreateProjectWith();
-        foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
+        foreach (var file in (folderComponent as FolderComposite).GetAllFiles())
         {
             var jsonReportComponent = new SourceFile((CsharpFileLeaf)file);
             foreach (var mutant in file.Mutants)
@@ -111,7 +110,7 @@ namespace ExtraProject.XUnit
     {
         var loggerMock = Mock.Of<ILogger>();
         var folderComponent = ReportTestHelper.CreateProjectWith(duplicateMutant: true);
-        foreach (var file in (folderComponent as CsharpFolderComposite).GetAllFiles())
+        foreach (var file in (folderComponent as FolderComposite).GetAllFiles())
         {
             var jsonReportComponent = new SourceFile((CsharpFileLeaf)file, loggerMock);
             foreach (var mutant in file.Mutants)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/MarkdownSummaryReporterTests.cs
@@ -3,9 +3,8 @@ using System.IO.Abstractions.TestingHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
 using Spectre.Console.Testing;
-using Stryker.Abstractions;
 using Stryker.Configuration.Options;
-using Stryker.Core.ProjectComponents.Csharp;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.Reporters;
 
 namespace Stryker.Core.UnitTest.Reporters;
@@ -136,7 +135,7 @@ public class MarkdownSummaryReporterTests : TestBase
         var console = new TestConsole().EmitAnsiSequences().Width(160);
 
         var reportGenerator = new MarkdownSummaryReporter(options, mockFileSystem, console);
-        var emptyReport = new CsharpFolderComposite() { FullPath = "/home/user/src/project/", RelativePath = "" };
+        var emptyReport = new FolderComposite() { FullPath = "/home/user/src/project/", RelativePath = "" };
 
         // Act
         reportGenerator.OnAllMutantsTested(emptyReport, null);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReportTestHelper.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Stryker.Abstractions;
 using Stryker.Abstractions.ProjectComponents;
 using Stryker.Core.Mutants;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.TestRunner.Tests;
 
@@ -25,11 +26,11 @@ public static class ReportTestHelper
             Type = Mutator.Arithmetic
         };
 
-        var folder = new CsharpFolderComposite { FullPath = $"{root}home/user/src/project/", RelativePath = "" };
+        var folder = new FolderComposite { FullPath = $"{root}home/user/src/project/", RelativePath = "" };
         var mutantCount = 0;
         for (var i = 1; i <= folders; i++)
         {
-            var addedFolder = new CsharpFolderComposite
+            var addedFolder = new FolderComposite
             {
                 RelativePath = $"{i}",
                 FullPath = $"{root}home/user/src/project/{i}",

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/StatusReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/StatusReporterTests.cs
@@ -1,15 +1,12 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using Shouldly;
-using Stryker.Abstractions.ProjectComponents;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Stryker.Core.Reporters;
 using Stryker.Core.Mutants;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Abstractions;
+using Stryker.Core.ProjectComponents;
 
 namespace Stryker.Core.UnitTest.Reporters;
 
@@ -18,16 +15,12 @@ public class StatusReporterTests : TestBase
 {
     private Mock<ILogger<FilteredMutantsLogger>> _loggerMock = new Mock<ILogger<FilteredMutantsLogger>>();
 
-    public StatusReporterTests()
-    {
-    }
-
     [TestMethod]
     public void ShouldPrintNoMutations()
     {
         var target = new FilteredMutantsLogger(_loggerMock.Object);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf()
         {
             Mutants = new Collection<IMutant>()
@@ -46,7 +39,7 @@ public class StatusReporterTests : TestBase
     {
         var target = new FilteredMutantsLogger(_loggerMock.Object);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf()
         {
             Mutants = new Collection<IMutant>()
@@ -68,7 +61,7 @@ public class StatusReporterTests : TestBase
     {
         var target = new FilteredMutantsLogger(_loggerMock.Object);
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf()
         {
             Mutants = new Collection<IMutant>()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
@@ -36,7 +36,6 @@ public class StrykerRunnerTests : TestBase
         var reporterFactoryMock = new Mock<IReporterFactory>(MockBehavior.Strict);
         var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
-        var fileSystemMock = new MockFileSystem();
 
         var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf()
@@ -105,14 +104,13 @@ public class StrykerRunnerTests : TestBase
         var reporterFactoryMock = new Mock<IReporterFactory>(MockBehavior.Strict);
         var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
-        var fileSystemMock = new MockFileSystem();
 
         var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
             Mutants = new Collection<IMutant>() { new Mutant() { Id = 1, ResultStatus = MutantStatus.Ignored } }
         });
-        
+
         var mutationTestInput = new MutationTestInput()
         {
             SourceProjectInfo = new SourceProjectInfo()
@@ -161,7 +159,6 @@ public class StrykerRunnerTests : TestBase
         var reporterFactoryMock = new Mock<IReporterFactory>(MockBehavior.Strict);
         var reporterMock = new Mock<IReporter>(MockBehavior.Strict);
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
-        var fileSystemMock = new MockFileSystem();
 
         var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
@@ -169,7 +166,7 @@ public class StrykerRunnerTests : TestBase
             Mutants = new Collection<IMutant>() { new Mutant() { Id = 1, ResultStatus = MutantStatus.Ignored } }
         });
         var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
-        
+
         var mutationTestInput = new MutationTestInput()
         {
             SourceProjectInfo = new SourceProjectInfo()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/StrykerRunnerTests.cs
@@ -17,6 +17,7 @@ using Stryker.Core.Baseline.Providers;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -37,7 +38,7 @@ public class StrykerRunnerTests : TestBase
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
         var fileSystemMock = new MockFileSystem();
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf()
         {
             Mutants = new List<IMutant> { new Mutant { Id = 1 } }
@@ -106,7 +107,7 @@ public class StrykerRunnerTests : TestBase
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
         var fileSystemMock = new MockFileSystem();
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
             Mutants = new Collection<IMutant>() { new Mutant() { Id = 1, ResultStatus = MutantStatus.Ignored } }
@@ -162,7 +163,7 @@ public class StrykerRunnerTests : TestBase
         var inputsMock = new Mock<IStrykerInputs>(MockBehavior.Strict);
         var fileSystemMock = new MockFileSystem();
 
-        var folder = new CsharpFolderComposite();
+        var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
             Mutants = new Collection<IMutant>() { new Mutant() { Id = 1, ResultStatus = MutantStatus.Ignored } }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -37,10 +38,24 @@ public class BuildalyzerHelperTests : TestBase
     }
 
     [TestMethod]
+    public void ShouldHandleAdditionalFiles()
+    {
+        var setupProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+            properties: new(),
+            projectFilePath: "path");
+        setupProjectAnalyzerResult.Setup(x => x.AdditionalFiles).Returns(["path.AssemblyInfo.cs"]);
+        var projectAnalyzerResult = setupProjectAnalyzerResult.Object;
+
+        var result = projectAnalyzerResult.GetAdditionalTexts();
+
+        result.Where(x => x.Path == "path.AssemblyInfo.cs").ShouldHaveSingleItem();
+    }
+
+    [TestMethod]
     public void ShouldLogAnalyzerLoadGeneralFailure()
     {
         var projectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-            properties: new(),
+            properties: new Dictionary<string, string>(),
             projectFilePath: "path", analyzers: ["1", "2"]).Object;
 
         var logger = new Mock<ILogger>(MockBehavior.Loose);
@@ -52,7 +67,7 @@ public class BuildalyzerHelperTests : TestBase
     public void ShouldLogAnalyzerLoadFailureWhenNoAnalyzer()
     {
         var projectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-            properties: new(),
+            properties: new Dictionary<string, string>(),
             projectFilePath: "path", analyzers: [Assembly.GetExecutingAssembly().Location]).Object;
 
         var logger = new Mock<ILogger>(MockBehavior.Loose);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
@@ -40,15 +41,25 @@ public class BuildalyzerHelperTests : TestBase
     [TestMethod]
     public void ShouldHandleAdditionalFiles()
     {
+        var path = Path.Combine("TestResources","ExampleSourceFile.cs");
         var setupProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-            properties: new(),
+            properties: new Dictionary<string, string>(),
             projectFilePath: "path");
-        setupProjectAnalyzerResult.Setup(x => x.AdditionalFiles).Returns(["path.AssemblyInfo.cs"]);
+        setupProjectAnalyzerResult.Setup(x => x.AdditionalFiles).Returns([path]);
         var projectAnalyzerResult = setupProjectAnalyzerResult.Object;
 
         var result = projectAnalyzerResult.GetAdditionalTexts();
 
-        result.Where(x => x.Path == "path.AssemblyInfo.cs").ShouldHaveSingleItem();
+        // check we have a single additional text
+        result.Where(x => x.Path == path).ShouldHaveSingleItem();
+        var additionalText = result.Where(x => x.Path == path).Single();
+        var fileContent = File.ReadAllText(path);
+        // which content the provided text
+        additionalText.GetText().ToString().ShouldBe(fileContent);
+        var buffer = new char[10];
+        // and copy to works as expected
+        additionalText.GetText().CopyTo(10, buffer, 0, 10);
+        new string(buffer).ShouldBe(fileContent.Substring(10, 10));
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ToolHelpers/BuildalyzerHelperTests.cs
@@ -41,7 +41,7 @@ public class BuildalyzerHelperTests : TestBase
     [TestMethod]
     public void ShouldHandleAdditionalFiles()
     {
-        var path = Path.Combine("TestResources","ExampleSourceFile.cs");
+        var path = Path.GetFullPath(Path.Combine("TestResources","ExampleSourceFile.cs"));
         var setupProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
             properties: new Dictionary<string, string>(),
             projectFilePath: "path");
@@ -56,10 +56,6 @@ public class BuildalyzerHelperTests : TestBase
         var fileContent = File.ReadAllText(path);
         // which content the provided text
         additionalText.GetText().ToString().ShouldBe(fileContent);
-        var buffer = new char[10];
-        // and copy to works as expected
-        additionalText.GetText().CopyTo(10, buffer, 0, 10);
-        new string(buffer).ShouldBe(fileContent.Substring(10, 10));
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -25,8 +25,8 @@ public interface ICompilationContent
 
 public interface ICSharpRollbackProcess
 {
-    IEnumerable<int> Start(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
-        ICSharpRollbackProcess.Mode mode, bool devMode);
+    IEnumerable<int> RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
+        Mode mode, bool devMode);
 
     enum Mode
     {
@@ -44,7 +44,7 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
     private List<int> RollBackedIds { get; } = [];
     private ILogger Logger { get; } = ApplicationLogging.LoggerFactory.CreateLogger<CSharpRollbackProcess>();
 
-    public IEnumerable<int> Start(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics, ICSharpRollbackProcess.Mode mode, bool devMode)
+    public IEnumerable<int> RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics, ICSharpRollbackProcess.Mode mode, bool devMode)
     {
         // match the diagnostics with their syntax trees
         var syntaxTreeMapping =
@@ -125,8 +125,7 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
             return new MutantInfo();
         }
 
-        Logger.LogDebug("Found mutant {id} of type '{type}' controlled by '{engine}'.", info.Id, info.Type,
-            info.Engine);
+        Logger.LogDebug("Found mutant {id} of type '{type}' controlled by '{engine}'.", info.Id, info.Type, info.Engine);
 
         return info;
     }

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -20,8 +20,6 @@ public interface ICompilationContent
     IEnumerable<SyntaxTree> SyntaxTrees { get; }
 
     void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated);
-
-    bool RestoreOriginal(SyntaxTree original);
 }
 
 
@@ -29,8 +27,6 @@ public interface ICSharpRollbackProcess
 {
     IEnumerable<int> Start(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
         ICSharpRollbackProcess.Mode mode, bool devMode);
-
-    SyntaxTree CleanUpFile(SyntaxTree file);
 
     enum Mode
     {
@@ -254,19 +250,6 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
         }
 
         return suspiciousMutations;
-    }
-
-    // removes all mutation from a file
-    public SyntaxTree CleanUpFile(SyntaxTree file)
-    {
-        var rollbackRoot = file.GetRoot();
-        var scan = ScanAllMutationsIfsAndIds(rollbackRoot);
-        var suspiciousMutations = new Collection<SyntaxNode>();
-        foreach (var mutant in scan.Where(mutant => !suspiciousMutations.Contains(mutant.Node)))
-        {
-            suspiciousMutations.Add(mutant.Node);
-        }
-        return file.WithRootAndOptions(RollTheseMutationsBack(rollbackRoot, suspiciousMutations), file.Options);
     }
 
     private static string DisplayName(SyntaxNode initNode) =>

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -125,7 +125,7 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
             return new MutantInfo();
         }
 
-        Logger.LogDebug("Found mutant {id} of type '{type}' controlled by '{engine}'.", info.Id, info.Type, info.Engine);
+        Logger.LogDebug("Found mutant {Id} of type '{Type}' controlled by '{Engine}'.", info.Id, info.Type, info.Engine);
 
         return info;
     }

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -15,10 +15,20 @@ using Stryker.Utilities.Logging;
 
 namespace Stryker.Core.Compiling;
 
+public interface ICompilationContent
+{
+    IEnumerable<SyntaxTree> SyntaxTrees { get; }
+
+    void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated);
+
+    bool RestoreOriginal(SyntaxTree original);
+}
+
+
 public interface ICSharpRollbackProcess
 {
-    CSharpRollbackProcessResult Start(Compilation compiler, ImmutableArray<Diagnostic> diagnostics,
-        Mode mode, bool devMode);
+    IEnumerable<int> Start(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
+        ICSharpRollbackProcess.Mode mode, bool devMode);
 
     SyntaxTree CleanUpFile(SyntaxTree file);
 
@@ -38,12 +48,11 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
     private List<int> RollBackedIds { get; } = [];
     private ILogger Logger { get; } = ApplicationLogging.LoggerFactory.CreateLogger<CSharpRollbackProcess>();
 
-    public CSharpRollbackProcessResult Start(Compilation compiler, ImmutableArray<Diagnostic> diagnostics,
-        ICSharpRollbackProcess.Mode mode, bool devMode)
+    public IEnumerable<int> Start(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics, ICSharpRollbackProcess.Mode mode, bool devMode)
     {
         // match the diagnostics with their syntax trees
         var syntaxTreeMapping =
-            compiler.SyntaxTrees.ToDictionary<SyntaxTree, SyntaxTree, ICollection<Diagnostic>>(
+            wrapper.SyntaxTrees.ToDictionary<SyntaxTree, SyntaxTree, ICollection<Diagnostic>>(
                 syntaxTree => syntaxTree, _ => new Collection<Diagnostic>());
 
         foreach (var diagnostic in diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error))
@@ -80,13 +89,10 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
             Logger.LogTrace("RolledBack to {UpdatedSyntaxTree}", updatedSyntaxTree.ToString());
 
             // update the compiler object with the new syntax tree
-            compiler = compiler.ReplaceSyntaxTree(originalTree, updatedSyntaxTree);
+            wrapper.ReplaceSyntaxTree(originalTree, updatedSyntaxTree);
         }
 
-        // by returning the same compiler object (with different syntax trees) the next compilation will use Roslyn's incremental compilation
-        return new CSharpRollbackProcessResult(
-            compiler,
-            RollBackedIds);
+        return RollBackedIds;
     }
 
     // search is this node contains or is within a mutation

--- a/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcessResult.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CompilingProcessResult.cs
@@ -2,6 +2,4 @@ using System.Collections.Generic;
 
 namespace Stryker.Core.Compiling;
 
-public record CompilingProcessResult(
-    bool Success,
-    IEnumerable<int> RollbackedIds);
+public record CompilingProcessResult(bool Success, IEnumerable<int> RolledbackIds);

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -43,7 +43,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     private Compilation _compilation;
     private readonly IEnumerable<SyntaxTree> _originalSyntaxTrees;
     private bool _needToRunGenerators;
-    private bool _someGeneratorMayCrash;
 
     public CsharpCompilingProcess(MutationTestInput input,
         ICSharpRollbackProcess rollbackProcess = null,
@@ -124,29 +123,21 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     [ExcludeFromCodeCoverage]
     private void RunSourceGenerators()
     {
-        if (!_needToRunGenerators || _someGeneratorMayCrash)
+        if (!_needToRunGenerators)
         {
             return;
         }
 
-        try
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation.RemoveSyntaxTrees(_generatorDriver.GetRunResult().GeneratedTrees), out _compilation, out var diagnostics);
+        _needToRunGenerators = false;
+        var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
+        if (errors.Count == 0)
         {
-            _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out _compilation, out var diagnostics);
-            _needToRunGenerators = false;
-            var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
-            if (errors.Count == 0)
-            {
-                return;
-            }
-            _logger.LogError("Failed to generate source code for mutated assembly, errors are: {Diagnostics}",
-                string.Join(Environment.NewLine, errors.Select(e => e.ToString())));
-            throw new CompilationException("Source Generator Failure");
+            return;
         }
-        catch (Exception e)
-        {
-            _someGeneratorMayCrash = true;
-            _logger.LogError(e, "Some generator(s) failed to run. Stryker will skip running code generators for the rest of this session.");
-        }
+        _logger.LogError("Failed to generate source code for mutated assembly, errors are: {Diagnostics}",
+            string.Join(Environment.NewLine, errors.Select(e => e.ToString())));
+        throw new CompilationException("Source Generator Failure");
     }
 
     private void InitCSharpCompilation()

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -128,7 +129,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             return;
         }
 
-        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation.RemoveSyntaxTrees(_generatorDriver.GetRunResult().GeneratedTrees), out _compilation, out var diagnostics);
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation.RemoveSyntaxTrees(GeneratedTrees)
+            , out _compilation, out var diagnostics);
         _needToRunGenerators = false;
         var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
         if (errors.Count == 0)
@@ -148,7 +150,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         }
 
         var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
-        // create the compiler
+        // create the compilation context
         _compilation= CSharpCompilation.Create(AssemblyName,
             _originalSyntaxTrees,
             _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
@@ -156,7 +158,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         // create the driver for source generators
         _generatorDriver = CSharpGeneratorDriver
             .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
+                additionalTexts:[.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()],
+                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult));
         // run the generators
         _needToRunGenerators = true;
         RunSourceGenerators();
@@ -251,7 +254,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         var cleanedSyntaxTrees = new HashSet<SyntaxTree>();
         // compile each file separately to identify the culprit(s)
         // we disregard generated files. If those trigger an exception, we can't fix it
-        foreach (var st in syntaxTrees.Where(st => !_generatorDriver.GetRunResult().GeneratedTrees.Contains(st)))
+        foreach (var st in syntaxTrees.Where(st => !GeneratedTrees.Contains(st)))
         {
             var local = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(st);
             try
@@ -280,6 +283,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _compilation = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(cleanedSyntaxTrees);
         RunSourceGenerators();
     }
+
+    private ImmutableArray<SyntaxTree> GeneratedTrees => _generatorDriver.GetRunResult().GeneratedTrees;
 
     private void LogEmitResult(EmitResult result)
     {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -275,7 +275,11 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             {
                 _logger.LogError(e, "Failed to compile {FilePath} (compiler crash)", st.FilePath);
                 _logger.LogTrace("source code:\n {Source}", st.GetText());
-                var cleanUpFile = _rollbackProcess.CleanUpFile(st);
+                var cleanUpFile = _originalSyntaxTrees.FirstOrDefault(x => x.FilePath == st.FilePath);
+                if (cleanUpFile == null)                {
+                    _logger.LogError("Failed to find the original syntax tree for {FilePath}. Assuming it is a generated file.", st.FilePath);
+                    continue;
+                }
                 cleanedSyntaxTrees.Add(cleanUpFile);
             }
         }
@@ -314,6 +318,12 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
         _logger.LogTrace("Compilation errors: {Diagnostics}", messageBuilder.ToString());
     }
+
+
+    public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
+
+    public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
+
 
     private static string ReadableNumber(int number) => number switch
     {
@@ -366,27 +376,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
             public override IEnumerable<string> Keys => [];
         }
-    }
-
-    public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
-
-    public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
-
-    public bool RestoreOriginal(SyntaxTree original)
-    {
-        if (string.IsNullOrEmpty(original.FilePath))
-        {
-            return false;
-        }
-        foreach (var tree in _originalSyntaxTrees)
-        {
-            if (tree.FilePath == original.FilePath)
-            {
-                _compilation = _compilation.ReplaceSyntaxTree(original, tree);
-                return true;
-            }
-        }
-        return false;
     }
 }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -37,6 +38,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     private readonly IStrykerOptions _options;
     private readonly ICSharpRollbackProcess _rollbackProcess;
     private readonly ILogger _logger;
+    private GeneratorDriver _generatorDriver;
+    private CSharpCompilation _compilation;
 
     public CsharpCompilingProcess(MutationTestInput input,
         ICSharpRollbackProcess rollbackProcess = null,
@@ -60,8 +63,9 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     /// </summary>
     public CompilingProcessResult Compile(IEnumerable<SyntaxTree> syntaxTrees, Stream ilStream, Stream symbolStream)
     {
-        var compilation = GetCSharpCompilation(syntaxTrees);
+        var compilation = GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
 
+        compilation = RunSourceGenerators(compilation);
         // first try compiling
         var retryCount = 1;
         (var rollbackProcessResult, var emitResult, retryCount) = TryCompilation(ilStream, symbolStream, ref compilation, null, ICSharpRollbackProcess.Mode.Normal, retryCount);
@@ -91,9 +95,9 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
 
         if (emitResult.Success)
         {
-            return new(
+            return new CompilingProcessResult(
                 true,
-                rollbackProcessResult?.RollbackedIds ?? Enumerable.Empty<int>());
+                rollbackProcessResult?.RollbackedIds ?? []);
         }
         // compiling failed
         _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
@@ -108,32 +112,23 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     /// <returns>Semantic models</returns>
     public IEnumerable<SemanticModel> GetSemanticModels(IEnumerable<SyntaxTree> syntaxTrees)
     {
-        var compilation = GetCSharpCompilation(syntaxTrees);
-
+        var compilation = GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
         // extract semantic models from compilation
-        var semanticModels = new List<SemanticModel>();
-        foreach (var tree in syntaxTrees)
-        {
-            semanticModels.Add(compilation.GetSemanticModel(tree));
-        }
-        return semanticModels;
+        return compilation.SyntaxTrees.Select(tree => compilation.GetSemanticModel(tree)).ToList();
     }
 
-    private static readonly string[] IgnoredErrors = ["RZ3600", "CS8784"];
+    private static readonly string[] IgnoredErrors = ["RZ3600"];
 
     // Can't test or mock code generators, so we exclude them from coverage
     [ExcludeFromCodeCoverage]
-    private CSharpCompilation RunSourceGenerators(IAnalyzerResult analyzerResult, Compilation compilation)
+    public Compilation RunSourceGenerators(Compilation compilation)
     {
-        var generators = analyzerResult.GetSourceGenerators(_logger);
-        _ = CSharpGeneratorDriver
-            .Create(generators, parseOptions: analyzerResult.GetParseOptions(_options), optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult))
-            .RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
         var errors = diagnostics.Where(diagnostic => IgnoredErrors.Contains(diagnostic.Id) || (diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None)).ToList();
         if (errors.Count == 0)
         {
-            return outputCompilation as CSharpCompilation;
+            return outputCompilation;
         }
         var fail = false;
         foreach (var diagnostic in errors)
@@ -155,17 +150,29 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         return outputCompilation as CSharpCompilation;
     }
 
-    private Compilation GetCSharpCompilation(IEnumerable<SyntaxTree> syntaxTrees)
+    private Compilation GetCSharpCompilation(IEnumerable<SyntaxTree> syntaxTrees,
+        ImmutableArray<AdditionalText> additionalTexts)
     {
         var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
 
-        var compilation = CSharpCompilation.Create(AssemblyName,
-            syntaxTrees.ToList(),
-            _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
-            analyzerResult.GetCompilationOptions());
+        if (_compilation == null)
+        {
+            _compilation??= CSharpCompilation.Create(AssemblyName,
+                syntaxTrees.ToList(),
+                _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
+                analyzerResult.GetCompilationOptions());
+        }
+        else
+        {
+            _compilation = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(syntaxTrees);
+        }
 
         // C# source generators must be executed before compilation
-        return RunSourceGenerators(analyzerResult, compilation);
+        _generatorDriver ??= CSharpGeneratorDriver
+            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
+                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts(additionalTexts);
+
+        return _compilation;
     }
 
     private (CSharpRollbackProcessResult, EmitResult, int) TryCompilation(
@@ -179,7 +186,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         CSharpRollbackProcessResult rollbackProcessResult = null;
 
         _logger.LogDebug("Trying compilation for the {retryCount} time.", ReadableNumber(retryCount));
-
         var emitOptions = symbolStream == null ? null : new EmitOptions(false, DebugInformationFormat.PortablePdb,
             _input.SourceProjectInfo.AnalyzerResult.GetSymbolFileName());
         EmitResult emitResult = null;
@@ -190,7 +196,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
             {
                 // remove broken mutations
                 rollbackProcessResult = _rollbackProcess.Start(compilation, previousEmitResult.Diagnostics, mode, _options.DiagMode);
-                compilation = rollbackProcessResult.Compilation;
+                compilation =  RunSourceGenerators(rollbackProcessResult.Compilation);
             }
 
             // reset the memoryStreams
@@ -221,7 +227,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         }
 
         LogEmitResult(emitResult);
-
         return (rollbackProcessResult, emitResult, retryCount + 1);
     }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -222,6 +222,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             _logger.LogError("Roslyn C# compiler raised an NullReferenceException. This is a known Roslyn's issue that may be triggered by invalid usage of conditional access expression.");
             _logger.LogInformation(e, "Exception");
             _logger.LogError("Stryker will attempt to skip problematic files.");
+            // cleanup the files triggering an exception
             ScanForCauseOfException();
             EmbeddedResourcesGenerator.ResetCache();
             ms.SetLength(0);
@@ -249,7 +250,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         var syntaxTrees = _compilation.SyntaxTrees.ToList();
         var cleanedSyntaxTrees = new HashSet<SyntaxTree>();
         // compile each file separately to identify the culprit(s)
-        foreach (var st in syntaxTrees)
+        // we disregard generated files. If those trigger an exception, we can't fix it
+        foreach (var st in syntaxTrees.Where(st => !_generatorDriver.GetRunResult().GeneratedTrees.Contains(st)))
         {
             var local = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(st);
             try
@@ -266,7 +268,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
                 _logger.LogError(e, "Failed to compile {FilePath} (compiler crash)", st.FilePath);
                 _logger.LogTrace("source code:\n {Source}", st.GetText());
                 var cleanUpFile = _originalSyntaxTrees.FirstOrDefault(x => x.FilePath == st.FilePath);
-                if (cleanUpFile == null)                {
+                if (cleanUpFile == null)
+                {
                     _logger.LogError("Failed to find the original syntax tree for {FilePath}. Assuming it is a generated file.", st.FilePath);
                     continue;
                 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -72,10 +72,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         // first try compiling
         var retryCount = 1;
         (var rollbackProcessResult, var emitResult, retryCount) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount);
-        if (!_generatorsFailInIncremental)
-        {
-            RunSourceGenerators();
-        }
         // If compiling failed and the error has no location, log and throw exception.
         if (!emitResult.Success && emitResult.Diagnostics.Any(diagnostic => diagnostic.Location == Location.None && diagnostic.Severity == DiagnosticSeverity.Error))
         {
@@ -166,14 +162,14 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
                 optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
         // run the generators
         _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var compilation, out var diagnostics);
-        // try again
+        // try again to see if it crashes
         try
         {
             _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out  _, out _);
         }
         catch (Exception e)
         {
-            _logger.LogError("Some generator(s) failed when run twice: {Diagnostics}", e.Message);
+            _logger.LogError(e, "Some generator(s) failed when run twice");
             _generatorsFailInIncremental = true;
         }
         _compilation = compilation;

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -281,6 +281,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         }
         _logger.LogError("Please report an issue and provide the source code of the file that caused the exception for analysis.");
         _compilation = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(cleanedSyntaxTrees);
+        _needToRunGenerators = true;
         RunSourceGenerators();
     }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -132,29 +132,21 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         try
         {
             _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out _compilation, out var diagnostics);
+            _needToRunGenerators = false;
             var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
             if (errors.Count == 0)
             {
                 return;
             }
-            var fail = false;
-            foreach (var diagnostic in errors)
-            {
-                _logger.LogError("Failed to generate source code for mutated assembly: {Diagnostics}", diagnostic);
-                fail = true;
-            }
-
-            if (fail)
-            {
-                throw new CompilationException("Source Generator Failure");
-            }
+            _logger.LogError("Failed to generate source code for mutated assembly, errors are: {Diagnostics}",
+                string.Join(Environment.NewLine, errors.Select(e => e.ToString())));
+            throw new CompilationException("Source Generator Failure");
         }
         catch (Exception e)
         {
             _someGeneratorMayCrash = true;
             _logger.LogError(e, "Some generator(s) failed to run. Stryker will skip running code generators for the rest of this session.");
         }
-        _needToRunGenerators = false;
     }
 
     private void InitCSharpCompilation()
@@ -197,7 +189,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _logger.LogDebug("Trying compilation for the {retryCount} time.", ReadableNumber(retryCount));
         var emitOptions = symbolStream == null ? null : new EmitOptions(false, DebugInformationFormat.PortablePdb,
             _input.SourceProjectInfo.AnalyzerResult.GetSymbolFileName());
-        EmitResult emitResult = null;
         var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
         if (previousEmitResult != null)
         {
@@ -209,7 +200,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         // reset the memoryStreams
         ms.SetLength(0);
         symbolStream?.SetLength(0);
-        emitResult = ActualCompilation(ms, symbolStream, resourceDescriptions, emitOptions);
+        var emitResult = ActualCompilation(ms, symbolStream, resourceDescriptions, emitOptions);
 
         LogEmitResult(emitResult);
         return (rollbackProcessResult, emitResult);
@@ -240,7 +231,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             _logger.LogError("Roslyn C# compiler raised an NullReferenceException. This is a known Roslyn's issue that may be triggered by invalid usage of conditional access expression.");
             _logger.LogInformation(e, "Exception");
             _logger.LogError("Stryker will attempt to skip problematic files.");
-            _compilation = ScanForCauseOfException(_compilation);
+            ScanForCauseOfException();
             EmbeddedResourcesGenerator.ResetCache();
             ms.SetLength(0);
             symbolStream?.SetLength(0);
@@ -262,14 +253,14 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
     [ExcludeFromCodeCoverage]     // unable to simulate a CS compiler fault
     // This method tries to identify which source file triggers a compiler exception
-    private Compilation ScanForCauseOfException(Compilation compilation)
+    private void ScanForCauseOfException()
     {
-        var syntaxTrees = compilation.SyntaxTrees.ToList();
+        var syntaxTrees = _compilation.SyntaxTrees.ToList();
         var cleanedSyntaxTrees = new HashSet<SyntaxTree>();
         // compile each file separately to identify the culprit(s)
         foreach (var st in syntaxTrees)
         {
-            var local = compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(st);
+            var local = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(st);
             try
             {
                 using var ms = new MemoryStream();
@@ -292,7 +283,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             }
         }
         _logger.LogError("Please report an issue and provide the source code of the file that caused the exception for analysis.");
-        return compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(cleanedSyntaxTrees);
+        _compilation = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(cleanedSyntaxTrees);
+        RunSourceGenerators();
     }
 
     private void LogEmitResult(EmitResult result)

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -147,7 +147,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         {
             throw new CompilationException("Source Generator Failure");
         }
-        return outputCompilation as CSharpCompilation;
+        return outputCompilation;
     }
 
     private Compilation GetCSharpCompilation(IEnumerable<SyntaxTree> syntaxTrees,
@@ -161,16 +161,10 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
                 syntaxTrees.ToList(),
                 _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
                 analyzerResult.GetCompilationOptions());
+            _generatorDriver = CSharpGeneratorDriver
+                .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
+                    optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts(additionalTexts);
         }
-        else
-        {
-            _compilation = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(syntaxTrees);
-        }
-
-        // C# source generators must be executed before compilation
-        _generatorDriver ??= CSharpGeneratorDriver
-            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts(additionalTexts);
 
         return _compilation;
     }

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -42,7 +42,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     private GeneratorDriver _generatorDriver;
     private Compilation _compilation;
     private bool _generatorsFailInIncremental;
-    private readonly IEnumerable<SyntaxTree> _syntaxTrees;
+    private readonly IEnumerable<SyntaxTree> _originalSyntaxTrees;
 
     public CsharpCompilingProcess(MutationTestInput input,
         ICSharpRollbackProcess rollbackProcess = null,
@@ -53,7 +53,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _options = options ?? new StrykerOptions();
         _rollbackProcess = rollbackProcess ?? new CSharpRollbackProcess();
         _logger = ApplicationLogging.LoggerFactory.CreateLogger<CsharpCompilingProcess>();
-        _syntaxTrees = syntaxTrees ?? ((ProjectComponent) _input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees.ToList();
+        _originalSyntaxTrees = syntaxTrees ?? ((ProjectComponent) _input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees.ToList();
         _generatorsFailInIncremental = false;
     }
 
@@ -157,7 +157,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
         // create the compiler
         _compilation= CSharpCompilation.Create(AssemblyName,
-            _syntaxTrees,
+            _originalSyntaxTrees,
             _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
             analyzerResult.GetCompilationOptions());
         // create the driver for source generators
@@ -382,7 +382,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         {
             return false;
         }
-        foreach (var tree in _syntaxTrees)
+        foreach (var tree in _originalSyntaxTrees)
         {
             if (tree.FilePath == original.FilePath)
             {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -71,7 +71,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         InitCSharpCompilation();
         // first try compiling
         var retryCount = 1;
-        (var rollbackProcessResult, var emitResult, retryCount) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount);
+        var (rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);
         // If compiling failed and the error has no location, log and throw exception.
         if (!emitResult.Success && emitResult.Diagnostics.Any(diagnostic => diagnostic.Location == Location.None && diagnostic.Severity == DiagnosticSeverity.Error))
         {
@@ -91,8 +91,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
                 _ => mode
             };
             // compilation did not succeed. let's compile a couple of times more for good measure
-            (rollbackProcessResult, emitResult, retryCount) = TryCompilation(ilStream, symbolStream,
-                emitResult, mode, retryCount);
+            (rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream,
+                emitResult, mode, retryCount++);
         }
 
         if (emitResult.Success)
@@ -123,8 +123,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     [ExcludeFromCodeCoverage]
     private void RunSourceGenerators()
     {
-        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var outputCompilation, out var diagnostics);
-        _compilation = outputCompilation;
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out _compilation, out var diagnostics);
         var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
         if (errors.Count == 0)
         {
@@ -145,23 +144,23 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
     private void InitCSharpCompilation()
     {
-        if (_compilation != null)
+        if (_compilation == null)
         {
-            return ;
+            var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
+            // create the compiler
+            _compilation= CSharpCompilation.Create(AssemblyName,
+                _originalSyntaxTrees,
+                _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
+                analyzerResult.GetCompilationOptions());
+            // create the driver for source generators
+            _generatorDriver = CSharpGeneratorDriver
+                .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
+                    optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
         }
 
-        var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
-        // create the compiler
-        _compilation= CSharpCompilation.Create(AssemblyName,
-            _originalSyntaxTrees,
-            _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
-            analyzerResult.GetCompilationOptions());
-        // create the driver for source generators
-        _generatorDriver = CSharpGeneratorDriver
-            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
         // run the generators
         _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var compilation, out var diagnostics);
+        _compilation = compilation;
         // try again to see if it crashes
         try
         {
@@ -172,7 +171,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             _logger.LogError(e, "Some generator(s) failed when run twice");
             _generatorsFailInIncremental = true;
         }
-        _compilation = compilation;
         var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
         if (errors.Count == 0)
         {
@@ -195,7 +193,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
     public void UpdateFile(SyntaxTree fileSyntaxTree, SyntaxTree fileMutatedSyntaxTree) => _compilation = _compilation.ReplaceSyntaxTree(fileSyntaxTree, fileMutatedSyntaxTree);
 
-    private (IEnumerable<int>, EmitResult, int) TryCompilation(
+    private (IEnumerable<int>, EmitResult) TryCompilation(
         Stream ms,
         Stream symbolStream,
         EmitResult previousEmitResult,
@@ -209,47 +207,68 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
             _input.SourceProjectInfo.AnalyzerResult.GetSymbolFileName());
         EmitResult emitResult = null;
         var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
-        while (emitResult == null)
+        if (previousEmitResult != null)
         {
-            if (previousEmitResult != null)
+            // remove broken mutations
+            rollbackProcessResult = _rollbackProcess.RollbackMutationsInError(this, previousEmitResult.Diagnostics, mode, _options.DiagMode);
+            if (!_generatorsFailInIncremental)
             {
-                // remove broken mutations
-                rollbackProcessResult = _rollbackProcess.Start(this, previousEmitResult.Diagnostics, mode, _options.DiagMode);
-                if (!_generatorsFailInIncremental)
-                {
-                    RunSourceGenerators();
-                }
-            }
-
-            // reset the memoryStreams
-            ms.SetLength(0);
-            symbolStream?.SetLength(0);
-            try
-            {
-                emitResult = _compilation.Emit(
-                    ms,
-                    symbolStream,
-                    manifestResources: resourceDescriptions,
-                    win32Resources: _compilation.CreateDefaultWin32Resources(
-                        true, // Important!
-                        false,
-                        null,
-                        null),
-                    options: emitOptions);
-            }
-#pragma warning disable S1696 // this catches an exception raised by the C# compiler
-            catch (NullReferenceException e)
-            {
-                _logger.LogError("Roslyn C# compiler raised an NullReferenceException. This is a known Roslyn's issue that may be triggered by invalid usage of conditional access expression.");
-                _logger.LogInformation(e, "Exception");
-                _logger.LogError("Stryker will attempt to skip problematic files.");
-                _compilation = ScanForCauseOfException(_compilation);
-                EmbeddedResourcesGenerator.ResetCache();
+                RunSourceGenerators();
             }
         }
 
+        // reset the memoryStreams
+        ms.SetLength(0);
+        symbolStream?.SetLength(0);
+        emitResult = ActualCompilation(ms, symbolStream, resourceDescriptions, emitOptions);
+
         LogEmitResult(emitResult);
-        return (rollbackProcessResult, emitResult, retryCount + 1);
+        return (rollbackProcessResult, emitResult);
+    }
+
+    [ExcludeFromCodeCoverage]     // unable to simulate a CS compiler fault
+    private EmitResult ActualCompilation(Stream ms, Stream symbolStream, IEnumerable<ResourceDescription> resourceDescriptions,
+        EmitOptions emitOptions)
+    {
+        EmitResult emitResult = null;
+
+        try
+        {
+            emitResult = _compilation.Emit(
+                ms,
+                symbolStream,
+                manifestResources: resourceDescriptions,
+                win32Resources: _compilation.CreateDefaultWin32Resources(
+                    true, // Important!
+                    false,
+                    null,
+                    null),
+                options: emitOptions);
+        }
+#pragma warning disable S1696 // this catches an exception raised by the C# compiler
+        catch (NullReferenceException e)
+        {
+            _logger.LogError("Roslyn C# compiler raised an NullReferenceException. This is a known Roslyn's issue that may be triggered by invalid usage of conditional access expression.");
+            _logger.LogInformation(e, "Exception");
+            _logger.LogError("Stryker will attempt to skip problematic files.");
+            _compilation = ScanForCauseOfException(_compilation);
+            EmbeddedResourcesGenerator.ResetCache();
+            ms.SetLength(0);
+            symbolStream?.SetLength(0);
+            // try again
+            emitResult = _compilation.Emit(
+                ms,
+                symbolStream,
+                manifestResources: resourceDescriptions,
+                win32Resources: _compilation.CreateDefaultWin32Resources(
+                    true, // Important!
+                    false,
+                    null,
+                    null),
+                options: emitOptions);
+        }
+
+        return emitResult;
     }
 
     [ExcludeFromCodeCoverage]     // unable to simulate a CS compiler fault

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -15,6 +14,7 @@ using Stryker.Abstractions.Exceptions;
 using Stryker.Abstractions.Options;
 using Stryker.Configuration.Options;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Utilities.Buildalyzer;
 using Stryker.Utilities.EmbeddedResources;
 using Stryker.Utilities.Logging;
@@ -23,15 +23,16 @@ namespace Stryker.Core.Compiling;
 
 public interface ICSharpCompilingProcess
 {
-    CompilingProcessResult Compile(IEnumerable<SyntaxTree> syntaxTrees, Stream ilStream, Stream symbolStream);
-    IEnumerable<SemanticModel> GetSemanticModels(IEnumerable<SyntaxTree> syntaxTrees);
+    CompilingProcessResult Compile(Stream ilStream, Stream symbolStream);
+
+    SemanticModel GetSemanticModel(SyntaxTree syntaxTree);
 }
 
 /// <summary>
 /// This process is in control of compiling the assembly and rolling back mutations that cannot compile
 /// Compiles the given input onto the memory stream
 /// </summary>
-public class CsharpCompilingProcess : ICSharpCompilingProcess
+public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationContent
 {
     private const int MaxAttempt = 50;
     private readonly MutationTestInput _input;
@@ -39,16 +40,21 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     private readonly ICSharpRollbackProcess _rollbackProcess;
     private readonly ILogger _logger;
     private GeneratorDriver _generatorDriver;
-    private CSharpCompilation _compilation;
+    private Compilation _compilation;
+    private bool _generatorsFailInIncremental;
+    private readonly IEnumerable<SyntaxTree> _syntaxTrees;
 
     public CsharpCompilingProcess(MutationTestInput input,
         ICSharpRollbackProcess rollbackProcess = null,
-        IStrykerOptions options = null)
+        IStrykerOptions options = null,
+        IEnumerable<SyntaxTree> syntaxTrees = null)
     {
         _input = input;
         _options = options ?? new StrykerOptions();
         _rollbackProcess = rollbackProcess ?? new CSharpRollbackProcess();
         _logger = ApplicationLogging.LoggerFactory.CreateLogger<CsharpCompilingProcess>();
+        _syntaxTrees = syntaxTrees ?? ((ProjectComponent) _input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees.ToList();
+        _generatorsFailInIncremental = false;
     }
 
     private string AssemblyName =>
@@ -57,19 +63,19 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     /// <summary>
     /// Compiles the given input onto the memory stream
     /// The compiling process is closely related to the rollback process. When the initial compilation fails, the rollback process will be executed.
-    /// <param name="syntaxTrees">The syntax trees to compile</param>
     /// <param name="ilStream">The memory stream to store the compilation result onto</param>
     /// <param name="symbolStream">The memory stream to store the debug symbol</param>
     /// </summary>
-    public CompilingProcessResult Compile(IEnumerable<SyntaxTree> syntaxTrees, Stream ilStream, Stream symbolStream)
+    public CompilingProcessResult Compile(Stream ilStream, Stream symbolStream)
     {
-        var compilation = GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
-
-        compilation = RunSourceGenerators(compilation);
+        InitCSharpCompilation();
         // first try compiling
         var retryCount = 1;
-        (var rollbackProcessResult, var emitResult, retryCount) = TryCompilation(ilStream, symbolStream, ref compilation, null, ICSharpRollbackProcess.Mode.Normal, retryCount);
-
+        (var rollbackProcessResult, var emitResult, retryCount) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount);
+        if (!_generatorsFailInIncremental)
+        {
+            RunSourceGenerators();
+        }
         // If compiling failed and the error has no location, log and throw exception.
         if (!emitResult.Success && emitResult.Diagnostics.Any(diagnostic => diagnostic.Location == Location.None && diagnostic.Severity == DiagnosticSeverity.Error))
         {
@@ -89,7 +95,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
                 _ => mode
             };
             // compilation did not succeed. let's compile a couple of times more for good measure
-            (rollbackProcessResult, emitResult, retryCount) = TryCompilation(ilStream, symbolStream, ref compilation,
+            (rollbackProcessResult, emitResult, retryCount) = TryCompilation(ilStream, symbolStream,
                 emitResult, mode, retryCount);
         }
 
@@ -97,7 +103,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         {
             return new CompilingProcessResult(
                 true,
-                rollbackProcessResult?.RollbackedIds ?? []);
+                rollbackProcessResult ?? []);
         }
         // compiling failed
         _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
@@ -108,76 +114,99 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     /// <summary>
     /// Analyzes the syntax trees and returns the semantic models
     /// </summary>
-    /// <param name="syntaxTrees">The syntax trees to analyze</param>
+    /// <param name="syntaxTree">The syntax tree to analyze</param>
     /// <returns>Semantic models</returns>
-    public IEnumerable<SemanticModel> GetSemanticModels(IEnumerable<SyntaxTree> syntaxTrees)
+    public SemanticModel GetSemanticModel(SyntaxTree syntaxTree)
     {
-        var compilation = RunSourceGenerators(GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]));
+        InitCSharpCompilation();
         // extract semantic models from compilation
-        return compilation.SyntaxTrees.Select(tree => compilation.GetSemanticModel(tree)).ToList();
+        return _compilation.GetSemanticModel(syntaxTree);
     }
-
-    private static readonly string[] IgnoredErrors = ["RZ3600"];
 
     // Can't test or mock code generators, so we exclude them from coverage
     [ExcludeFromCodeCoverage]
-    private Compilation RunSourceGenerators(Compilation compilation)
+    private void RunSourceGenerators()
     {
-        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
-
-        var errors = diagnostics.Where(diagnostic => IgnoredErrors.Contains(diagnostic.Id) || (diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None)).ToList();
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var outputCompilation, out var diagnostics);
+        _compilation = outputCompilation;
+        var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
         if (errors.Count == 0)
         {
-            return outputCompilation;
+            return;
         }
         var fail = false;
         foreach (var diagnostic in errors)
         {
-            if (IgnoredErrors.Contains(diagnostic.Id))
-            {
-                _logger.LogWarning("Stryker encountered a known error from a coe generator but it will keep on. Compilation may still fail later on: {0}", diagnostic);
-            }
-            else
-            {
-                _logger.LogError("Failed to generate source code for mutated assembly: {Diagnostics}", diagnostic);
-                fail = true;
-            }
+            _logger.LogError("Failed to generate source code for mutated assembly: {Diagnostics}", diagnostic);
+            fail = true;
         }
+
         if (fail)
         {
             throw new CompilationException("Source Generator Failure");
         }
-        return outputCompilation;
     }
 
-    private Compilation GetCSharpCompilation(IEnumerable<SyntaxTree> syntaxTrees,
-        ImmutableArray<AdditionalText> additionalTexts)
+    private void InitCSharpCompilation()
     {
-        var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
-
-        if (_compilation == null)
+        if (_compilation != null)
         {
-            _compilation= CSharpCompilation.Create(AssemblyName,
-                syntaxTrees.ToList(),
-                _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
-                analyzerResult.GetCompilationOptions());
-            _generatorDriver = CSharpGeneratorDriver
-                .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                    optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts(additionalTexts);
+            return ;
         }
 
-        return _compilation;
+        var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
+        // create the compiler
+        _compilation= CSharpCompilation.Create(AssemblyName,
+            _syntaxTrees,
+            _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
+            analyzerResult.GetCompilationOptions());
+        // create the driver for source generators
+        _generatorDriver = CSharpGeneratorDriver
+            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
+                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
+        // run the generators
+        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var compilation, out var diagnostics);
+        // try again
+        try
+        {
+            _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out  _, out _);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError("Some generator(s) failed when run twice: {Diagnostics}", e.Message);
+            _generatorsFailInIncremental = true;
+        }
+        _compilation = compilation;
+        var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
+        if (errors.Count == 0)
+        {
+            return;
+        }
+        foreach (var diagnostic in errors)
+        {
+            _logger.LogError("Failed to generate source code for assembly: {Diagnostics}", diagnostic);
+        }
+
+        if (_options.DiagMode)
+        {
+            _logger.LogError("Diag mode: keep on despite errors to have a full diagnostic.");
+        }
+        else
+        {
+            throw new CompilationException("Source Generator Failure");
+        }
     }
 
-    private (CSharpRollbackProcessResult, EmitResult, int) TryCompilation(
+    public void UpdateFile(SyntaxTree fileSyntaxTree, SyntaxTree fileMutatedSyntaxTree) => _compilation = _compilation.ReplaceSyntaxTree(fileSyntaxTree, fileMutatedSyntaxTree);
+
+    private (IEnumerable<int>, EmitResult, int) TryCompilation(
         Stream ms,
         Stream symbolStream,
-        ref Compilation compilation,
         EmitResult previousEmitResult,
         ICSharpRollbackProcess.Mode mode,
         int retryCount)
     {
-        CSharpRollbackProcessResult rollbackProcessResult = null;
+        IEnumerable<int> rollbackProcessResult = null;
 
         _logger.LogDebug("Trying compilation for the {retryCount} time.", ReadableNumber(retryCount));
         var emitOptions = symbolStream == null ? null : new EmitOptions(false, DebugInformationFormat.PortablePdb,
@@ -189,8 +218,11 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
             if (previousEmitResult != null)
             {
                 // remove broken mutations
-                rollbackProcessResult = _rollbackProcess.Start(compilation, previousEmitResult.Diagnostics, mode, _options.DiagMode);
-                compilation =  RunSourceGenerators(rollbackProcessResult.Compilation);
+                rollbackProcessResult = _rollbackProcess.Start(this, previousEmitResult.Diagnostics, mode, _options.DiagMode);
+                if (!_generatorsFailInIncremental)
+                {
+                    RunSourceGenerators();
+                }
             }
 
             // reset the memoryStreams
@@ -198,11 +230,11 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
             symbolStream?.SetLength(0);
             try
             {
-                emitResult = compilation.Emit(
+                emitResult = _compilation.Emit(
                     ms,
                     symbolStream,
                     manifestResources: resourceDescriptions,
-                    win32Resources: compilation.CreateDefaultWin32Resources(
+                    win32Resources: _compilation.CreateDefaultWin32Resources(
                         true, // Important!
                         false,
                         null,
@@ -215,7 +247,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
                 _logger.LogError("Roslyn C# compiler raised an NullReferenceException. This is a known Roslyn's issue that may be triggered by invalid usage of conditional access expression.");
                 _logger.LogInformation(e, "Exception");
                 _logger.LogError("Stryker will attempt to skip problematic files.");
-                compilation = ScanForCauseOfException(compilation);
+                _compilation = ScanForCauseOfException(_compilation);
                 EmbeddedResourcesGenerator.ResetCache();
             }
         }
@@ -224,8 +256,8 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
         return (rollbackProcessResult, emitResult, retryCount + 1);
     }
 
-    [ExcludeFromCodeCoverage]
-    // unable to simulate a CS compiler fault
+    [ExcludeFromCodeCoverage]     // unable to simulate a CS compiler fault
+    // This method tries to identify which source file triggers a compiler exception
     private Compilation ScanForCauseOfException(Compilation compilation)
     {
         var syntaxTrees = compilation.SyntaxTrees.ToList();
@@ -338,7 +370,27 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
 
             public override IEnumerable<string> Keys => [];
         }
+    }
 
+    public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
+
+    public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
+
+    public bool RestoreOriginal(SyntaxTree original)
+    {
+        if (string.IsNullOrEmpty(original.FilePath))
+        {
+            return false;
+        }
+        foreach (var tree in _syntaxTrees)
+        {
+            if (tree.FilePath == original.FilePath)
+            {
+                _compilation = _compilation.ReplaceSyntaxTree(original, tree);
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -41,8 +41,9 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     private readonly ILogger _logger;
     private GeneratorDriver _generatorDriver;
     private Compilation _compilation;
-    private bool _generatorsFailInIncremental;
     private readonly IEnumerable<SyntaxTree> _originalSyntaxTrees;
+    private bool _needToRunGenerators;
+    private bool _someGeneratorMayCrash;
 
     public CsharpCompilingProcess(MutationTestInput input,
         ICSharpRollbackProcess rollbackProcess = null,
@@ -54,7 +55,6 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _rollbackProcess = rollbackProcess ?? new CSharpRollbackProcess();
         _logger = ApplicationLogging.LoggerFactory.CreateLogger<CsharpCompilingProcess>();
         _originalSyntaxTrees = syntaxTrees ?? ((ProjectComponent) _input.SourceProjectInfo.ProjectContents).CompilationSyntaxTrees.ToList();
-        _generatorsFailInIncremental = false;
     }
 
     private string AssemblyName =>
@@ -69,6 +69,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     public CompilingProcessResult Compile(Stream ilStream, Stream symbolStream)
     {
         InitCSharpCompilation();
+        RunSourceGenerators();
         // first try compiling
         var retryCount = 1;
         var (rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);
@@ -123,75 +124,66 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     [ExcludeFromCodeCoverage]
     private void RunSourceGenerators()
     {
-        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out _compilation, out var diagnostics);
-        var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
-        if (errors.Count == 0)
+        if (!_needToRunGenerators || _someGeneratorMayCrash)
         {
             return;
         }
-        var fail = false;
-        foreach (var diagnostic in errors)
-        {
-            _logger.LogError("Failed to generate source code for mutated assembly: {Diagnostics}", diagnostic);
-            fail = true;
-        }
 
-        if (fail)
+        try
         {
-            throw new CompilationException("Source Generator Failure");
+            _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out _compilation, out var diagnostics);
+            var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
+            if (errors.Count == 0)
+            {
+                return;
+            }
+            var fail = false;
+            foreach (var diagnostic in errors)
+            {
+                _logger.LogError("Failed to generate source code for mutated assembly: {Diagnostics}", diagnostic);
+                fail = true;
+            }
+
+            if (fail)
+            {
+                throw new CompilationException("Source Generator Failure");
+            }
         }
+        catch (Exception e)
+        {
+            _someGeneratorMayCrash = true;
+            _logger.LogError(e, "Some generator(s) failed to run. Stryker will skip running code generators for the rest of this session.");
+        }
+        _needToRunGenerators = false;
     }
 
     private void InitCSharpCompilation()
     {
-        if (_compilation == null)
-        {
-            var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
-            // create the compiler
-            _compilation= CSharpCompilation.Create(AssemblyName,
-                _originalSyntaxTrees,
-                _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
-                analyzerResult.GetCompilationOptions());
-            // create the driver for source generators
-            _generatorDriver = CSharpGeneratorDriver
-                .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                    optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
-        }
-
-        // run the generators
-        _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(_compilation, out var compilation, out var diagnostics);
-        _compilation = compilation;
-        // try again to see if it crashes
-        try
-        {
-            _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out  _, out _);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Some generator(s) failed when run twice");
-            _generatorsFailInIncremental = true;
-        }
-        var errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error && diagnostic.Location == Location.None).ToList();
-        if (errors.Count == 0)
+        if (_compilation != null)
         {
             return;
         }
-        foreach (var diagnostic in errors)
-        {
-            _logger.LogError("Failed to generate source code for assembly: {Diagnostics}", diagnostic);
-        }
 
-        if (_options.DiagMode)
-        {
-            _logger.LogError("Diag mode: keep on despite errors to have a full diagnostic.");
-        }
-        else
-        {
-            throw new CompilationException("Source Generator Failure");
-        }
+        var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
+        // create the compiler
+        _compilation= CSharpCompilation.Create(AssemblyName,
+            _originalSyntaxTrees,
+            _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
+            analyzerResult.GetCompilationOptions());
+        // create the driver for source generators
+        _generatorDriver = CSharpGeneratorDriver
+            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
+                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult)).AddAdditionalTexts([.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
+        // run the generators
+        _needToRunGenerators = true;
+        RunSourceGenerators();
     }
 
-    public void UpdateFile(SyntaxTree fileSyntaxTree, SyntaxTree fileMutatedSyntaxTree) => _compilation = _compilation.ReplaceSyntaxTree(fileSyntaxTree, fileMutatedSyntaxTree);
+    public void UpdateFile(SyntaxTree fileSyntaxTree, SyntaxTree fileMutatedSyntaxTree)
+    {
+        _compilation = _compilation.ReplaceSyntaxTree(fileSyntaxTree, fileMutatedSyntaxTree);
+        _needToRunGenerators = true;
+    }
 
     private (IEnumerable<int>, EmitResult) TryCompilation(
         Stream ms,
@@ -211,10 +203,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         {
             // remove broken mutations
             rollbackProcessResult = _rollbackProcess.RollbackMutationsInError(this, previousEmitResult.Diagnostics, mode, _options.DiagMode);
-            if (!_generatorsFailInIncremental)
-            {
-                RunSourceGenerators();
-            }
+            RunSourceGenerators();
         }
 
         // reset the memoryStreams
@@ -338,11 +327,9 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _logger.LogTrace("Compilation errors: {Diagnostics}", messageBuilder.ToString());
     }
 
-
     public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
 
     public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
-
 
     private static string ReadableNumber(int number) => number switch
     {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -112,7 +112,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
     /// <returns>Semantic models</returns>
     public IEnumerable<SemanticModel> GetSemanticModels(IEnumerable<SyntaxTree> syntaxTrees)
     {
-        var compilation = GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]);
+        var compilation = RunSourceGenerators(GetCSharpCompilation(syntaxTrees, [.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()]));
         // extract semantic models from compilation
         return compilation.SyntaxTrees.Select(tree => compilation.GetSemanticModel(tree)).ToList();
     }
@@ -121,7 +121,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
 
     // Can't test or mock code generators, so we exclude them from coverage
     [ExcludeFromCodeCoverage]
-    public Compilation RunSourceGenerators(Compilation compilation)
+    private Compilation RunSourceGenerators(Compilation compilation)
     {
         _generatorDriver = _generatorDriver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
@@ -157,7 +157,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess
 
         if (_compilation == null)
         {
-            _compilation??= CSharpCompilation.Create(AssemblyName,
+            _compilation= CSharpCompilation.Create(AssemblyName,
                 syntaxTrees.ToList(),
                 _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
                 analyzerResult.GetCompilationOptions());

--- a/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
@@ -34,7 +34,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
         _logger = logger;
     }
 
-    public override IReadOnlyProjectComponent Build()
+       public override IReadOnlyProjectComponent Build()
     {
         FolderComposite inputFiles;
         if (_projectInfo.AnalyzerResult.SourceFiles!=null && _projectInfo.AnalyzerResult.SourceFiles.Length != 0)
@@ -86,7 +86,8 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
         foreach (var sourceFile in analyzerResult.SourceFiles)
         {
             var relativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, sourceFile);
-            var folderComposite = GetOrBuildFolderComposite(cache, FileSystem.Path.GetDirectoryName(relativePath), sourceProjectDir, projectUnderTestFolderComposite);
+            var folderComposite = GetOrBuildFolderComposite(cache, FileSystem.Path.GetDirectoryName(relativePath) ?? string.Empty
+                , sourceProjectDir, projectUnderTestFolderComposite);
 
             var file = new CsharpFileLeaf()
             {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
@@ -37,13 +37,13 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
     public override IReadOnlyProjectComponent Build()
     {
         FolderComposite inputFiles;
-        if (_projectInfo.AnalyzerResult.SourceFiles.Length != 0)
+        if (_projectInfo.AnalyzerResult.SourceFiles!=null && _projectInfo.AnalyzerResult.SourceFiles.Length != 0)
         {
             inputFiles = FindProjectFilesUsingBuildalyzer(_projectInfo.AnalyzerResult, _options);
         }
         else
         {
-            _logger.LogWarning("Buildalyzer could not find source files. This should not happen. We fallback to filesystem scan. Please report an issue at github.");
+            _logger.LogWarning("Buildalyzer could not find source files. This should not happen. We fall back to filesystem scan. Please report an issue at GitHub.");
             inputFiles = FindProjectFilesScanningProjectFolders(_projectInfo.AnalyzerResult);
         }
         return inputFiles;

--- a/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/CsharpProjectComponentsBuilder.cs
@@ -36,28 +36,29 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
 
     public override IReadOnlyProjectComponent Build()
     {
-        CsharpFolderComposite inputFiles;
-        if (_projectInfo.AnalyzerResult.SourceFiles != null && _projectInfo.AnalyzerResult.SourceFiles.Any())
+        FolderComposite inputFiles;
+        if (_projectInfo.AnalyzerResult.SourceFiles.Length != 0)
         {
             inputFiles = FindProjectFilesUsingBuildalyzer(_projectInfo.AnalyzerResult, _options);
         }
         else
         {
-            _logger.LogWarning("Buildalyzer could not find sourcefiles. This should not happen. We fallback to filesystem scan. Please report an issue at github.");
+            _logger.LogWarning("Buildalyzer could not find source files. This should not happen. We fallback to filesystem scan. Please report an issue at github.");
             inputFiles = FindProjectFilesScanningProjectFolders(_projectInfo.AnalyzerResult);
         }
         return inputFiles;
     }
 
     // This is a backup strategy
-    private CsharpFolderComposite FindProjectFilesScanningProjectFolders(IAnalyzerResult analyzerResult)
+    private FolderComposite FindProjectFilesScanningProjectFolders(IAnalyzerResult analyzerResult)
     {
-        var inputFiles = new CsharpFolderComposite();
-        var sourceProjectDir = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
+        var inputFiles = new FolderComposite();
+        var sourceProjectDir = FileSystem.Path.GetDirectoryName(analyzerResult.ProjectFilePath);
+        var directoryName = FileSystem.Path.GetDirectoryName(sourceProjectDir) ?? "";
         var cSharpParseOptions = analyzerResult.GetParseOptions(_options);
         foreach (var dir in ExtractProjectFolders(analyzerResult))
         {
-            var folder = FileSystem.Path.Combine(Path.GetDirectoryName(sourceProjectDir), dir);
+            var folder = FileSystem.Path.Combine(directoryName, dir);
             _logger.LogDebug("Scanning {Folder}", folder);
             inputFiles.Add(FindInputFiles(folder, sourceProjectDir, analyzerResult, cSharpParseOptions));
         }
@@ -66,25 +67,26 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
     }
 
     public override void InjectHelpers(IReadOnlyProjectComponent inputFiles)
-        => InjectMutantHelpers((CsharpFolderComposite)inputFiles, _projectInfo.AnalyzerResult.GetParseOptions(_options));
+        => InjectMutantHelpers((FolderComposite)inputFiles, _projectInfo.AnalyzerResult.GetParseOptions(_options));
 
-    private CsharpFolderComposite FindProjectFilesUsingBuildalyzer(IAnalyzerResult analyzerResult, IStrykerOptions options)
+    private FolderComposite FindProjectFilesUsingBuildalyzer(IAnalyzerResult analyzerResult, IStrykerOptions options)
     {
         var generatedAssemblyInfo = analyzerResult.AssemblyAttributeFileName();
-        var projectUnderTestFolderComposite = new CsharpFolderComposite()
+        var sourceProjectDir = FileSystem.Path.GetDirectoryName(analyzerResult.ProjectFilePath) ?? "";
+        var projectUnderTestFolderComposite = new FolderComposite
         {
-            FullPath = Path.GetDirectoryName(analyzerResult.ProjectFilePath),
-            RelativePath = Path.GetDirectoryName(Path.GetDirectoryName(analyzerResult.ProjectFilePath)),
+            FullPath = sourceProjectDir,
+            RelativePath = FileSystem.Path.GetDirectoryName(sourceProjectDir) ?? "",
         };
-        var cache = new Dictionary<string, CsharpFolderComposite> { [string.Empty] = projectUnderTestFolderComposite };
+        var cache = new Dictionary<string, FolderComposite> { [string.Empty] = projectUnderTestFolderComposite };
 
         // Save cache in a singleton, so we can use it in other parts of the project
-        FolderCompositeCache<CsharpFolderComposite>.Instance.Cache = cache;
+        FolderCompositeCache<FolderComposite>.Instance.Cache = cache;
 
         foreach (var sourceFile in analyzerResult.SourceFiles)
         {
-            var relativePath = Path.GetRelativePath(Path.GetDirectoryName(analyzerResult.ProjectFilePath), sourceFile);
-            var folderComposite = GetOrBuildFolderComposite(cache, Path.GetDirectoryName(relativePath), Path.GetDirectoryName(analyzerResult.ProjectFilePath), projectUnderTestFolderComposite);
+            var relativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, sourceFile);
+            var folderComposite = GetOrBuildFolderComposite(cache, FileSystem.Path.GetDirectoryName(relativePath), sourceProjectDir, projectUnderTestFolderComposite);
 
             var file = new CsharpFileLeaf()
             {
@@ -96,38 +98,40 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
             // Get the syntax tree for the source file
             var syntaxTree = CSharpSyntaxTree.ParseText(file.SourceCode, analyzerResult.GetParseOptions(options), file.FullPath, encoding: Encoding.UTF32);
 
-            // don't mutate auto generated code
-            if (syntaxTree.IsGenerated())
+            if (!syntaxTree.IsGenerated())
             {
-                // we found the generated assemblyinfo file
-                if (FileSystem.Path.GetFileName(sourceFile).ToLowerInvariant() == generatedAssemblyInfo)
-                {
-                    // add the mutated text
-                    syntaxTree = InjectMutationLabel(syntaxTree);
-                }
-                _logger.LogDebug("Skipping auto-generated code file: {fileName}", file.FullPath);
-                folderComposite.AddCompilationSyntaxTree(syntaxTree); // Add the syntaxTree to the list of compilationSyntaxTrees
-                continue; // Don't add the file to the folderComposite as we're not reporting on the file
+                // normal file
+                file.SyntaxTree = syntaxTree;
+                folderComposite.Add(file);
+                continue;
             }
 
-            file.SyntaxTree = syntaxTree;
-            folderComposite.Add(file);
+            // don't mutate auto generated code
+            if (FileSystem.Path.GetFileName(sourceFile)
+                .Equals(generatedAssemblyInfo, StringComparison.InvariantCultureIgnoreCase))
+            {
+                // add the mutated text
+                syntaxTree = InjectMutationLabel(syntaxTree);
+            }
+
+            _logger.LogDebug("Skipping auto-generated code file: {fileName}", file.FullPath);
+            folderComposite.AddCompilationSyntaxTree(syntaxTree); // Add the syntaxTree to the list of compilationSyntaxTrees
         }
         return projectUnderTestFolderComposite;
     }
 
-    public override Action PostBuildAction() => () => ScanPackageContentFiles(_projectInfo.AnalyzerResult, (CsharpFolderComposite)_projectInfo.ProjectContents);
+    public override Action PostBuildAction() => () => ScanPackageContentFiles(_projectInfo.AnalyzerResult, (FolderComposite)_projectInfo.ProjectContents);
 
-    public void ScanPackageContentFiles(IAnalyzerResult analyzerResult, CsharpFolderComposite projectUnderTestFolderComposite)
+    private void ScanPackageContentFiles(IAnalyzerResult analyzerResult, FolderComposite projectUnderTestFolderComposite)
     {
         // look for extra source files coming from Nuget packages
         var folder = analyzerResult.GetProperty("ContentPreprocessorOutputDirectory");
-        var sourceProjectDir = Path.GetDirectoryName(analyzerResult.ProjectFilePath);
+        var sourceProjectDir = FileSystem.Path.GetDirectoryName(analyzerResult.ProjectFilePath);
         if (string.IsNullOrEmpty(folder))
         {
             return;
         }
-        folder = Path.Combine(sourceProjectDir, folder);
+        folder = FileSystem.Path.Combine(sourceProjectDir, folder);
         if (FileSystem.Directory.Exists(folder))
         {
             projectUnderTestFolderComposite.Add(FindInputFiles(folder, sourceProjectDir, analyzerResult.GetParseOptions(_options), false));
@@ -157,25 +161,23 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
         var newAttribute = myAttribute.ReplaceNode(labelNode,
             SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(newLabel)));
         return root.ReplaceNode(myAttribute, newAttribute).SyntaxTree;
-
     }
 
     /// <summary>
     /// Recursively scans the given directory for files to mutate
     /// Deprecated method, should not be maintained
     /// </summary>
-    private CsharpFolderComposite FindInputFiles(string path, string sourceProjectDir,
+    private FolderComposite FindInputFiles(string path, string sourceProjectDir,
         IAnalyzerResult analyzerResult, CSharpParseOptions cSharpParseOptions)
     {
-        var rootFolderComposite = new CsharpFolderComposite
+        var rootFolderComposite = new FolderComposite
         {
-            FullPath = Path.GetFullPath(path),
-            RelativePath = Path.GetRelativePath(sourceProjectDir, Path.GetFullPath(path))
+            FullPath = FileSystem.Path.GetFullPath(path),
+            RelativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, FileSystem.Path.GetFullPath(path))
         };
 
-
         rootFolderComposite.Add(
-            FindInputFiles(path, Path.GetDirectoryName(analyzerResult.ProjectFilePath), cSharpParseOptions)
+            FindInputFiles(path, FileSystem.Path.GetDirectoryName(analyzerResult.ProjectFilePath), cSharpParseOptions)
         );
         return rootFolderComposite;
     }
@@ -184,16 +186,15 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
     /// Recursively scans the given directory for files to mutate
     /// Deprecated method, should not be maintained
     /// </summary>
-    private CsharpFolderComposite FindInputFiles(string path, string sourceProjectDir, CSharpParseOptions cSharpParseOptions, bool mutate = true)
+    private FolderComposite FindInputFiles(string path, string sourceProjectDir, CSharpParseOptions cSharpParseOptions, bool mutate = true)
     {
-
-        var folderComposite = new CsharpFolderComposite
+        var folderComposite = new FolderComposite
         {
-            FullPath = Path.GetFullPath(path),
-            RelativePath = Path.GetRelativePath(sourceProjectDir, Path.GetFullPath(path))
+            FullPath = FileSystem.Path.GetFullPath(path),
+            RelativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, FileSystem.Path.GetFullPath(path))
         };
 
-        foreach (var folder in FileSystem.Directory.EnumerateDirectories(folderComposite.FullPath).Where(x => !_foldersToExclude.Contains(Path.GetFileName(x))))
+        foreach (var folder in FileSystem.Directory.EnumerateDirectories(folderComposite.FullPath).Where(x => !_foldersToExclude.Contains(FileSystem.Path.GetFileName(x))))
         {
             folderComposite.Add(FindInputFiles(folder, sourceProjectDir, cSharpParseOptions, mutate));
         }
@@ -207,7 +208,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
             {
                 SourceCode = FileSystem.File.ReadAllText(file),
                 FullPath = file,
-                RelativePath = Path.GetRelativePath(sourceProjectDir, file)
+                RelativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, file)
             };
 
             // Get the syntax tree for the source file
@@ -228,7 +229,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
         return folderComposite;
     }
 
-    private void InjectMutantHelpers(CsharpFolderComposite rootFolderComposite, CSharpParseOptions cSharpParseOptions)
+    private void InjectMutantHelpers(FolderComposite rootFolderComposite, CSharpParseOptions cSharpParseOptions)
     {
         foreach (var (name, code) in _projectInfo.CodeInjector.MutantHelpers)
         {
@@ -237,7 +238,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
     }
 
     // get the FolderComposite object representing the project's folder 'targetFolder'. Build the needed FolderComposite(s) for a complete path
-    private CsharpFolderComposite GetOrBuildFolderComposite(IDictionary<string, CsharpFolderComposite> cache, string targetFolder, string sourceProjectDir, ProjectComponent<SyntaxTree> inputFiles)
+    private FolderComposite GetOrBuildFolderComposite(Dictionary<string, FolderComposite> cache, string targetFolder, string sourceProjectDir, FolderComposite inputFiles)
     {
         if (cache.TryGetValue(targetFolder, out var composite))
         {
@@ -245,7 +246,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
         }
 
         var folder = targetFolder;
-        CsharpFolderComposite subDir = null;
+        FolderComposite subDir = null;
         // build the cache recursively (in reverse order)
         while (!string.IsNullOrEmpty(folder))
         {
@@ -258,10 +259,10 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
 
             // we have not scanned this folder yet
             var fullPath = FileSystem.Path.Combine(sourceProjectDir, folder);
-            var newComposite = new CsharpFolderComposite
+            var newComposite = new FolderComposite
             {
                 FullPath = fullPath,
-                RelativePath = Path.GetRelativePath(sourceProjectDir, fullPath),
+                RelativePath = FileSystem.Path.GetRelativePath(sourceProjectDir, fullPath),
             };
             if (subDir == null)
             {
@@ -280,7 +281,7 @@ public class CsharpProjectComponentsBuilder : ProjectComponentsBuilder
             if (string.IsNullOrEmpty(folder))
             {
                 // we are at root
-                (inputFiles as IFolderComposite).Add(subDir);
+                inputFiles.Add(subDir);
             }
         }
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -96,7 +96,7 @@ public class InitialisationProcess : IInitialisationProcess
                     testProjects.Count);
 
                 _initialBuildProcess.InitialBuild(
-                    testProjects[i].TargetsFullFramework(),
+                    testProjects[i].TargetsClassicFramework(),
                     testProjects[i].ProjectFilePath,
                     options.SolutionPath,
                     testProjects[i].GetProperty("Configuration"),

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InitialisationProcess.cs
@@ -74,7 +74,7 @@ public class InitialisationProcess : IInitialisationProcess
         // we build the whole solution if we have a solution file path, even in project mode
         if (!string.IsNullOrEmpty(solutionFilePath))
         {
-            var framework = projects.Any(p => p.IsFullFramework);
+            var framework = projects.Any(p => p.AnalyzerResult.TargetsDesktop());
             // Build the complete solution
             _logger.LogInformation("Building solution {SolutionPathName}.", FileSystem.Path.GetRelativePath(options.WorkingDirectory, solutionFilePath));
 
@@ -96,7 +96,7 @@ public class InitialisationProcess : IInitialisationProcess
                     testProjects.Count);
 
                 _initialBuildProcess.InitialBuild(
-                    testProjects[i].TargetsClassicFramework(),
+                    testProjects[i].TargetsDesktop(),
                     testProjects[i].ProjectFilePath,
                     options.SolutionPath,
                     testProjects[i].GetProperty("Configuration"),

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -494,7 +494,7 @@ public class InputFileResolver : IInputFileResolver
     private IAnalyzerResults RetryBuild(IProjectAnalyzer project, IStrykerOptions options, string projectLogName,
         IAnalyzerResults buildResult, out bool buildResultOverallSuccess)
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT && buildResult.Any(r => !r.IsValid() && r.TargetsFullFramework()))
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT && buildResult.Any(r => !r.IsValid() && r.TargetsClassicFramework()))
         {
             _logger.LogWarning("Project {projectFilePath} analysis failed. Stryker will retry after a nuget restore.", projectLogName);
 
@@ -624,7 +624,7 @@ public class InputFileResolver : IInputFileResolver
 
         IAnalyzerResult PickFrameworkVersion()
         {
-            return validResults.Find(a => a.Succeeded && !a.TargetsFullFramework()) ?? validResults[0];
+            return validResults.Find(a => a.Succeeded && !a.TargetsClassicFramework()) ?? validResults[0];
         }
     }
 

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -494,7 +494,7 @@ public class InputFileResolver : IInputFileResolver
     private IAnalyzerResults RetryBuild(IProjectAnalyzer project, IStrykerOptions options, string projectLogName,
         IAnalyzerResults buildResult, out bool buildResultOverallSuccess)
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT && buildResult.Any(r => !r.IsValid() && r.TargetsClassicFramework()))
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT && buildResult.Any(r => !r.IsValid() && r.TargetsDesktop()))
         {
             _logger.LogWarning("Project {projectFilePath} analysis failed. Stryker will retry after a nuget restore.", projectLogName);
 
@@ -624,7 +624,7 @@ public class InputFileResolver : IInputFileResolver
 
         IAnalyzerResult PickFrameworkVersion()
         {
-            return validResults.Find(a => a.Succeeded && !a.TargetsClassicFramework()) ?? validResults[0];
+            return validResults.Find(a => a.Succeeded && !a.TargetsDesktop()) ?? validResults[0];
         }
     }
 

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -38,12 +38,13 @@ public class CsharpMutationProcess : IMutationProcess
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
 
+        var semanticModels = projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().ToDictionary(x => x, x => compilingProcess.GetSemanticModel(x.SyntaxTree));
         // Mutate source files
-        foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())
+        foreach (var file in semanticModels.Keys)
         {
             _logger.LogDebug("Mutating {FilePath}", file.SyntaxTree.FilePath);
             // Mutate the syntax tree
-            var mutatedSyntaxTree = orchestrator.Mutate(file.SyntaxTree, compilingProcess.GetSemanticModel(file.SyntaxTree));
+            var mutatedSyntaxTree = orchestrator.Mutate(file.SyntaxTree, semanticModels[file]);
             // Add the mutated syntax tree for compilation
             file.MutatedSyntaxTree = mutatedSyntaxTree;
             if (_options.DiagMode)

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -37,14 +37,13 @@ public class CsharpMutationProcess : IMutationProcess
         var projectInfo = (ProjectComponent) input.SourceProjectInfo.ProjectContents;
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
-        var semanticModels =  compilingProcess.GetSemanticModels(projectInfo.CompilationSyntaxTrees);
 
         // Mutate source files
         foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())
         {
-            _logger.LogDebug("Mutating {FilePath}", file.FullPath);
+            _logger.LogDebug("Mutating {FilePath}", file.SyntaxTree.FilePath);
             // Mutate the syntax tree
-            var mutatedSyntaxTree = orchestrator.Mutate(file.SyntaxTree, semanticModels.First(x => x.SyntaxTree == file.SyntaxTree));
+            var mutatedSyntaxTree = orchestrator.Mutate(file.SyntaxTree, compilingProcess.GetSemanticModel(file.SyntaxTree));
             // Add the mutated syntax tree for compilation
             file.MutatedSyntaxTree = mutatedSyntaxTree;
             if (_options.DiagMode)
@@ -54,6 +53,7 @@ public class CsharpMutationProcess : IMutationProcess
             }
             // Filter the mutants
             file.Mutants = orchestrator.GetLatestMutantBatch();
+            compilingProcess.UpdateFile(file.SyntaxTree, file.MutatedSyntaxTree);
         }
 
         _logger.LogDebug("{MutantsCount} mutants created", projectInfo.Mutants.Count());
@@ -68,7 +68,7 @@ public class CsharpMutationProcess : IMutationProcess
         using var ms = new MemoryStream();
         using var msForSymbols = _options.DiagMode ? new MemoryStream() : null;
         // compile the mutated syntax trees
-        var compileResult = compilingProcess.Compile(projectInfo.CompilationSyntaxTrees, ms, msForSymbols);
+        var compileResult = compilingProcess.Compile(ms, msForSymbols);
 
         foreach (var testProject in info.TestProjectsInfo.AnalyzerResults)
         {
@@ -94,21 +94,23 @@ public class CsharpMutationProcess : IMutationProcess
             _logger.LogDebug("Injected the mutated assembly file into {InjectionPath}", injectionPath);
         }
 
-        // if a rollback took place, mark the rolled back mutants as status:BuildError
-        if (compileResult.RollbackedIds.Any())
+        if (!compileResult.RolledbackIds.Any())
         {
-            foreach (var mutant in projectInfo.Mutants
-                .Where(x => compileResult.RollbackedIds.Contains(x.Id)))
-            {
-                // Ignore compilation errors if the mutation is skipped anyways.
-                if (mutant.ResultStatus == MutantStatus.Ignored)
-                {
-                    continue;
-                }
+            return;
+        }
 
-                mutant.ResultStatus = MutantStatus.CompileError;
-                mutant.ResultStatusReason = "Mutant caused compile errors";
+        // if a rollback took place, mark the rolled back mutants as status:BuildError
+        foreach (var mutant in projectInfo.Mutants
+                     .Where(x => compileResult.RolledbackIds.Contains(x.Id)))
+        {
+            // Ignore compilation errors if the mutation is skipped anyway.
+            if (mutant.ResultStatus == MutantStatus.Ignored)
+            {
+                continue;
             }
+
+            mutant.ResultStatus = MutantStatus.CompileError;
+            mutant.ResultStatusReason = "Mutant caused compile errors";
         }
     }
 

--- a/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/CsharpMutationProcess.cs
@@ -34,10 +34,10 @@ public class CsharpMutationProcess : IMutationProcess
     public void Mutate(MutationTestInput input, IStrykerOptions options)
     {
         _options = options;
-        var projectInfo = input.SourceProjectInfo.ProjectContents;
+        var projectInfo = (ProjectComponent) input.SourceProjectInfo.ProjectContents;
         var orchestrator = new CsharpMutantOrchestrator(new MutantPlacer(input.SourceProjectInfo.CodeInjector), options: _options);
         var compilingProcess = new CsharpCompilingProcess(input, options: _options);
-        var semanticModels = compilingProcess.GetSemanticModels(projectInfo.GetAllFiles().Cast<CsharpFileLeaf>().Select(x => x.SyntaxTree));
+        var semanticModels =  compilingProcess.GetSemanticModels(projectInfo.CompilationSyntaxTrees);
 
         // Mutate source files
         foreach (var file in projectInfo.GetAllFiles().Cast<CsharpFileLeaf>())
@@ -64,7 +64,7 @@ public class CsharpMutationProcess : IMutationProcess
     private void CompileMutations(MutationTestInput input, CsharpCompilingProcess compilingProcess)
     {
         var info = input.SourceProjectInfo;
-        var projectInfo = (ProjectComponent<SyntaxTree>)info.ProjectContents;
+        var projectInfo = (ProjectComponent)info.ProjectContents;
         using var ms = new MemoryStream();
         using var msForSymbols = _options.DiagMode ? new MemoryStream() : null;
         // compile the mutated syntax trees

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
@@ -25,7 +25,7 @@ public class CsharpFileLeaf : ProjectComponent, IFileLeaf
 
     public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => [MutatedSyntaxTree ?? SyntaxTree ];
 
-    public override string ToString() => SourceCode;
+    public override string ToString() => SourceCode ?? "<empty>";
 
     public override IEnumerable<IFileLeaf> GetAllFiles() => [this];
 

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Stryker.Core.ProjectComponents.Csharp;
 
-public class CsharpFileLeaf : ProjectComponent<SyntaxTree>, IFileLeaf<SyntaxTree>
+public class CsharpFileLeaf : ProjectComponent, IFileLeaf
 {
     public string SourceCode { get; set; }
 
@@ -23,15 +23,11 @@ public class CsharpFileLeaf : ProjectComponent<SyntaxTree>, IFileLeaf<SyntaxTree
 
     public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => MutatedSyntaxTrees;
 
-    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => new List<SyntaxTree> { MutatedSyntaxTree };
+    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => [MutatedSyntaxTree ?? SyntaxTree ];
 
-    public override IEnumerable<IFileLeaf<SyntaxTree>> GetAllFiles()
-    {
-        yield return this;
-    }
+    public override string ToString() => SourceCode;
 
-    public override void Display()
-    {
-        DisplayFile(this);
-    }
+    public override IEnumerable<IFileLeaf> GetAllFiles() => [this];
+
+    public override void Display() => DisplayFile(this);
 }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFolderComposite.cs
@@ -1,9 +1,0 @@
-using Microsoft.CodeAnalysis;
-using Stryker.Abstractions.ProjectComponents;
-
-namespace Stryker.Core.ProjectComponents.Csharp;
-
-public class CsharpFolderComposite : FolderComposite<SyntaxTree>, IFolderComposite
-{
-
-}

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
@@ -33,7 +33,7 @@ public class FolderComposite : ProjectComponent, IFolderComposite
         if (child is not ProjectComponent projectComponent)
         {
             // accepts only same type
-            throw new ArgumentException("Only ProjectComponent instances can be added to the solution.");
+            throw new ArgumentException("Only ProjectComponent instances can be added to a folder.");
         }
 
         projectComponent.Parent = this;

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Stryker.Abstractions;
 using Stryker.Abstractions.ProjectComponents;
 
 namespace Stryker.Core.ProjectComponents;
 
-public class FolderComposite<T> : ProjectComponent<T>, IFolderComposite
+public class FolderComposite : ProjectComponent, IFolderComposite
 {
-    private readonly List<IReadOnlyProjectComponent> _children = [];
-    public readonly List<T> _compilationSyntaxTrees = [];
+    private readonly List<ProjectComponent> _children = [];
+    private readonly List<SyntaxTree> _compilationSyntaxTrees = [];
 
     public IEnumerable<IReadOnlyProjectComponent> Children => _children;
 
@@ -22,15 +23,21 @@ public class FolderComposite<T> : ProjectComponent<T>, IFolderComposite
     /// <summary>
     /// Add a syntax tree to this folder that is needed in compilation but should not be mutated
     /// </summary>
-    public void AddCompilationSyntaxTree(T syntaxTree) => _compilationSyntaxTrees.Add(syntaxTree);
-    public override IEnumerable<T> CompilationSyntaxTrees => _compilationSyntaxTrees.Union(ChildCompilationSyntaxTree);
-    private IEnumerable<T> ChildCompilationSyntaxTree => Children.Cast<ProjectComponent<T>>().SelectMany(c => c.CompilationSyntaxTrees);
-    public override IEnumerable<T> MutatedSyntaxTrees => Children.Cast<ProjectComponent<T>>().SelectMany(c => c.MutatedSyntaxTrees);
+    public void AddCompilationSyntaxTree(SyntaxTree syntaxTree) => _compilationSyntaxTrees.Add(syntaxTree);
+    public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => _compilationSyntaxTrees.Union(ChildCompilationSyntaxTree);
+    private IEnumerable<SyntaxTree> ChildCompilationSyntaxTree => _children.SelectMany(c => c.CompilationSyntaxTrees);
+    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => _children.SelectMany(c => c.MutatedSyntaxTrees);
 
     public void Add(IProjectComponent child)
     {
-        child.Parent = this;
-        _children.Add(child);
+        if (child is not ProjectComponent projectComponent)
+        {
+            // accepts only same type
+            return;
+        }
+
+        projectComponent.Parent = this;
+        _children.Add(projectComponent);
     }
 
     public void AddRange(IEnumerable<IProjectComponent> children)

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
@@ -33,7 +33,7 @@ public class FolderComposite : ProjectComponent, IFolderComposite
         if (child is not ProjectComponent projectComponent)
         {
             // accepts only same type
-            return;
+            throw new ArgumentException("Only ProjectComponent instances can be added to the solution.");
         }
 
         projectComponent.Parent = this;

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
 using Stryker.Abstractions.ProjectComponents;
@@ -52,6 +53,15 @@ public abstract class ProjectComponent : IProjectComponent
             m.ResultStatus is MutantStatus.Killed or MutantStatus.Timeout);
 
     /// <summary>
+    /// All syntax trees that should be a part of the compilation
+    /// </summary>
+    public abstract IEnumerable<SyntaxTree> CompilationSyntaxTrees { get; }
+    /// <summary>
+    /// Only those syntax trees that were changed by the mutation process
+    /// </summary>
+    public abstract IEnumerable<SyntaxTree> MutatedSyntaxTrees { get; }
+
+    /// <summary>
     /// Returns the mutation score for this folder / file
     /// </summary>
     /// <returns>double between 0 and 1 or NaN when no score could be calculated</returns>
@@ -73,16 +83,4 @@ public abstract class ProjectComponent : IProjectComponent
             _ => Health.Danger
         };
     }
-}
-
-public abstract class ProjectComponent<T> : ProjectComponent
-{
-    /// <summary>
-    /// All syntax trees that should be a part of the compilation
-    /// </summary>
-    public abstract IEnumerable<T> CompilationSyntaxTrees { get; }
-    /// <summary>
-    /// Only those syntax trees that were changed by the mutation process
-    /// </summary>
-    public abstract IEnumerable<T> MutatedSyntaxTrees { get; }
 }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Stryker.Abstractions;
 using Stryker.Abstractions.ProjectComponents;
 
@@ -8,7 +9,7 @@ namespace Stryker.Core.ProjectComponents;
 
 public class Solution : ProjectComponent, IFolderComposite
 {
-    private readonly IList<IReadOnlyProjectComponent> _children = new List<IReadOnlyProjectComponent>();
+    private readonly IList<ProjectComponent> _children = new List<ProjectComponent>();
 
     public IEnumerable<IReadOnlyProjectComponent> Children => _children;
 
@@ -18,7 +19,14 @@ public class Solution : ProjectComponent, IFolderComposite
         set => throw new NotSupportedException("Folders do not contain mutants.");
     }
 
-    public void Add(IProjectComponent child) => _children.Add(child);
+    public void Add(IProjectComponent child)
+    {
+        if (child is not ProjectComponent projectComponent)
+        {
+            return;
+        }
+        _children.Add(projectComponent);
+    }
 
     public void AddRange(IEnumerable<IProjectComponent> children)
     {
@@ -37,6 +45,9 @@ public class Solution : ProjectComponent, IFolderComposite
             child.Display();
         }
     }
+
+    public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => _children.SelectMany(c => c.CompilationSyntaxTrees);
+    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees=> _children.SelectMany(c => c.MutatedSyntaxTrees);
 
     public override IEnumerable<IFileLeaf> GetAllFiles() => Children.SelectMany(x => x.GetAllFiles());
 }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
@@ -23,7 +23,7 @@ public class Solution : ProjectComponent, IFolderComposite
     {
         if (child is not ProjectComponent projectComponent)
         {
-            return;
+            throw new ArgumentException("Only ProjectComponent instances can be added to the solution.");
         }
         _children.Add(projectComponent);
     }
@@ -47,7 +47,8 @@ public class Solution : ProjectComponent, IFolderComposite
     }
 
     public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => _children.SelectMany(c => c.CompilationSyntaxTrees);
-    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees=> _children.SelectMany(c => c.MutatedSyntaxTrees);
+
+    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => _children.SelectMany(c => c.MutatedSyntaxTrees);
 
     public override IEnumerable<IFileLeaf> GetAllFiles() => Children.SelectMany(x => x.GetAllFiles());
 }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
@@ -30,7 +30,7 @@ public class SourceProjectInfo : IProjectAndTests
     /// </summary>
     public IReadOnlyProjectComponent ProjectContents { get; set; }
 
-    public bool IsFullFramework => AnalyzerResult.TargetsFullFramework();
+    public bool IsFullFramework => AnalyzerResult.TargetsClassicFramework();
 
     public string HelperNamespace => CodeInjector.HelperNamespace;
 

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/SourceProjectInfo.cs
@@ -30,8 +30,6 @@ public class SourceProjectInfo : IProjectAndTests
     /// </summary>
     public IReadOnlyProjectComponent ProjectContents { get; set; }
 
-    public bool IsFullFramework => AnalyzerResult.TargetsClassicFramework();
-
     public string HelperNamespace => CodeInjector.HelperNamespace;
 
     public CodeInjection CodeInjector { get; } = new();

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -143,14 +143,17 @@ public class StrykerRunner : IStrykerRunner
 
     private void AnalyzeCoverage(IStrykerOptions options)
     {
-        if (options.OptimizationMode.HasFlag(OptimizationModes.SkipUncoveredMutants) || options.OptimizationMode.HasFlag(OptimizationModes.CoverageBasedTest))
+        if (!options.OptimizationMode.HasFlag(OptimizationModes.SkipUncoveredMutants) &&
+            !options.OptimizationMode.HasFlag(OptimizationModes.CoverageBasedTest))
         {
-            _logger.LogInformation("Capture mutant coverage using '{OptimizationMode}' mode.", options.OptimizationMode);
+            return;
+        }
 
-            foreach (var project in _mutationTestProcesses)
-            {
-                project.GetCoverage();
-            }
+        _logger.LogInformation("Capture mutant coverage using '{OptimizationMode}' mode.", options.OptimizationMode);
+
+        foreach (var project in _mutationTestProcesses)
+        {
+            project.GetCoverage();
         }
     }
 
@@ -177,6 +180,6 @@ public class StrykerRunner : IStrykerRunner
             return rootComponent;
         }
 
-        return projectComponents.FirstOrDefault();
+        return projectComponents.First();
     }
 }

--- a/src/Stryker.TestRunner.VsTest.UnitTest/VsTestMockingHelper.cs
+++ b/src/Stryker.TestRunner.VsTest.UnitTest/VsTestMockingHelper.cs
@@ -23,6 +23,7 @@ using Stryker.Core.CoverageAnalysis;
 using Stryker.Core.Initialisation;
 using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
@@ -104,7 +105,7 @@ public class VsTestMockingHelper : TestBase
 
     internal SourceProjectInfo BuildSourceProjectInfo(IEnumerable<Mutant> mutants = null)
     {
-        var content = new CsharpFolderComposite();
+        var content = new FolderComposite();
         content.Add(new CsharpFileLeaf { Mutants = mutants ?? new[] { Mutant, OtherMutant } });
         return new SourceProjectInfo
         {

--- a/src/Stryker.TestRunner.VsTest.UnitTest/VsTextContextInformationTests.cs
+++ b/src/Stryker.TestRunner.VsTest.UnitTest/VsTextContextInformationTests.cs
@@ -13,9 +13,9 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Moq;
 using Serilog.Events;
 using Shouldly;
-using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
 using Stryker.Configuration.Options;
+using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Core.UnitTest;
@@ -63,7 +63,7 @@ public class VsTextContextInformationTests : TestBase
         var firstTest = BuildCase("T0");
         var secondTest = BuildCaseMsTest("T1");
 
-        var content = new CsharpFolderComposite();
+        var content = new FolderComposite();
         _fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
             { projectUnderTestPath, new MockFileData(DefaultTestProjectFileContents)},

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -25,7 +25,7 @@ public static class IAnalyzerResultCSharpExtensions
             .WithSpecificDiagnosticOptions(analyzerResult.GetDiagnosticOptions())
             .WithWarningLevel(analyzerResult.GetWarningLevel());
 
-        if (analyzerResult.IsSignedAssembly() && analyzerResult.GetAssemblyOriginatorKeyFile() is var keyFile && keyFile is not null)
+        if (analyzerResult.IsSignedAssembly() && analyzerResult.GetAssemblyOriginatorKeyFile() is var keyFile&& keyFile is not null)
         {
             compilationOptions = compilationOptions.WithCryptoKeyFile(keyFile)
                 .WithStrongNameProvider(new DesktopStrongNameProvider())
@@ -34,37 +34,26 @@ public static class IAnalyzerResultCSharpExtensions
         return compilationOptions;
     }
 
-    public static CSharpParseOptions GetParseOptions(this IAnalyzerResult analyzerResult, IStrykerOptions options)
-    {
-        var parseOptions = new CSharpParseOptions(
+    public static CSharpParseOptions GetParseOptions(this IAnalyzerResult analyzerResult, IStrykerOptions options) =>
+        new CSharpParseOptions(
             options.LanguageVersion,
             DocumentationMode.None,
             preprocessorSymbols: analyzerResult.PreprocessorSymbols
-        );
-
-        var features = ExtractCSharpFeatures(analyzerResult);
-
-        if (features.Count > 0)
-        {
-            parseOptions = parseOptions.WithFeatures(features);
-        }
-
-        return parseOptions;
-    }
+        ).WithFeatures(ExtractCSharpFeatures(analyzerResult));
 
     /// <summary>
-    /// The <Features> MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
+    /// The Features> MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
     /// It is not publicly documented by Microsoft as it is primarily intended for internal compiler development.
     /// Interceptors are a use case relying on this mechanism, using the features InterceptorsNamespaces and InterceptorsPreviewNamespaces.
     ///
     /// About the Interceptors:
-    /// 
+    ///
     /// This feature allow the user to specify namespaces that should be considered as containing interceptor types.
     /// This is necessary for the Roslyn compiler to properly handle them during compilation and enable the associated features and behaviors.
-    /// 
+    ///
     /// Here is a doc explaining the interceptors feature:
     /// https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md.
-    /// 
+    ///
     /// And here is the part where the user configure the namespaces which are allowed to use interceptors in their project file:
     /// https://github.com/dotnet/roslyn/blob/main/docs/features/interceptors.md#user-opt-in
     /// </summary>

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -25,7 +25,7 @@ public static class IAnalyzerResultCSharpExtensions
             .WithSpecificDiagnosticOptions(analyzerResult.GetDiagnosticOptions())
             .WithWarningLevel(analyzerResult.GetWarningLevel());
 
-        if (analyzerResult.IsSignedAssembly() && analyzerResult.GetAssemblyOriginatorKeyFile() is var keyFile&& keyFile is not null)
+        if (analyzerResult.IsSignedAssembly() && analyzerResult.GetAssemblyOriginatorKeyFile() is { } keyFile)
         {
             compilationOptions = compilationOptions.WithCryptoKeyFile(keyFile)
                 .WithStrongNameProvider(new DesktopStrongNameProvider())
@@ -42,7 +42,7 @@ public static class IAnalyzerResultCSharpExtensions
         ).WithFeatures(ExtractCSharpFeatures(analyzerResult));
 
     /// <summary>
-    /// The Features> MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
+    /// The Features MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
     /// It is not publicly documented by Microsoft as it is primarily intended for internal compiler development.
     /// Interceptors are a use case relying on this mechanism, using the features InterceptorsNamespaces and InterceptorsPreviewNamespaces.
     ///

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -48,7 +48,7 @@ public static class IAnalyzerResultCSharpExtensions
     ///
     /// About the Interceptors:
     ///
-    /// This feature allow the user to specify namespaces that should be considered as containing interceptor types.
+    /// This feature allows the user to specify namespaces that should be considered as containing interceptor types.
     /// This is necessary for the Roslyn compiler to properly handle them during compilation and enable the associated features and behaviors.
     ///
     /// Here is a doc explaining the interceptors feature:

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -88,7 +88,7 @@ public static class IAnalyzerResultExtensions
     }
 
     public static IEnumerable<AdditionalText> GetAdditionalTexts(this IAnalyzerResult result) =>
-        result.AdditionalFiles.Select(additionalFile => new AdditionalTextFromFile(additionalFile)).Cast<AdditionalText>();
+        result.AdditionalFiles?.Select(additionalFile => new AdditionalTextFromFile(additionalFile)) ?? [];
 
     // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
     private sealed class AdditionalFile(string text) : SourceText

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -87,13 +87,8 @@ public static class IAnalyzerResultExtensions
         return generators;
     }
 
-    public static IEnumerable<AdditionalText> GetAdditionalTexts(this IAnalyzerResult result)
-    {
-        foreach (var additionalFile in result.AdditionalFiles)
-        {
-            yield return new AdditionalTextFromFile(additionalFile);
-        }
-    }
+    public static IEnumerable<AdditionalText> GetAdditionalTexts(this IAnalyzerResult result) =>
+        result.AdditionalFiles.Select(additionalFile => new AdditionalTextFromFile(additionalFile)).Cast<AdditionalText>();
 
     // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
     private sealed class AdditionalFile(string text) : SourceText
@@ -107,6 +102,7 @@ public static class IAnalyzerResultExtensions
         }
 
         public override Encoding? Encoding => null;
+
         public override int Length => text.Length;
 
         public override char this[int position] => text[position];
@@ -115,9 +111,15 @@ public static class IAnalyzerResultExtensions
     // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
     private sealed class AdditionalTextFromFile(string path) : AdditionalText
     {
-        public override SourceText? GetText(CancellationToken cancellationToken = default) => new AdditionalFile(File.ReadAllText(Path));
+        private readonly Lazy<string> _source = new(() => File.ReadAllText(path));
 
-        public override string Path { get; } = path;
+        public override SourceText? GetText(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return new AdditionalFile(_source.Value);
+        }
+
+        public override string Path => path;
     }
 
     [ExcludeFromCodeCoverage(Justification = "Impossible to unit test")]
@@ -176,7 +178,7 @@ public static class IAnalyzerResultExtensions
         throw new InputException(message);
     }
 
-    public static bool TargetsFullFramework(this IAnalyzerResult analyzerResult) => analyzerResult.GetNuGetFramework()?.IsDesktop() == true;
+    public static bool TargetsClassicFramework(this IAnalyzerResult analyzerResult) => analyzerResult.GetNuGetFramework()?.IsDesktop() == true;
 
     public static Language GetLanguage(this IAnalyzerResult analyzerResult) =>
         analyzerResult.GetPropertyOrDefault("Language") switch

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -160,7 +160,7 @@ public static class IAnalyzerResultExtensions
         throw new InputException(message);
     }
 
-    public static bool TargetsClassicFramework(this IAnalyzerResult analyzerResult) => analyzerResult.GetNuGetFramework()?.IsDesktop() == true;
+    public static bool TargetsDesktop(this IAnalyzerResult analyzerResult) => analyzerResult.GetNuGetFramework()?.IsDesktop() == true;
 
     public static Language GetLanguage(this IAnalyzerResult analyzerResult) =>
         analyzerResult.GetPropertyOrDefault("Language") switch

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -91,24 +91,6 @@ public static class IAnalyzerResultExtensions
         result.AdditionalFiles?.Select(additionalFile => new AdditionalTextFromFile(additionalFile)) ?? [];
 
     // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
-    private sealed class AdditionalFile(string text) : SourceText
-    {
-        public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
-        {
-            for (var i = 0; i < count; i++)
-            {
-                destination[i+destinationIndex] = text[i + sourceIndex];
-            }
-        }
-
-        public override Encoding? Encoding => null;
-
-        public override int Length => text.Length;
-
-        public override char this[int position] => text[position];
-    }
-
-    // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
     private sealed class AdditionalTextFromFile(string path) : AdditionalText
     {
         private readonly Lazy<string> _source = new(() => File.ReadAllText(path));
@@ -116,7 +98,7 @@ public static class IAnalyzerResultExtensions
         public override SourceText? GetText(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return new AdditionalFile(_source.Value);
+            return SourceText.From(_source.Value, Encoding.UTF8);
         }
 
         public override string Path => path;

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -95,7 +95,8 @@ public static class IAnalyzerResultExtensions
         }
     }
 
-    private class AdditionalFile(string text) : SourceText
+    // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
+    private sealed class AdditionalFile(string text) : SourceText
     {
         public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
         {
@@ -111,9 +112,10 @@ public static class IAnalyzerResultExtensions
         public override char this[int position] => text[position];
     }
 
-    private class AdditionalTextFromFile(string path) : AdditionalText
+    // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
+    private sealed class AdditionalTextFromFile(string path) : AdditionalText
     {
-        public override SourceText? GetText(CancellationToken _ = new()) => new AdditionalFile(File.ReadAllText(Path));
+        public override SourceText? GetText(CancellationToken cancellationToken = default) => new AdditionalFile(File.ReadAllText(Path));
 
         public override string Path { get; } = path;
     }

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -5,9 +5,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using System.Threading;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using NuGet.Frameworks;
 using Stryker.Abstractions;
@@ -82,6 +85,37 @@ public static class IAnalyzerResultExtensions
         }
 
         return generators;
+    }
+
+    public static IEnumerable<AdditionalText> GetAdditionalTexts(this IAnalyzerResult result)
+    {
+        foreach (var additionalFile in result.AdditionalFiles)
+        {
+            yield return new AdditionalTextFromFile(additionalFile);
+        }
+    }
+
+    private class AdditionalFile(string text) : SourceText
+    {
+        public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                destination[i+destinationIndex] = text[i + sourceIndex];
+            }
+        }
+
+        public override Encoding? Encoding => null;
+        public override int Length => text.Length;
+
+        public override char this[int position] => text[position];
+    }
+
+    private class AdditionalTextFromFile(string path) : AdditionalText
+    {
+        public override SourceText? GetText(CancellationToken _ = new()) => new AdditionalFile(File.ReadAllText(Path));
+
+        public override string Path { get; } = path;
     }
 
     [ExcludeFromCodeCoverage(Justification = "Impossible to unit test")]


### PR DESCRIPTION
# Status
I view this PR as ready for merge

# Overview
Significant upgrade for CodeGenerators:

- Support additional files (used as templates/descriptions for code generators)
- Ensure code generators are properly ran when rolling back mutations
- Ensure generated code is included in the semantic model
Workflow appears to be more consistent with incremental compilation logic so it could bring some performance improvements.

# Expected benefits
- will fix mutation step failures for project relying on code generators (e.g. Blazor/razor)
- improve Stryker support for said projects

## Minor changes
- removed remnants of F# tentative support (removal of some generic classes)

## Fixes
Should fix mysterious compilation errors that some people faced
FIx most issues related code generators:
#3599, #3605, #2445, #3096 


