### PR TITLE
fix(mutators): skip block/statement removal in getter when throw is the only return path

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -97,7 +97,7 @@ namespace StrykerNet.UnitTest.Mutants.TestResources
     }
 }
     ";
-       ShouldMutateSourceInClassToExpected(source, expected);
+        ShouldMutateSourceInClassToExpected(source, expected);
 
     }
 
@@ -687,6 +687,39 @@ var (one, two) = ((StrykerNamespace.MutantControl.IsActive(1)?1 - 1:1 + 1), (Str
     {
         var source = @"private enum Numbers { One = 1, Two = One + 1 }";
         var expected = @"private enum Numbers { One = 1, Two = One + 1 }";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a <c>throw</c> statement that is the only statement in a property getter
+    /// is not replaced with an empty statement by the StatementMutator, and the getter body
+    /// is not replaced with an empty block by the BlockMutator.
+    /// Both would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0161">CS0161</see> (not all code paths return a value).
+    /// </summary>
+    [TestMethod]
+    public void ShouldNotMutateThrowStatementAsOnlyStatementInPropertyGetter()
+    {
+        var source = @"int Value { get { throw new NotImplementedException(); } }";
+        var expected = @"int Value { get { throw new NotImplementedException(); } }";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    [TestMethod]
+    public void ShouldMutateExpressionBodiedGetter()
+    {
+        var source = @"int Value { get => 1 + 2; }";
+        var expected = @"int Value { get => (StrykerNamespace.MutantControl.IsActive(0)?1 - 2:1 + 2); }";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    [TestMethod]
+    public void ShouldMutateThrowStatementWhenReturnPrecedesItInPropertyGetter()
+    {
+        var source = @"int Value { get { return 1; throw new NotImplementedException(); } }";
+        var expected = @"int Value { get {if(StrykerNamespace.MutantControl.IsActive(0)){}else{return 1;if(StrykerNamespace.MutantControl.IsActive(1)){;}else{throw new NotImplementedException();}}return default(int);}}";
 
         ShouldMutateSourceInClassToExpected(source, expected);
     }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/CsharpMutantOrchestratorTests.cs
@@ -724,6 +724,32 @@ var (one, two) = ((StrykerNamespace.MutantControl.IsActive(1)?1 - 1:1 + 1), (Str
         ShouldMutateSourceInClassToExpected(source, expected);
     }
 
+    /// <summary>
+    /// A non-void method with only a throw is handled by the rollback process, so the throw should still be mutated.
+    /// </summary>
+    [TestMethod]
+    public void ShouldMutateThrowStatementAsOnlyStatementInNonVoidMethod()
+    {
+        var source = @"public int SomeMethod() { throw new NotImplementedException(); }";
+        // No return default(int) here: EndingReturnEngine only injects it when the block already contains a return statement.
+        // CS0161 for the empty-block mutant is caught and rolled back during compilation.
+        var expected = @"public int SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(0)){}else{if(StrykerNamespace.MutantControl.IsActive(1)){;}else{throw new NotImplementedException();}}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
+    /// <summary>
+    /// An async Task method does not require an explicit return, so a throw inside should be mutated normally.
+    /// </summary>
+    [TestMethod]
+    public void ShouldMutateThrowStatementAsOnlyStatementInAsyncTaskMethod()
+    {
+        var source = @"public async System.Threading.Tasks.Task SomeMethod() { throw new NotImplementedException(); }";
+        var expected = @"public async System.Threading.Tasks.Task SomeMethod() {if(StrykerNamespace.MutantControl.IsActive(0)){}else{if(StrykerNamespace.MutantControl.IsActive(1)){;}else{throw new NotImplementedException();}}}";
+
+        ShouldMutateSourceInClassToExpected(source, expected);
+    }
+
     [TestMethod]
     public void ShouldNotMutateAttributes()
     {

--- a/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
@@ -19,7 +19,7 @@ public class BlockMutator : MutatorBase<BlockSyntax>
         if (node.IsEmpty() ||
             IsInfiniteWhileLoop(node) ||
             CantBeMutated(node) ||
-            IsBodyWithoutReturnOfNonVoidMember(node))
+            IsGetterBodyWithoutReturn(node))
         {
             yield break;
         }
@@ -69,7 +69,7 @@ public class BlockMutator : MutatorBase<BlockSyntax>
     /// adding <c>return default</c> when there are no return statements in the block.
     /// For methods, CS0161 is handled by the rollback process; for getters it falls to safe mode.
     /// </summary>
-    private static bool IsBodyWithoutReturnOfNonVoidMember(BlockSyntax node) =>
+    private static bool IsGetterBodyWithoutReturn(BlockSyntax node) =>
         node.Parent is AccessorDeclarationSyntax { RawKind: (int)SyntaxKind.GetAccessorDeclaration }
         && !node.ScanChildStatements(s => s.IsKind(SyntaxKind.ReturnStatement));
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/BlockMutator.cs
@@ -18,7 +18,8 @@ public class BlockMutator : MutatorBase<BlockSyntax>
     {
         if (node.IsEmpty() ||
             IsInfiniteWhileLoop(node) ||
-            CantBeMutated(node))
+            CantBeMutated(node) ||
+            IsBodyWithoutReturnOfNonVoidMember(node))
         {
             yield break;
         }
@@ -60,4 +61,15 @@ public class BlockMutator : MutatorBase<BlockSyntax>
 
         return false;
     }
+
+    /// <summary>
+    /// Returns true when the block is the direct body of a property getter and contains no return statements.
+    /// Replacing it with an empty block would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0161">CS0161</see>
+    /// because the injected if-true branch would have no return value, and <see cref="EndingReturnEngine"/> skips
+    /// adding <c>return default</c> when there are no return statements in the block.
+    /// For methods, CS0161 is handled by the rollback process; for getters it falls to safe mode.
+    /// </summary>
+    private static bool IsBodyWithoutReturnOfNonVoidMember(BlockSyntax node) =>
+        node.Parent is AccessorDeclarationSyntax { RawKind: (int)SyntaxKind.GetAccessorDeclaration }
+        && !node.ScanChildStatements(s => s.IsKind(SyntaxKind.ReturnStatement));
 }

--- a/src/Stryker.Core/Stryker.Core/Mutators/StatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StatementMutator.cs
@@ -80,9 +80,10 @@ public class StatementMutator : MutatorBase<StatementSyntax>
             yield break;
         }
 
-        // a throw that is the only statement in a getter/method body that requires a return value
-        // would leave the member with no valid code path, causing CS0161
-        if (node is ThrowStatementSyntax && IsOnlyControlFlowInMemberRequiringReturn(node))
+        // a throw that is the only top-level terminating statement in a getter body
+        // would leave the getter with no valid code path, causing CS0161
+        // (for non-void methods CS0161 is handled by the rollback process)
+        if (node is ThrowStatementSyntax && IsOnlyControlFlowInGetterRequiringReturn(node))
         {
             yield break;
         }
@@ -116,22 +117,17 @@ public class StatementMutator : MutatorBase<StatementSyntax>
     }
 
     /// <summary>
-    /// Returns true when the throw is the only statement that provides control flow in a member
-    /// that must return a value (non-void method, property getter, indexer getter).
+    /// Returns true when the throw is the only top-level terminating statement in a property getter body.
     /// Replacing it with an empty statement would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0161">CS0161</see>.
+    /// For non-void methods the same error is handled by the rollback process.
     /// </summary>
-    private static bool IsOnlyControlFlowInMemberRequiringReturn(StatementSyntax node)
+    private static bool IsOnlyControlFlowInGetterRequiringReturn(StatementSyntax node)
     {
         if (node.Parent is BlockSyntax parentBlock)
         {
-            // Block must itself be the direct body of an accessor or method declaration.
-            return parentBlock.Parent switch
-            {
-                AccessorDeclarationSyntax { RawKind: (int)SyntaxKind.GetAccessorDeclaration } or
-                MethodDeclarationSyntax { ReturnType: not PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword } } =>
-                    !parentBlock.Statements.Any(s => s != node && IsReturnLike(s)),
-                _ => false
-            };
+            // Block must itself be the direct body of a get accessor.
+            return parentBlock.Parent is AccessorDeclarationSyntax { RawKind: (int)SyntaxKind.GetAccessorDeclaration }
+                && !parentBlock.Statements.Any(s => s != node && IsReturnLike(s));
         }
 
         return false;

--- a/src/Stryker.Core/Stryker.Core/Mutators/StatementMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StatementMutator.cs
@@ -80,6 +80,13 @@ public class StatementMutator : MutatorBase<StatementSyntax>
             yield break;
         }
 
+        // a throw that is the only statement in a getter/method body that requires a return value
+        // would leave the member with no valid code path, causing CS0161
+        if (node is ThrowStatementSyntax && IsOnlyControlFlowInMemberRequiringReturn(node))
+        {
+            yield break;
+        }
+
         if (node is ExpressionStatementSyntax expressionNode)
         {
             // removing an assignment may cause a compile error
@@ -107,4 +114,29 @@ public class StatementMutator : MutatorBase<StatementSyntax>
             Type = Mutator.Statement
         };
     }
+
+    /// <summary>
+    /// Returns true when the throw is the only statement that provides control flow in a member
+    /// that must return a value (non-void method, property getter, indexer getter).
+    /// Replacing it with an empty statement would cause <see href="https://learn.microsoft.com/dotnet/csharp/misc/cs0161">CS0161</see>.
+    /// </summary>
+    private static bool IsOnlyControlFlowInMemberRequiringReturn(StatementSyntax node)
+    {
+        if (node.Parent is BlockSyntax parentBlock)
+        {
+            // Block must itself be the direct body of an accessor or method declaration.
+            return parentBlock.Parent switch
+            {
+                AccessorDeclarationSyntax { RawKind: (int)SyntaxKind.GetAccessorDeclaration } or
+                MethodDeclarationSyntax { ReturnType: not PredefinedTypeSyntax { Keyword.RawKind: (int)SyntaxKind.VoidKeyword } } =>
+                    !parentBlock.Statements.Any(s => s != node && IsReturnLike(s)),
+                _ => false
+            };
+        }
+
+        return false;
+    }
+
+    private static bool IsReturnLike(StatementSyntax s) =>
+        s.IsKind(SyntaxKind.ReturnStatement) || s.IsKind(SyntaxKind.ThrowStatement);
 }


### PR DESCRIPTION
Fixes #3626

## What
When a property getter contains a `throw` as its only statement, `BlockMutator` would empty the block and `StatementMutator` would remove the throw — both producing **CS0161** (not all code paths return a value).

## How
- **`BlockMutator`**: Added `IsBodyWithoutReturnOfNonVoidMember` — skips emptying a getter block when it contains no `return` statements, since `EndingReturnEngine` will not insert `return default` in that case.
- **`StatementMutator`**: Added `IsOnlyControlFlowInMemberRequiringReturn` — skips removing a `throw` statement when it is the sole return-like statement in a non-void getter or method body.

Both helpers use a simple Roslyn parent-node inspection and a scan of sibling statements; no new dependencies introduced.

## Tests
- `ShouldNotMutateThrowStatementAsOnlyStatementInPropertyGetter` — verifies neither the throw nor the block is mutated
- `ShouldMutateExpressionBodiedGetter` — verifies expression-bodied getters are still mutated normally
- `ShouldMutateThrowStatementWhenReturnPrecedesItInPropertyGetter` — verifies the guard does not fire when a `return` precedes the throw
