### PR TITLE
feat: Retrieve actual project's language version when not configured

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
@@ -179,12 +179,16 @@ public class AnalyzerResultExtensionsTests
     }
 
     [TestMethod]
-    public void GetParseOptions_ShouldReturnActualCSharpVersion()
+    [DataRow("8.0", LanguageVersion.CSharp8)]
+    [DataRow("7.1", LanguageVersion.CSharp7_1)]
+    [DataRow("latest", LanguageVersion.CSharp14)]
+    [DataRow("dontCare", LanguageVersion.CSharp14)] // it will return the latest version
+    public void GetParseOptions_ShouldReturnActualCSharpVersion(string actualLangVersion, LanguageVersion expected)
     {
         // Arrange
         var properties = new Dictionary<string, string>();
         var preprocessorSymbols = new[] { "DEBUG" };
-        properties["LangVersion"] = "8.0";
+        properties["LangVersion"] = actualLangVersion;
         var analyzerResult = CreateAnalyzerResultWithProperties(properties, preprocessorSymbols);
         var options = CreateStrykerOptions(LanguageVersion.Default);
 
@@ -192,10 +196,8 @@ public class AnalyzerResultExtensionsTests
         var parseOptions = analyzerResult.GetParseOptions(options);
 
         // Assert
-        parseOptions.LanguageVersion.ShouldBe(LanguageVersion.CSharp8);
-        parseOptions.PreprocessorSymbolNames.ShouldContain("DEBUG");
-        parseOptions.Features.ShouldBeEmpty();
-    }
+        parseOptions.LanguageVersion.ShouldBe(expected);
+        }
 
     [TestMethod]
     public void GetParseOptions_ShouldReturnBasicOptions_WhenNoFeaturesAreUsed()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
@@ -179,6 +179,25 @@ public class AnalyzerResultExtensionsTests
     }
 
     [TestMethod]
+    public void GetParseOptions_ShouldReturnActualCSharpVersion()
+    {
+        // Arrange
+        var properties = new Dictionary<string, string>();
+        var preprocessorSymbols = new[] { "DEBUG" };
+        properties["LangVersion"] = "8.0";
+        var analyzerResult = CreateAnalyzerResultWithProperties(properties, preprocessorSymbols);
+        var options = CreateStrykerOptions(LanguageVersion.Default);
+
+        // Act
+        var parseOptions = analyzerResult.GetParseOptions(options);
+
+        // Assert
+        parseOptions.LanguageVersion.ShouldBe(LanguageVersion.CSharp8);
+        parseOptions.PreprocessorSymbolNames.ShouldContain("DEBUG");
+        parseOptions.Features.ShouldBeEmpty();
+    }
+
+    [TestMethod]
     public void GetParseOptions_ShouldReturnBasicOptions_WhenNoFeaturesAreUsed()
     {
         // Arrange
@@ -195,6 +214,7 @@ public class AnalyzerResultExtensionsTests
         parseOptions.PreprocessorSymbolNames.ShouldContain("DEBUG");
         parseOptions.Features.ShouldBeEmpty();
     }
+
 
     [TestMethod]
     [DataRow("Features", "InterceptorsPreview", "InterceptorsPreview", null)]
@@ -398,6 +418,10 @@ public class AnalyzerResultExtensionsTests
         Mock.Get(analyzerResult)
             .SetupGet(g => g.Properties)
             .Returns(properties);
+
+        Mock.Get(analyzerResult).Setup(p => p.GetProperty(It.IsAny<string>()))
+            .Returns((string key) => properties.TryGetValue(key, out var value) ? value : null);
+
         Mock.Get(analyzerResult)
             .SetupGet(g => g.PreprocessorSymbols)
             .Returns(preprocessorSymbols ?? ["NET10_0"]);

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
@@ -43,17 +42,17 @@ public static class IAnalyzerResultCSharpExtensions
         ).WithFeatures(ExtractCSharpFeatures(analyzerResult));
 
 
-        private static LanguageVersion GetLanguageVersion(this IAnalyzerResult analyzerResult, IStrykerOptions options)
+    private static LanguageVersion GetLanguageVersion(this IAnalyzerResult analyzerResult, IStrykerOptions options)
+    {
+        if (options.LanguageVersion != LanguageVersion.Default)
         {
-            if (options.LanguageVersion != LanguageVersion.Default)
-            {
-                return options.LanguageVersion;
-            }
-            var version = analyzerResult.GetProperty("LangVersion");
-            return !string.IsNullOrWhiteSpace(version) && LanguageVersionFacts.TryParse(version, out var parsedVersion)
-                ? parsedVersion
-                : LanguageVersion.Default;
+            return options.LanguageVersion;
         }
+        var version = analyzerResult.GetProperty("LangVersion");
+        return !string.IsNullOrWhiteSpace(version) && LanguageVersionFacts.TryParse(version, out var parsedVersion)
+            ? parsedVersion
+            : LanguageVersion.Default;
+    }
     /// <summary>
     /// The Features MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
     /// It is not publicly documented by Microsoft as it is primarily intended for internal compiler development.

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
@@ -36,11 +37,28 @@ public static class IAnalyzerResultCSharpExtensions
 
     public static CSharpParseOptions GetParseOptions(this IAnalyzerResult analyzerResult, IStrykerOptions options) =>
         new CSharpParseOptions(
-            options.LanguageVersion,
+            GetLanguageVersion(analyzerResult, options),
             DocumentationMode.None,
             preprocessorSymbols: analyzerResult.PreprocessorSymbols
         ).WithFeatures(ExtractCSharpFeatures(analyzerResult));
 
+
+        private static LanguageVersion GetLanguageVersion(this IAnalyzerResult analyzerResult, IStrykerOptions options)
+        {
+            if (options.LanguageVersion != LanguageVersion.Default)
+            {
+                return options.LanguageVersion;
+            }
+            var version = analyzerResult.GetProperty("LangVersion");
+            if (version is null || !double.TryParse(version, CultureInfo.InvariantCulture, out var numericVersion))
+            {
+                return LanguageVersion.Default;
+            }
+
+            return numericVersion > 7.0
+                ? (LanguageVersion)((int)numericVersion*100)
+                : (LanguageVersion)(int)numericVersion;
+        }
     /// <summary>
     /// The Features MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().
     /// It is not publicly documented by Microsoft as it is primarily intended for internal compiler development.

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -50,14 +50,9 @@ public static class IAnalyzerResultCSharpExtensions
                 return options.LanguageVersion;
             }
             var version = analyzerResult.GetProperty("LangVersion");
-            if (version is null || !double.TryParse(version, CultureInfo.InvariantCulture, out var numericVersion))
-            {
-                return LanguageVersion.Default;
-            }
-
-            return numericVersion > 7.0
-                ? (LanguageVersion)((int)numericVersion*100)
-                : (LanguageVersion)(int)numericVersion;
+            return string.IsNullOrWhiteSpace(version) && LanguageVersionFacts.TryParse(version, out var parsedVersion)
+                ? parsedVersion
+                : LanguageVersion.Default;
         }
     /// <summary>
     /// The Features MSBuild property is an internal Roslyn mechanism that passes a key-value dictionary directly to CSharpParseOptions.WithFeatures().

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultCSharpExtensions.cs
@@ -50,7 +50,7 @@ public static class IAnalyzerResultCSharpExtensions
                 return options.LanguageVersion;
             }
             var version = analyzerResult.GetProperty("LangVersion");
-            return string.IsNullOrWhiteSpace(version) && LanguageVersionFacts.TryParse(version, out var parsedVersion)
+            return !string.IsNullOrWhiteSpace(version) && LanguageVersionFacts.TryParse(version, out var parsedVersion)
                 ? parsedVersion
                 : LanguageVersion.Default;
         }


### PR DESCRIPTION
Uses language version from BuildAlyzer results when not configured (or configured to default)