### PR TITLE
fix(mutators): do not mutate string literals in switch case labels and goto case

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -97,7 +97,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     }
 }
     ";
-       ShouldMutateSourceInClassToExpected(source, expected);
+        ShouldMutateSourceInClassToExpected(source, expected);
 
     }
 
@@ -687,6 +687,91 @@ var (one, two) = ((StrykerNamespace.MutantControl.IsActive(1)?1 - 1:1 + 1), (Str
     {
         var source = @"private enum Numbers { One = 1, Two = One + 1 }";
         var expected = @"private enum Numbers { One = 1, Two = One + 1 }";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    /// <summary>
+    /// Verifies that string literals inside <c>goto case</c> targets are not mutated.
+    /// A ternary expression is not a compile-time constant, so mutating would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0150">CS0150</see>.
+    /// </summary>
+    [TestMethod]
+    public void ShouldNotMutateStringInGotoCaseStatement()
+    {
+        var source = @"void TestMethod(string input)
+{
+    switch (input)
+    {
+        case ""first"":
+            goto case ""second"";
+        case ""second"":
+            break;
+    }
+}";
+        var expected = @"void TestMethod(string input)
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+    switch (input)
+    {
+        case ""first"":
+            goto case ""second"";
+        case ""second"":
+            break;
+    }
+}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    /// <summary>
+    /// Verifies that string literals inside <c>case</c> switch labels are not mutated.
+    /// A ternary expression is not a compile-time constant, so mutating would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0150">CS0150</see>.
+    /// </summary>
+    [TestMethod]
+    public void ShouldNotMutateStringInSwitchCaseLabel()
+    {
+        var source = @"void TestMethod(string input)
+{
+    switch (input)
+    {
+        case ""hello"":
+            break;
+    }
+}";
+        var expected = @"void TestMethod(string input)
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+    switch (input)
+    {
+        case ""hello"":
+            break;
+    }
+}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    /// <summary>
+    /// Verifies that string literals inside pattern-matching <c>case</c> labels (<c>case "x" when ...: </c>) are not mutated.
+    /// A ternary expression is not a compile-time constant, so mutating would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0150">CS0150</see>.
+    /// </summary>
+    [TestMethod]
+    public void ShouldNotMutateStringInCasePatternSwitchLabel()
+    {
+        var source = @"void TestMethod(string input)
+{
+    switch (input)
+    {
+        case ""hello"" when input.Length > 0:
+            break;
+    }
+}";
+        var expected = @"void TestMethod(string input)
+{if(StrykerNamespace.MutantControl.IsActive(0)){}else{
+    switch (input)
+    {
+        case ""hello"" when input.Length > 0:
+            break;
+    }
+}}";
 
         ShouldMutateSourceInClassToExpected(source, expected);
     }

--- a/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/CsharpMutantOrchestrator.cs
@@ -44,6 +44,10 @@ public class CsharpMutantOrchestrator : BaseMutantOrchestrator<SyntaxTree, Seman
         new DoNotMutateOrchestrator<ParameterListSyntax>(),
         // enum values
         new DoNotMutateOrchestrator<EnumMemberDeclarationSyntax>(),
+        // case labels (including pattern-matching labels) and goto case require compile-time constants
+        new DoNotMutateOrchestrator<CaseSwitchLabelSyntax>(),
+        new DoNotMutateOrchestrator<CasePatternSwitchLabelSyntax>(),
+        new DoNotMutateOrchestrator<GotoStatementSyntax>(t => t.IsKind(SyntaxKind.GotoCaseStatement)),
         new DoNotMutateOrchestrator<UsingDirectiveSyntax>(),
         // constants and constant fields
         new DoNotMutateOrchestrator<FieldDeclarationSyntax>(


### PR DESCRIPTION
Fixes #3623

## What
String literals inside `case` labels and `goto case` statements were being mutated by `StringMutator`, replacing them with ternary expressions. Ternary expressions are not compile-time constants, so the mutated code failed to compile with **CS0150**, aborting the mutation run.

## How
Register two new `DoNotMutateOrchestrator` rules in `CsharpMutantOrchestrator`:
- `DoNotMutateOrchestrator<CaseSwitchLabelSyntax>` — prevents mutation of all expressions in `case` labels
- `DoNotMutateOrchestrator<GotoStatementSyntax>` filtered to `GotoCaseStatement` — prevents mutation in `goto case` expressions

This is consistent with how `EnumMemberDeclarationSyntax`, attributes, and `UsingDirectiveSyntax` are already excluded.

## Tests
Added two new unit tests in `CsharpMutantOrchestratorTests`:
- `ShouldNotMutateStringInSwitchCaseLabel`
- `ShouldNotMutateStringInGotoCaseStatement`
