### PR TITLE
feat(baseline)!: baseline disk provider now follows output path option

### DIFF
--- a/src/Stryker.Abstractions/Options/IStrykerOptions.cs
+++ b/src/Stryker.Abstractions/Options/IStrykerOptions.cs
@@ -15,6 +15,7 @@ public interface IStrykerOptions
     string S3Endpoint { get; init; }
     string S3Region { get; init; }
     BaselineProvider BaselineProvider { get; init; }
+    string BaselineOutputPath { get; init; }
     bool BreakOnInitialTestFailure { get; set; }
     int Concurrency { get; init; }
     string Configuration { get; init; }

--- a/src/Stryker.CLI/Stryker.CLI.UnitTest/Logging/InputBuilderTests.cs
+++ b/src/Stryker.CLI/Stryker.CLI.UnitTest/Logging/InputBuilderTests.cs
@@ -27,7 +27,8 @@ public class InputBuilderTests
         var gitIgnoreFile =
             fileSystemMock.AllFiles.Single(x => x.EndsWith(Path.Combine(".gitignore")));
         gitIgnoreFile.ShouldNotBeNull();
-        DateTime.TryParse(Directory.GetParent(gitIgnoreFile)!.Name.Split(".")[0], out _).ShouldBeTrue();
+        // the gitignore lives at the stable output root, not the per-run timestamped folder
+        Directory.GetParent(gitIgnoreFile)!.Name.ShouldBe("StrykerOutput");
         var fileContents = fileSystemMock.GetFile(gitIgnoreFile).Contents;
         Encoding.Default.GetString(fileContents).ShouldBe("*");
     }
@@ -66,5 +67,37 @@ public class InputBuilderTests
         gitIgnoreFile.ShouldNotBeNull();
         var fileContents = fileSystemMock.GetFile(gitIgnoreFile).Contents;
         Encoding.Default.GetString(fileContents).ShouldBe("*");
+    }
+
+    [TestMethod]
+    public void ShouldSetBaselineOutputToStableRoot()
+    {
+        var fileSystemMock = new MockFileSystem();
+        var basePath = Directory.GetCurrentDirectory();
+        var target = new LoggingInitializer();
+
+        var inputs = new StrykerInputs();
+        inputs.BasePathInput.SuppliedInput = basePath;
+        target.SetupLogOptions(inputs, fileSystemMock);
+
+        // the baseline follows the stable output root, not the per-run timestamped output path
+        inputs.BaselineOutputInput.SuppliedInput.ShouldBe(Path.Combine(basePath, "StrykerOutput"));
+        inputs.OutputPathInput.SuppliedInput.ShouldStartWith(Path.Combine(basePath, "StrykerOutput") + Path.DirectorySeparatorChar);
+    }
+
+    [TestMethod]
+    public void ShouldSetBaselineOutputToSuppliedOutputPath()
+    {
+        var fileSystemMock = new MockFileSystem();
+        var basePath = Directory.GetCurrentDirectory();
+        var target = new LoggingInitializer();
+
+        var inputs = new StrykerInputs();
+        inputs.BasePathInput.SuppliedInput = basePath;
+        inputs.OutputPathInput.SuppliedInput = "output";
+        target.SetupLogOptions(inputs, fileSystemMock);
+
+        // an explicit output path has no timestamp subfolder, so it is the root itself
+        inputs.BaselineOutputInput.SuppliedInput.ShouldBe(Path.Combine(basePath, "output"));
     }
 }

--- a/src/Stryker.CLI/Stryker.CLI/Logging/LoggingInitializer.cs
+++ b/src/Stryker.CLI/Stryker.CLI/Logging/LoggingInitializer.cs
@@ -36,7 +36,17 @@ public class LoggingInitializer : ILoggingInitializer
 
     private string CreateOutputPath(IStrykerInputs inputs, IFileSystem fileSystem)
     {
-        var outputPath = inputs.OutputPathInput.SuppliedInput ?? Path.Combine("StrykerOutput", DateTime.Now.ToString("yyyy-MM-dd.HH-mm-ss"));
+        // The stable output root. When no output path is supplied the per-run output lives in a
+        // timestamped subfolder of this root; an explicitly supplied output path is the root itself.
+        // The root is where the disk baseline is stored (so it can be found on the next run) and
+        // where the gitignore is placed (so the baseline and all run outputs are excluded from git).
+        var outputRoot = inputs.OutputPathInput.SuppliedInput ?? "StrykerOutput";
+        var outputPath = inputs.OutputPathInput.SuppliedInput ?? Path.Combine(outputRoot, DateTime.Now.ToString("yyyy-MM-dd.HH-mm-ss"));
+
+        if (!Path.IsPathRooted(outputRoot))
+        {
+            outputRoot = Path.Combine(inputs.BasePathInput.SuppliedInput, outputRoot);
+        }
 
         if (!Path.IsPathRooted(outputPath))
         {
@@ -46,8 +56,11 @@ public class LoggingInitializer : ILoggingInitializer
         // outputpath should always be created
         fileSystem.Directory.CreateDirectory(FilePathUtils.NormalizePathSeparators(outputPath));
 
-        // add gitignore if it didn't exist yet
-        var gitignorePath = FilePathUtils.NormalizePathSeparators(Path.Combine(outputPath, ".gitignore"));
+        // store the baseline under the stable output root so it follows --output and persists across runs
+        inputs.BaselineOutputInput.SuppliedInput = outputRoot;
+
+        // add gitignore to the output root if it didn't exist yet
+        var gitignorePath = FilePathUtils.NormalizePathSeparators(Path.Combine(outputRoot, ".gitignore"));
         if (!fileSystem.File.Exists(gitignorePath))
         {
             try

--- a/src/Stryker.Configuration/Options/Inputs/BaselineOutputInput.cs
+++ b/src/Stryker.Configuration/Options/Inputs/BaselineOutputInput.cs
@@ -1,0 +1,25 @@
+using Stryker.Abstractions.Baseline;
+using Stryker.Abstractions.Exceptions;
+
+namespace Stryker.Configuration.Options.Inputs;
+
+public class BaselineOutputInput : Input<string>
+{
+    protected override string Description => "The directory the disk baseline provider stores and loads the baseline report from. Required when the disk baseline provider is selected.";
+
+    public override string Default => string.Empty;
+
+    public string Validate(BaselineProvider baselineProvider, bool withBaseline)
+    {
+        if (withBaseline && baselineProvider == BaselineProvider.Disk)
+        {
+            if (string.IsNullOrWhiteSpace(SuppliedInput))
+            {
+                throw new InputException("BaselineOutput can't be null or whitespace");
+            }
+
+            return SuppliedInput;
+        }
+        return Default;
+    }
+}

--- a/src/Stryker.Configuration/Options/Inputs/BaselineOutputInput.cs
+++ b/src/Stryker.Configuration/Options/Inputs/BaselineOutputInput.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Stryker.Abstractions.Baseline;
 using Stryker.Abstractions.Exceptions;
 
@@ -16,6 +17,11 @@ public class BaselineOutputInput : Input<string>
             if (string.IsNullOrWhiteSpace(SuppliedInput))
             {
                 throw new InputException("BaselineOutput can't be null or whitespace");
+            }
+
+            if (!Path.IsPathFullyQualified(SuppliedInput))
+            {
+                throw new InputException($"BaselineOutput must be a fully qualified path, but was: {SuppliedInput}");
             }
 
             return SuppliedInput;

--- a/src/Stryker.Configuration/Options/StrykerInputs.cs
+++ b/src/Stryker.Configuration/Options/StrykerInputs.cs
@@ -14,6 +14,7 @@ public interface IStrykerInputs
     S3RegionInput S3RegionInput { get; init; }
     AzureFileStorageUrlInput AzureFileStorageUrlInput { get; init; }
     BaselineProviderInput BaselineProviderInput { get; init; }
+    BaselineOutputInput BaselineOutputInput { get; init; }
     BasePathInput BasePathInput { get; init; }
     ConcurrencyInput ConcurrencyInput { get; init; }
     ConfigurationInput ConfigurationInput { get; init; }
@@ -90,6 +91,7 @@ public class StrykerInputs : IStrykerInputs
     public WithBaselineInput WithBaselineInput { get; init; } = new();
     public ReportersInput ReportersInput { get; init; } = new();
     public BaselineProviderInput BaselineProviderInput { get; init; } = new();
+    public BaselineOutputInput BaselineOutputInput { get; init; } = new();
     public AzureFileStorageUrlInput AzureFileStorageUrlInput { get; init; } = new();
     public AzureFileStorageSasInput AzureFileStorageSasInput { get; init; } = new();
     public S3BucketNameInput S3BucketNameInput { get; init; } = new();
@@ -175,6 +177,7 @@ public class StrykerInputs : IStrykerInputs
             S3Region = S3RegionInput.Validate(baselineProvider, withBaseline),
             WithBaseline = withBaseline,
             BaselineProvider = baselineProvider,
+            BaselineOutputPath = BaselineOutputInput.Validate(baselineProvider, withBaseline),
             FallbackVersion = FallbackVersionInput.Validate(withBaseline, projectVersion, sinceTarget),
             Since = sinceEnabled,
             SinceTarget = sinceTarget,

--- a/src/Stryker.Configuration/Options/StrykerOptions.cs
+++ b/src/Stryker.Configuration/Options/StrykerOptions.cs
@@ -159,6 +159,13 @@ public class StrykerOptions : IStrykerOptions
     public BaselineProvider BaselineProvider { get; init; }
 
     /// <summary>
+    /// The directory the disk baseline provider stores and loads the baseline report from.
+    /// A relative path is resolved against <see cref="ProjectPath"/>. Defaults to the stable
+    /// StrykerOutput folder so baselines persist across runs.
+    /// </summary>
+    public string BaselineOutputPath { get; init; }
+
+    /// <summary>
     /// The url to connect to the Azure File Storage API
     /// </summary>
     public string AzureFileStorageUrl { get; init; }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
@@ -24,7 +24,8 @@ public class DiskBaselineProviderTests : TestBase
         var fileSystemMock = new MockFileSystem();
         var options = new StrykerOptions()
         {
-            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder"
+            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
+            BaselineOutputPath = "StrykerOutput"
         };
         var sut = new DiskBaselineProvider(options, fileSystemMock);
 
@@ -39,11 +40,70 @@ public class DiskBaselineProviderTests : TestBase
     }
 
     [TestMethod]
+    public async Task ShouldWriteToConfiguredBaselineOutputPathAsync()
+    {
+        var fileSystemMock = new MockFileSystem();
+        var options = new StrykerOptions()
+        {
+            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
+            BaselineOutputPath = "custom-baseline"
+        };
+        var sut = new DiskBaselineProvider(options, fileSystemMock);
+
+        await sut.Save(JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<TestProjectsInfo>()), "baseline/version");
+
+        var path = FilePathUtils.NormalizePathSeparators(@"C:/Users/JohnDoe/Project/TestFolder/custom-baseline/baseline/version/stryker-report.json");
+
+        var file = fileSystemMock.GetFile(path);
+        file.ShouldNotBeNull();
+    }
+
+    [TestMethod]
+    public async Task ShouldWriteToAbsoluteBaselineOutputPathAsync()
+    {
+        var fileSystemMock = new MockFileSystem();
+        var options = new StrykerOptions()
+        {
+            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
+            BaselineOutputPath = @"D:/shared/baselines"
+        };
+        var sut = new DiskBaselineProvider(options, fileSystemMock);
+
+        await sut.Save(JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<TestProjectsInfo>()), "baseline/version");
+
+        var path = FilePathUtils.NormalizePathSeparators(@"D:/shared/baselines/baseline/version/stryker-report.json");
+
+        var file = fileSystemMock.GetFile(path);
+        file.ShouldNotBeNull();
+    }
+
+    [TestMethod]
+    public async Task ShouldLoadReportFromConfiguredBaselineOutputPathAsync()
+    {
+        var fileSystemMock = new MockFileSystem();
+        var options = new StrykerOptions()
+        {
+            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
+            BaselineOutputPath = "custom-baseline"
+        };
+        var report = JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<ITestProjectsInfo>());
+
+        fileSystemMock.AddFile("C:/Users/JohnDoe/Project/TestFolder/custom-baseline/baseline/version/stryker-report.json", report.ToJson());
+
+        var target = new DiskBaselineProvider(options, fileSystemMock);
+
+        var result = await target.Load("baseline/version");
+
+        result.ShouldNotBeNull();
+        result.ToJson().ShouldBe(report.ToJson());
+    }
+
+    [TestMethod]
     public async Task ShouldHandleFileNotFoundExceptionOnLoadAsync()
     {
         // Arrange
         var fileSystemMock = new MockFileSystem();
-        var options = new StrykerOptions { ProjectPath = "C:/Dev" };
+        var options = new StrykerOptions { ProjectPath = "C:/Dev", BaselineOutputPath = "StrykerOutput" };
         var sut = new DiskBaselineProvider(options, fileSystemMock);
 
         // Act
@@ -59,7 +119,8 @@ public class DiskBaselineProviderTests : TestBase
         var fileSystemMock = new MockFileSystem();
         var options = new StrykerOptions()
         {
-            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder"
+            ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
+            BaselineOutputPath = "StrykerOutput"
         };
         var report = JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<ITestProjectsInfo>());
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Baseline/Providers/DiskBaselineProviderTests.cs
@@ -25,7 +25,7 @@ public class DiskBaselineProviderTests : TestBase
         var options = new StrykerOptions()
         {
             ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
-            BaselineOutputPath = "StrykerOutput"
+            BaselineOutputPath = @"C:/Users/JohnDoe/Project/TestFolder/StrykerOutput"
         };
         var sut = new DiskBaselineProvider(options, fileSystemMock);
 
@@ -46,7 +46,7 @@ public class DiskBaselineProviderTests : TestBase
         var options = new StrykerOptions()
         {
             ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
-            BaselineOutputPath = "custom-baseline"
+            BaselineOutputPath = @"C:/Users/JohnDoe/Project/TestFolder/custom-baseline"
         };
         var sut = new DiskBaselineProvider(options, fileSystemMock);
 
@@ -84,7 +84,7 @@ public class DiskBaselineProviderTests : TestBase
         var options = new StrykerOptions()
         {
             ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
-            BaselineOutputPath = "custom-baseline"
+            BaselineOutputPath = @"C:/Users/JohnDoe/Project/TestFolder/custom-baseline"
         };
         var report = JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<ITestProjectsInfo>());
 
@@ -103,7 +103,7 @@ public class DiskBaselineProviderTests : TestBase
     {
         // Arrange
         var fileSystemMock = new MockFileSystem();
-        var options = new StrykerOptions { ProjectPath = "C:/Dev", BaselineOutputPath = "StrykerOutput" };
+        var options = new StrykerOptions { ProjectPath = "C:/Dev", BaselineOutputPath = "C:/Dev/StrykerOutput" };
         var sut = new DiskBaselineProvider(options, fileSystemMock);
 
         // Act
@@ -120,7 +120,7 @@ public class DiskBaselineProviderTests : TestBase
         var options = new StrykerOptions()
         {
             ProjectPath = @"C:/Users/JohnDoe/Project/TestFolder",
-            BaselineOutputPath = "StrykerOutput"
+            BaselineOutputPath = @"C:/Users/JohnDoe/Project/TestFolder/StrykerOutput"
         };
         var report = JsonReport.Build(options, ReportTestHelper.CreateProjectWith(), It.IsAny<ITestProjectsInfo>());
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/BaselineOutputInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/BaselineOutputInputTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using Stryker.Abstractions.Baseline;
+using Stryker.Abstractions.Exceptions;
+using Stryker.Configuration.Options.Inputs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Stryker.Core.UnitTest.Options.Inputs;
+
+[TestClass]
+public class BaselineOutputInputTests : TestBase
+{
+    [TestMethod]
+    public void ShouldHaveHelpText()
+    {
+        var target = new BaselineOutputInput();
+        target.HelpText.ShouldNotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("  ")]
+    public void ShouldThrow_WhenDiskBaselineAndNotSupplied(string input)
+    {
+        var target = new BaselineOutputInput { SuppliedInput = input };
+
+        Should.Throw<InputException>(() => target.Validate(BaselineProvider.Disk, withBaseline: true));
+    }
+
+    [TestMethod]
+    public void ShouldReturnSuppliedValue_WhenDiskBaseline()
+    {
+        var target = new BaselineOutputInput { SuppliedInput = "custom-baseline" };
+
+        var result = target.Validate(BaselineProvider.Disk, withBaseline: true);
+
+        result.ShouldBe("custom-baseline");
+    }
+
+    [TestMethod]
+    public void ShouldReturnDefault_WhenBaselineDisabled()
+    {
+        var target = new BaselineOutputInput { SuppliedInput = null };
+
+        var result = target.Validate(BaselineProvider.Disk, withBaseline: false);
+
+        result.ShouldBe(string.Empty);
+    }
+
+    [TestMethod]
+    public void ShouldReturnDefault_WhenNonDiskProvider()
+    {
+        var target = new BaselineOutputInput { SuppliedInput = null };
+
+        var result = target.Validate(BaselineProvider.Dashboard, withBaseline: true);
+
+        result.ShouldBe(string.Empty);
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/BaselineOutputInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/BaselineOutputInputTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Shouldly;
 using Stryker.Abstractions.Baseline;
 using Stryker.Abstractions.Exceptions;
@@ -30,11 +31,23 @@ public class BaselineOutputInputTests : TestBase
     [TestMethod]
     public void ShouldReturnSuppliedValue_WhenDiskBaseline()
     {
-        var target = new BaselineOutputInput { SuppliedInput = "custom-baseline" };
+        // a path that is fully qualified on whatever OS the tests run on
+        var fullPath = Path.GetFullPath("custom-baseline");
+        var target = new BaselineOutputInput { SuppliedInput = fullPath };
 
         var result = target.Validate(BaselineProvider.Disk, withBaseline: true);
 
-        result.ShouldBe("custom-baseline");
+        result.ShouldBe(fullPath);
+    }
+
+    [TestMethod]
+    [DataRow("custom-baseline")]
+    [DataRow("relative/baseline")]
+    public void ShouldThrow_WhenDiskBaselineAndNotFullyQualified(string input)
+    {
+        var target = new BaselineOutputInput { SuppliedInput = input };
+
+        Should.Throw<InputException>(() => target.Validate(BaselineProvider.Disk, withBaseline: true));
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
@@ -176,7 +176,7 @@ public class StrykerInputsTests : TestBase
         _target.BaselineProviderInput.SuppliedInput = "disk";
         _target.WithBaselineInput.SuppliedInput = true;
         _target.ProjectVersionInput.SuppliedInput = "develop";
-        _target.BaselineOutputInput.SuppliedInput = "StrykerOutput";
+        _target.BaselineOutputInput.SuppliedInput = Path.GetFullPath("StrykerOutput");
 
         var result = _target.ValidateAll();
 
@@ -198,8 +198,8 @@ public class StrykerInputsTests : TestBase
     {
         _target.ProjectVersionInput.SuppliedInput = "1";
         _target.WithBaselineInput.SuppliedInput = true;
-        // the disk baseline output is mandatory and is set from the output path by the CLI before validation
-        _target.BaselineOutputInput.SuppliedInput = "StrykerOutput";
+        // the disk baseline output is mandatory and is set from the output path (a full path) by the CLI before validation
+        _target.BaselineOutputInput.SuppliedInput = Path.GetFullPath("StrykerOutput");
 
         Should.NotThrow(() => _target.ValidateAll());
     }
@@ -226,11 +226,12 @@ public class StrykerInputsTests : TestBase
     {
         _target.ProjectVersionInput.SuppliedInput = "1";
         _target.WithBaselineInput.SuppliedInput = true;
-        _target.BaselineOutputInput.SuppliedInput = "custom-baseline";
+        var fullPath = Path.GetFullPath("custom-baseline");
+        _target.BaselineOutputInput.SuppliedInput = fullPath;
 
         var result = _target.ValidateAll();
 
-        result.BaselineOutputPath.ShouldBe("custom-baseline");
+        result.BaselineOutputPath.ShouldBe(fullPath);
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/StrykerInputsTests.cs
@@ -19,6 +19,7 @@ public class StrykerInputsTests : TestBase
         AzureFileStorageSasInput = new AzureFileStorageSasInput(),
         AzureFileStorageUrlInput = new AzureFileStorageUrlInput(),
         BaselineProviderInput = new BaselineProviderInput(),
+        BaselineOutputInput = new BaselineOutputInput(),
         BasePathInput = new BasePathInput() { SuppliedInput = Directory.GetCurrentDirectory() },
         ConcurrencyInput = new ConcurrencyInput(),
         DashboardApiKeyInput = new DashboardApiKeyInput(),
@@ -175,6 +176,7 @@ public class StrykerInputsTests : TestBase
         _target.BaselineProviderInput.SuppliedInput = "disk";
         _target.WithBaselineInput.SuppliedInput = true;
         _target.ProjectVersionInput.SuppliedInput = "develop";
+        _target.BaselineOutputInput.SuppliedInput = "StrykerOutput";
 
         var result = _target.ValidateAll();
 
@@ -196,8 +198,39 @@ public class StrykerInputsTests : TestBase
     {
         _target.ProjectVersionInput.SuppliedInput = "1";
         _target.WithBaselineInput.SuppliedInput = true;
+        // the disk baseline output is mandatory and is set from the output path by the CLI before validation
+        _target.BaselineOutputInput.SuppliedInput = "StrykerOutput";
 
         Should.NotThrow(() => _target.ValidateAll());
+    }
+
+    [TestMethod]
+    public void BaselineOutputPathShouldThrowWhenDiskBaselineAndNotSupplied()
+    {
+        _target.ProjectVersionInput.SuppliedInput = "1";
+        _target.WithBaselineInput.SuppliedInput = true;
+
+        Should.Throw<InputException>(() => _target.ValidateAll());
+    }
+
+    [TestMethod]
+    public void BaselineOutputPathShouldBeDefaultWhenBaselineDisabled()
+    {
+        var result = _target.ValidateAll();
+
+        result.BaselineOutputPath.ShouldBe(string.Empty);
+    }
+
+    [TestMethod]
+    public void ShouldSetBaselineOutputPathWhenSupplied()
+    {
+        _target.ProjectVersionInput.SuppliedInput = "1";
+        _target.WithBaselineInput.SuppliedInput = true;
+        _target.BaselineOutputInput.SuppliedInput = "custom-baseline";
+
+        var result = _target.ValidateAll();
+
+        result.BaselineOutputPath.ShouldBe("custom-baseline");
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
@@ -16,7 +16,6 @@ public class DiskBaselineProvider : IBaselineProvider
     private readonly IStrykerOptions _options;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<DiskBaselineProvider> _logger;
-    private const string _outputPath = "StrykerOutput";
 
     public DiskBaselineProvider(IStrykerOptions options, IFileSystem fileSystem = null)
     {
@@ -29,7 +28,7 @@ public class DiskBaselineProvider : IBaselineProvider
     public async Task<IJsonReport> Load(string version)
     {
         var reportPath = FilePathUtils.NormalizePathSeparators(
-            Path.Combine(_options.ProjectPath, _outputPath, version, "stryker-report.json"));
+            Path.Combine(_options.ProjectPath, _options.BaselineOutputPath, version, "stryker-report.json"));
 
         if (_fileSystem.File.Exists(reportPath))
         {
@@ -45,7 +44,7 @@ public class DiskBaselineProvider : IBaselineProvider
     public async Task Save(IJsonReport report, string version)
     {
         var reportDirectory = FilePathUtils.NormalizePathSeparators(
-            Path.Combine(_options.ProjectPath, _outputPath, version));
+            Path.Combine(_options.ProjectPath, _options.BaselineOutputPath, version));
 
         _fileSystem.Directory.CreateDirectory(reportDirectory);
 

--- a/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
+++ b/src/Stryker.Core/Stryker.Core/Baseline/Providers/DiskBaselineProvider.cs
@@ -27,8 +27,9 @@ public class DiskBaselineProvider : IBaselineProvider
 
     public async Task<IJsonReport> Load(string version)
     {
+        // at this point, BaseLineOutputPath is a fully qualified path
         var reportPath = FilePathUtils.NormalizePathSeparators(
-            Path.Combine(_options.ProjectPath, _options.BaselineOutputPath, version, "stryker-report.json"));
+            Path.Combine(_options.BaselineOutputPath, version, "stryker-report.json"));
 
         if (_fileSystem.File.Exists(reportPath))
         {
@@ -43,8 +44,9 @@ public class DiskBaselineProvider : IBaselineProvider
 
     public async Task Save(IJsonReport report, string version)
     {
+        // at this point, BaseLineOutputPath is a fully qualified path
         var reportDirectory = FilePathUtils.NormalizePathSeparators(
-            Path.Combine(_options.ProjectPath, _options.BaselineOutputPath, version));
+            Path.Combine(_options.BaselineOutputPath, version));
 
         _fileSystem.Directory.CreateDirectory(reportDirectory);
 


### PR DESCRIPTION
The disk baseline provider always writes the baseline to a hard-coded "StrykerOutput" folder under the project path. Storing the baseline inside the test project's directory is problematic: without a non-obvious workaround, Stryker flags it as a change to the test project and ignores the baseline.

The disk baseline provider now stores and loads baselines from the stable output root. If --output is supplied, the disk baseline follows that path. Without --output, the baseline remains under StrykerOutput, while individual run reports continue to use timestamped subfolders. Only the disk provider is affected; the Azure and S3 providers are untouched.

fix #3615 

BREAKING CHANGE: The disk baseline provider now follows the configured output path.

Previously, disk baselines were always stored under <project>/StrykerOutput, even when --output was configured. Disk baselines are now stored and loaded from the stable output root. With the default output this remains <project>/StrykerOutput. When --output is supplied, baselines are stored under that output directory.

If you use disk baselines in CI and cache/persist baseline files, update the cached path to match your configured --output value. Existing baselines are not migrated automatically. Stryker also writes .gitignore to the stable output root so baseline files and run outputs are ignored by default.