### PR TITLE
fix(mtp): Add StackOverflowException handling in MTP testrunner

### DIFF
--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/SampleTests.cs
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/SampleTests.cs
@@ -24,4 +24,14 @@ public class SampleTests
 
         sut.SomeLoop();
     }
+
+    [TestMethod]
+    public void TestStackOverflow()
+    {
+        var sut = new TargetProject.StrykerFeatures.StackOverflow();
+
+        // Mutating the recursion makes this overflow the stack and crash the test host,
+        // which the MTP runner reports as a RuntimeError mutant.
+        Assert.AreEqual(6, sut.SumTo(3));
+    }
 }

--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.NUnit/stryker-config.json
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.NUnit/stryker-config.json
@@ -12,7 +12,8 @@
       "string"
     ],
     "mutate": [
-      "!Person.cs"
+      "!Person.cs",
+      "!**/StackOverflow.cs"
     ],
     "mutation-level": "Complete"
   }

--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.TUnit/stryker-config.json
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.TUnit/stryker-config.json
@@ -12,7 +12,8 @@
       "string"
     ],
     "mutate": [
-      "!Person.cs"
+      "!Person.cs",
+      "!**/StackOverflow.cs"
     ],
     "mutation-level": "Complete"
   }

--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.XUnit/stryker-config.json
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.XUnit/stryker-config.json
@@ -12,7 +12,8 @@
       "string"
     ],
     "mutate": [
-      "!Person.cs"
+      "!Person.cs",
+      "!**/StackOverflow.cs"
     ],
     "mutation-level": "Complete"
   }

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/stryker-config.json
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/stryker-config.json
@@ -11,7 +11,8 @@
       "string"
     ],
     "mutate": [
-      "!Person.cs"
+      "!Person.cs",
+      "!**/StackOverflow.cs"
     ],
     "mutation-level": "Complete"
   }

--- a/integrationtest/TargetProjects/NetCore/TargetProject/StrykerFeatures/StackOverflow.cs
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/StrykerFeatures/StackOverflow.cs
@@ -1,0 +1,20 @@
+namespace TargetProject.StrykerFeatures
+{
+    public class StackOverflow
+    {
+        // This method recurses towards its base case (count <= 0). Mutating the recursion so it no
+        // longer approaches that base case - for example "count - 1" -> "count + 1", or emptying the
+        // guard block - makes it recurse forever, overflowing the stack and crashing the test host.
+        // A StackOverflowException cannot be caught and terminates the process, so under the Microsoft
+        // Testing Platform runner the mutant is reported with the RuntimeError state.
+        public int SumTo(int count)
+        {
+            if (count <= 0)
+            {
+                return 0;
+            }
+
+            return count + SumTo(count - 1);
+        }
+    }
+}

--- a/integrationtest/TargetProjects/NetCore/TargetProject/stryker-config.json
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/stryker-config.json
@@ -9,6 +9,9 @@
       "../NetCoreTestProject.XUnit/NetCoreTestProject.XUnit.csproj",
       "../NetCoreTestProject.NUnit/NetCoreTestProject.NUnit.csproj"
     ],
+    "mutate": [
+      "!**/StackOverflow.cs"
+    ],
     "mutation-level": "Complete"
   }
 }

--- a/integrationtest/TargetProjects/NetCore/stryker-config.json
+++ b/integrationtest/TargetProjects/NetCore/stryker-config.json
@@ -11,7 +11,8 @@
         "string"
       ],
       "mutate": [
-        "!Person.cs"
+        "!Person.cs",
+        "!**/StackOverflow.cs"
       ],
       "mutation-level": "Complete"
     }

--- a/integrationtest/TargetProjects/stryker-config.json
+++ b/integrationtest/TargetProjects/stryker-config.json
@@ -11,7 +11,8 @@
       "string"
     ],
     "mutate": [
-      "!Person.cs"
+      "!Person.cs",
+      "!**/StackOverflow.cs"
     ],
     "mutation-level": "Complete"
   }

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 2, killed: 1, timeout: 2, nocoverage: 350);
+        CheckReportMutants(report, total: 667, ignored: 272, survived: 3, killed: 4, timeout: 2, nocoverage: 350, runtimeError: 2);
     }
 
     [Fact]
@@ -285,7 +285,7 @@ public class ValidateStrykerResults
         }
     }
 
-    private void CheckReportMutants(IJsonReport report, int total, int ignored, int survived, int killed, int timeout, int nocoverage)
+    private void CheckReportMutants(IJsonReport report, int total, int ignored, int survived, int killed, int timeout, int nocoverage, int runtimeError = 0)
     {
         var actualTotal = report.Files.Select(f => f.Value.Mutants.Count()).Sum();
         var actualIgnored = report.Files.Select(f => f.Value.Mutants.Count(m => m.Status == MutantStatus.Ignored.ToString())).Sum();
@@ -293,6 +293,7 @@ public class ValidateStrykerResults
         var actualKilled = report.Files.Select(f => f.Value.Mutants.Count(m => m.Status == MutantStatus.Killed.ToString())).Sum();
         var actualTimeout = report.Files.Select(f => f.Value.Mutants.Count(m => m.Status == MutantStatus.Timeout.ToString())).Sum();
         var actualNoCoverage = report.Files.Select(f => f.Value.Mutants.Count(m => m.Status == MutantStatus.NoCoverage.ToString())).Sum();
+        var actualRuntimeError = report.Files.Select(f => f.Value.Mutants.Count(m => m.Status == MutantStatus.RuntimeError.ToString())).Sum();
 
         report.Files.ShouldSatisfyAllConditions(
             () => actualTotal.ShouldBe(total),
@@ -300,7 +301,8 @@ public class ValidateStrykerResults
             () => actualSurvived.ShouldBe(survived),
             () => actualKilled.ShouldBe(killed),
             () => actualTimeout.ShouldBe(timeout),
-            () => actualNoCoverage.ShouldBe(nocoverage)
+            () => actualNoCoverage.ShouldBe(nocoverage),
+            () => actualRuntimeError.ShouldBe(runtimeError)
         );
 
         CheckMutationKindsValidity(report);

--- a/src/Stryker.Abstractions/IMutant.cs
+++ b/src/Stryker.Abstractions/IMutant.cs
@@ -17,5 +17,5 @@ public interface IMutant : IReadOnlyMutant
     string DisplayName { get; }
     bool MustBeTestedInIsolation { get; set; }
 
-    void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError = false);
+    void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError);
 }

--- a/src/Stryker.Abstractions/IMutant.cs
+++ b/src/Stryker.Abstractions/IMutant.cs
@@ -17,5 +17,5 @@ public interface IMutant : IReadOnlyMutant
     string DisplayName { get; }
     bool MustBeTestedInIsolation { get; set; }
 
-    void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut);
+    void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError = false);
 }

--- a/src/Stryker.Abstractions/MutantStatus.cs
+++ b/src/Stryker.Abstractions/MutantStatus.cs
@@ -8,5 +8,6 @@ public enum MutantStatus
     Timeout,
     CompileError,
     Ignored,
-    NoCoverage
+    NoCoverage,
+    RuntimeError
 }

--- a/src/Stryker.Abstractions/Testing/ITestRunResult.cs
+++ b/src/Stryker.Abstractions/Testing/ITestRunResult.cs
@@ -17,7 +17,7 @@ public interface ITestRunResult
     /// (e.g. a mutation caused a fatal fault such as a stack overflow). The affected mutants
     /// cannot be conclusively tested and are reported as <see cref="MutantStatus.RuntimeError"/>.
     /// </summary>
-    bool SessionRuntimeError { get; }
+    bool SessionHadRuntimeIssue { get; }
     ITestIdentifiers TimedOutTests { get; }
     IEnumerable<IFrameworkTestDescription> TestDescriptions { get; }
 }

--- a/src/Stryker.Abstractions/Testing/ITestRunResult.cs
+++ b/src/Stryker.Abstractions/Testing/ITestRunResult.cs
@@ -11,6 +11,13 @@ public interface ITestRunResult
     IEnumerable<string> Messages { get; }
     string ResultMessage { get; }
     bool SessionTimedOut { get; }
+
+    /// <summary>
+    /// True when the test run could not be completed because the test host process crashed
+    /// (e.g. a mutation caused a fatal fault such as a stack overflow). The affected mutants
+    /// cannot be conclusively tested and are reported as <see cref="MutantStatus.RuntimeError"/>.
+    /// </summary>
+    bool SessionRuntimeError { get; }
     ITestIdentifiers TimedOutTests { get; }
     IEnumerable<IFrameworkTestDescription> TestDescriptions { get; }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -492,8 +492,18 @@ public class Calculator
                         { "AssemblyName", "AssemblyName" },
                         { "TargetFileName", "TargetFileName.dll" },
                     },
-                    // add a reference to system so the example code can compile
-                    references: [typeof(object).Assembly.Location]
+                    // add a reference to system so the example code can compile, plus the assemblies the
+                    // injected MutantControl needs for its MemoryMappedFile-based MTP mutant control. The
+                    // MemoryMappedFiles assembly is compiled against the contract assemblies, so resolving it
+                    // also requires System.Runtime (FileStream/FileMode/Object/Enum) and
+                    // System.Runtime.InteropServices (UnmanagedMemoryAccessor, the base of the view accessor).
+                    references:
+                    [
+                        typeof(object).Assembly.Location,
+                        typeof(System.IO.MemoryMappedFiles.MemoryMappedFile).Assembly.Location,
+                        Assembly.Load("System.Runtime").Location,
+                        Assembly.Load("System.Runtime.InteropServices").Location
+                    ]
                 ).Object,
                 TestProjectsInfo = new TestProjectsInfo(fileSystem)
                 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -143,6 +143,11 @@ public class CSharpRollbackProcessTests : TestBase
             typeof(List<string>).Assembly.Location,
             typeof(Enumerable).Assembly.Location,
             typeof(PipeStream).Assembly.Location,
+            // MutantControl maps the mutant-id file via MemoryMappedFile (MTP runner). ReadInt32 comes from
+            // UnmanagedMemoryAccessor, whose reference identity is System.Runtime.InteropServices (loaded by
+            // name because the runtime type is forwarded to CoreLib).
+            typeof(System.IO.MemoryMappedFiles.MemoryMappedFile).Assembly.Location,
+            Assembly.Load("System.Runtime.InteropServices").Location,
         };
         Assembly.GetEntryAssembly().GetReferencedAssemblies().ToList().ForEach(a => references.Add(Assembly.Load(a).Location));
 
@@ -229,6 +234,11 @@ public class CSharpRollbackProcessTests : TestBase
             typeof(List<string>).Assembly.Location,
             typeof(Enumerable).Assembly.Location,
             typeof(PipeStream).Assembly.Location,
+            // MutantControl maps the mutant-id file via MemoryMappedFile (MTP runner). ReadInt32 comes from
+            // UnmanagedMemoryAccessor, whose reference identity is System.Runtime.InteropServices (loaded by
+            // name because the runtime type is forwarded to CoreLib).
+            typeof(System.IO.MemoryMappedFiles.MemoryMappedFile).Assembly.Location,
+            Assembly.Load("System.Runtime.InteropServices").Location,
         };
         Assembly.GetEntryAssembly().GetReferencedAssemblies().ToList().ForEach(a => references.Add(Assembly.Load(a).Location));
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
@@ -30,9 +30,13 @@ public class InjectedHelperTests : TestBase
     [DataRow(LanguageVersion.Preview)]
     public void InjectHelpers_ShouldCompile_ForAllLanguageVersions(LanguageVersion version)
     {
+        // MutantControl maps the mutant-id file via MemoryMappedFile for the MTP runner; touch the type
+        // so its defining assembly is loaded before the snapshot below and can be referenced.
+        _ = typeof(System.IO.MemoryMappedFiles.MemoryMappedFile);
+
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-        var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
+        var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", "System.IO.MemoryMappedFiles", ".Collections", ".Console" };
         var references = new List<MetadataReference>();
         foreach (var assembly in assemblies)
         {
@@ -72,9 +76,13 @@ public class InjectedHelperTests : TestBase
     [DataRow(LanguageVersion.Preview)]
     public void InjectHelpers_ShouldCompile_ForAllLanguageVersionsWithNullableOptions(LanguageVersion version)
     {
+        // MutantControl maps the mutant-id file via MemoryMappedFile for the MTP runner; touch the type
+        // so its defining assembly is loaded before the snapshot below and can be referenced.
+        _ = typeof(System.IO.MemoryMappedFiles.MemoryMappedFile);
+
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-        var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
+        var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", "System.IO.MemoryMappedFiles", ".Collections", ".Console" };
         var references = new List<MetadataReference>();
         var hack = new NamedPipeClientStream("test");
         foreach (var assembly in assemblies)

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
@@ -27,6 +27,7 @@ public class MutantTests : TestBase
 
     [TestMethod]
     [DataRow(MutantStatus.CompileError, false)]
+    [DataRow(MutantStatus.RuntimeError, false)]
     [DataRow(MutantStatus.Ignored, false)]
     [DataRow(MutantStatus.Killed, true)]
     [DataRow(MutantStatus.NoCoverage, true)]
@@ -130,5 +131,42 @@ public class MutantTests : TestBase
             true);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
+    }
+
+    [TestMethod]
+    public void ShouldSetRuntimeErrorStateWhenSessionHasRuntimeError()
+    {
+        var mutant = new Mutant
+        {
+            AssessingTests = TestIdentifierList.EveryTest()
+        };
+
+        mutant.AnalyzeTestRun(TestIdentifierList.NoTest(),
+            TestIdentifierList.NoTest(),
+            TestIdentifierList.NoTest(),
+            sessionTimedOut: false,
+            sessionRuntimeError: true);
+
+        mutant.ResultStatus.ShouldBe(MutantStatus.RuntimeError);
+        mutant.ResultStatusReason.ShouldNotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void ShouldNotSetRuntimeErrorWhenAnAssessingTestFailed()
+    {
+        // A real failing test takes precedence: the mutant is killed, not flagged as a runtime error.
+        var failingTest = Guid.NewGuid().ToString();
+        var mutant = new Mutant
+        {
+            AssessingTests = new TestIdentifierList(new[] { failingTest })
+        };
+
+        mutant.AnalyzeTestRun(new TestIdentifierList(new[] { failingTest }),
+            TestIdentifierList.NoTest(),
+            TestIdentifierList.NoTest(),
+            sessionTimedOut: false,
+            sessionRuntimeError: true);
+
+        mutant.ResultStatus.ShouldBe(MutantStatus.Killed);
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutants/MutantTests.cs
@@ -57,6 +57,7 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(new TestIdentifierList(new[] { failingTest }),
             new TestIdentifierList(new[] { succeedingTest }),
             TestIdentifierList.NoTest(),
+            false,
             false);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Killed);
@@ -77,6 +78,7 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(new TestIdentifierList(new[] { failingTest }),
             new TestIdentifierList(new[] { succeedingTest }),
             TestIdentifierList.NoTest(),
+            false,
             false);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Survived);
@@ -95,6 +97,7 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(TestIdentifierList.NoTest(),
             new TestIdentifierList(new[] { succeedingTest }),
             TestIdentifierList.NoTest(),
+            false,
             false);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Survived);
@@ -112,6 +115,7 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(TestIdentifierList.NoTest(),
             TestIdentifierList.EveryTest(),
             TestIdentifierList.EveryTest(),
+            false,
             false);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
@@ -128,7 +132,8 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(TestIdentifierList.NoTest(),
             TestIdentifierList.NoTest(),
             TestIdentifierList.NoTest(),
-            true);
+            true,
+            false);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.Timeout);
     }
@@ -144,8 +149,8 @@ public class MutantTests : TestBase
         mutant.AnalyzeTestRun(TestIdentifierList.NoTest(),
             TestIdentifierList.NoTest(),
             TestIdentifierList.NoTest(),
-            sessionTimedOut: false,
-            sessionRuntimeError: true);
+            false,
+            true);
 
         mutant.ResultStatus.ShouldBe(MutantStatus.RuntimeError);
         mutant.ResultStatusReason.ShouldNotBeNullOrEmpty();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestExecutorTests.cs
@@ -74,6 +74,49 @@ public class MutationTestExecutorTests : TestBase
     }
 
     [TestMethod]
+    public async Task MutationTestExecutor_RuntimeErrorShouldBeReportedAsRuntimeError()
+    {
+        var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
+        var mutant = new Mutant { Id = 1, CoveringTests = TestIdentifierList.EveryTest() };
+        testRunnerMock.Setup(x => x.TestMultipleMutantsAsync(It.IsAny<IProjectAndTests>(), It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<IMutant>>(), null)).
+            Returns(Task.FromResult(TestRunResult.RuntimeError(new List<VsTestDescription>(), TestIdentifierList.NoTest(), TestIdentifierList.NoTest(), TestIdentifierList.NoTest(), "the test host crashed", Enumerable.Empty<string>(), TimeSpan.Zero) as ITestRunResult));
+
+        var loggerMock = new Mock<ILogger<MutationTestExecutor>>();
+        var target = new MutationTestExecutor(loggerMock.Object);
+        target.TestRunner = testRunnerMock.Object;
+
+        await target.TestAsync(null, new List<IMutant> { mutant }, null, null);
+
+        mutant.ResultStatus.ShouldBe(MutantStatus.RuntimeError);
+        mutant.ResultStatusReason.ShouldNotBeNullOrEmpty();
+        testRunnerMock.Verify(x => x.TestMultipleMutantsAsync(It.IsAny<IProjectAndTests>(), It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<IMutant>>(), null), Times.Once);
+        // a crash is not a test failure: it must not be logged as an error
+        loggerMock.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task MutationTestExecutor_ShouldSwitchToSingleModeOnRuntimeError()
+    {
+        // A crash in a batch can't be attributed to one mutant, so the batch is rerun one by one
+        // to isolate the culprit (mirrors the dubious-timeout behaviour).
+        var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);
+        var mutant1 = new Mutant { Id = 1, CoveringTests = TestIdentifierList.EveryTest() };
+        var mutant2 = new Mutant { Id = 2, CoveringTests = TestIdentifierList.EveryTest() };
+        testRunnerMock.Setup(x => x.TestMultipleMutantsAsync(It.IsAny<IProjectAndTests>(), It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<IMutant>>(), null)).
+            Returns(Task.FromResult(TestRunResult.RuntimeError(new List<VsTestDescription>(), TestIdentifierList.NoTest(), TestIdentifierList.NoTest(), TestIdentifierList.NoTest(), "the test host crashed", Enumerable.Empty<string>(), TimeSpan.Zero) as ITestRunResult));
+
+        var loggerMock = new Mock<ILogger<MutationTestExecutor>>();
+        var target = new MutationTestExecutor(loggerMock.Object);
+        target.TestRunner = testRunnerMock.Object;
+
+        await target.TestAsync(null, new List<IMutant> { mutant1, mutant2 }, null, null);
+
+        mutant1.ResultStatus.ShouldBe(MutantStatus.RuntimeError);
+        mutant2.ResultStatus.ShouldBe(MutantStatus.RuntimeError);
+        testRunnerMock.Verify(x => x.TestMultipleMutantsAsync(It.IsAny<IProjectAndTests>(), It.IsAny<ITimeoutValueCalculator>(), It.IsAny<IReadOnlyList<IMutant>>(), null), Times.Exactly(3));
+    }
+
+    [TestMethod]
     public async Task MutationTestExecutor_ShouldSwitchToSingleModeOnDubiousTimeouts()
     {
         var testRunnerMock = new Mock<ITestRunner>(MockBehavior.Strict);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/CollectionExpressionMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/CollectionExpressionMutatorTests.cs
@@ -470,6 +470,13 @@ public class CollectionExpressionMutatorTests : TestBase
             typeof(Enumerable).Assembly.Location,
             typeof(ImmutableArray<>).Assembly.Location,
             typeof(ValueType).Assembly.Location,
+            // MutantControl uses MemoryMappedFile for the MTP runner's file-based mutant control.
+            // MemoryMappedViewAccessor.ReadInt32 is inherited from UnmanagedMemoryAccessor, whose reference
+            // identity is System.Runtime.InteropServices (at runtime the type is forwarded to CoreLib, so it
+            // must be loaded by assembly name rather than via typeof). Both assemblies are required for the
+            // injected helper to compile.
+            typeof(System.IO.MemoryMappedFiles.MemoryMappedFile).Assembly.Location,
+            Assembly.Load("System.Runtime.InteropServices").Location,
             ..Assembly.GetEntryAssembly()?.GetReferencedAssemblies().Select(a => Assembly.Load(a).Location) ?? []
         ];
 
@@ -506,7 +513,7 @@ public class CollectionExpressionMutatorTests : TestBase
             result.Success.ShouldBe(true);
             result.RolledbackIds.ShouldBeEmpty();
         }
-        catch (CompilationException)
+        catch (CompilationException ex)
         {
             Assert.Fail($"Compilation failed with code: {syntaxTree}");
         }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ConsoleDotReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ConsoleDotReporterTests.cs
@@ -14,6 +14,7 @@ public class ConsoleDotReporterTests : TestBase
     [DataRow(MutantStatus.Killed, ".", "default")]
     [DataRow(MutantStatus.Survived, "S", "red")]
     [DataRow(MutantStatus.Timeout, "T", "default")]
+    [DataRow(MutantStatus.RuntimeError, "E", "yellow")]
     public void ConsoleDotReporter_ShouldPrintRightCharOnMutation(MutantStatus givenStatus, string expectedOutput, string color)
     {
         var console = new TestConsole().EmitAnsiSequences();
@@ -32,6 +33,11 @@ public class ConsoleDotReporterTests : TestBase
         if (color == "red")
         {
             console.Output.RedSpanCount().ShouldBe(1);
+        }
+
+        if (color == "yellow")
+        {
+            console.Output.YellowSpanCount().ShouldBe(1);
         }
 
         console.Output.RemoveAnsi().ShouldBe(expectedOutput);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
@@ -43,6 +43,7 @@ public class ProgressBarReporterTests
     [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 2 │ K 1 │ S 0 │ T 0 │ E 0 │ ~0m 00s │")]
     [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 2 │ K 0 │ S 1 │ T 0 │ E 0 │ ~0m 00s │")]
     [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 2 │ K 0 │ S 0 │ T 1 │ E 0 │ ~0m 00s │")]
+    [DataRow(MutantStatus.RuntimeError, "│ Testing mutant 1 / 2 │ K 0 │ S 0 │ T 0 │ E 1 │ ~0m 00s │")]
     public void ReportRunTest_ShouldReportTestProgressAs50PercentageDone_And_FirstTestExecutionTime_WhenHalfOfTestsAreDone(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -68,6 +69,7 @@ public class ProgressBarReporterTests
     [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 10000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~1m 39s │")]
     [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 10000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~1m 39s │")]
     [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 10000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~1m 39s │")]
+    [DataRow(MutantStatus.RuntimeError, "│ Testing mutant 1 / 10000 │ K 0 │ S 0 │ T 0 │ E 1 │ ~1m 39s │")]
     public void ReportRunTest_TestExecutionTimeInMinutes(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -93,6 +95,7 @@ public class ProgressBarReporterTests
     [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 1000000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~2h 46m │")]
     [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 1000000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~2h 46m │")]
     [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 1000000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~2h 46m │")]
+    [DataRow(MutantStatus.RuntimeError, "│ Testing mutant 1 / 1000000 │ K 0 │ S 0 │ T 0 │ E 1 │ ~2h 46m │")]
     public void ReportRunTest_TestExecutionTimeInHours(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -117,6 +120,7 @@ public class ProgressBarReporterTests
     [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 100000000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~11d 13h │")]
     [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 100000000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~11d 13h │")]
     [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 100000000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~11d 13h │")]
+    [DataRow(MutantStatus.RuntimeError, "│ Testing mutant 1 / 100000000 │ K 0 │ S 0 │ T 0 │ E 1 │ ~11d 13h │")]
     public void ReportRunTest_TestExecutionTimeInDays(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Progress/ProgressBarReporterTests.cs
@@ -22,7 +22,7 @@ public class ProgressBarReporterTests
 
         progressBarMock.Verify(x => x.Start(
             It.Is<int>(a => a == 3),
-            It.Is<string>(b => b == "│ Testing mutant 0 / 3 │ K 0 │ S 0 │ T 0 │ NA │")
+            It.Is<string>(b => b == "│ Testing mutant 0 / 3 │ K 0 │ S 0 │ T 0 │ E 0 │ NA │")
         ));
     }
 
@@ -40,9 +40,9 @@ public class ProgressBarReporterTests
     }
 
     [TestMethod]
-    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 2 │ K 1 │ S 0 │ T 0 │ ~0m 00s │")]
-    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 2 │ K 0 │ S 1 │ T 0 │ ~0m 00s │")]
-    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 2 │ K 0 │ S 0 │ T 1 │ ~0m 00s │")]
+    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 2 │ K 1 │ S 0 │ T 0 │ E 0 │ ~0m 00s │")]
+    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 2 │ K 0 │ S 1 │ T 0 │ E 0 │ ~0m 00s │")]
+    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 2 │ K 0 │ S 0 │ T 1 │ E 0 │ ~0m 00s │")]
     public void ReportRunTest_ShouldReportTestProgressAs50PercentageDone_And_FirstTestExecutionTime_WhenHalfOfTestsAreDone(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -65,9 +65,9 @@ public class ProgressBarReporterTests
     }
 
     [TestMethod]
-    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 10000 │ K 1 │ S 0 │ T 0 │ ~1m 39s │")]
-    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 10000 │ K 0 │ S 1 │ T 0 │ ~1m 39s │")]
-    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 10000 │ K 0 │ S 0 │ T 1 │ ~1m 39s │")]
+    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 10000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~1m 39s │")]
+    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 10000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~1m 39s │")]
+    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 10000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~1m 39s │")]
     public void ReportRunTest_TestExecutionTimeInMinutes(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -90,9 +90,9 @@ public class ProgressBarReporterTests
     }
 
     [TestMethod]
-    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 1000000 │ K 1 │ S 0 │ T 0 │ ~2h 46m │")]
-    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 1000000 │ K 0 │ S 1 │ T 0 │ ~2h 46m │")]
-    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 1000000 │ K 0 │ S 0 │ T 1 │ ~2h 46m │")]
+    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 1000000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~2h 46m │")]
+    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 1000000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~2h 46m │")]
+    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 1000000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~2h 46m │")]
     public void ReportRunTest_TestExecutionTimeInHours(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);
@@ -114,9 +114,9 @@ public class ProgressBarReporterTests
     }
 
     [TestMethod]
-    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 100000000 │ K 1 │ S 0 │ T 0 │ ~11d 13h │")]
-    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 100000000 │ K 0 │ S 1 │ T 0 │ ~11d 13h │")]
-    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 100000000 │ K 0 │ S 0 │ T 1 │ ~11d 13h │")]
+    [DataRow(MutantStatus.Killed, "│ Testing mutant 1 / 100000000 │ K 1 │ S 0 │ T 0 │ E 0 │ ~11d 13h │")]
+    [DataRow(MutantStatus.Survived, "│ Testing mutant 1 / 100000000 │ K 0 │ S 1 │ T 0 │ E 0 │ ~11d 13h │")]
+    [DataRow(MutantStatus.Timeout, "│ Testing mutant 1 / 100000000 │ K 0 │ S 0 │ T 1 │ E 0 │ ~11d 13h │")]
     public void ReportRunTest_TestExecutionTimeInDays(MutantStatus status, string expected)
     {
         var progressBarMock = new Mock<IProgressBar>(MockBehavior.Strict);

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
@@ -11,10 +11,22 @@ namespace Stryker
         private static System.Collections.Generic.List<int> _coveredStaticMutants = new System.Collections.Generic.List<int>();
         private static string envName = string.Empty;
         private static System.Object _coverageLock = new System.Object();
-        private static long _lastMutantFileVersion = -1;
         // Initialized to avoid nullable warnings/errors
         private static string _cachedMutantFilePath = string.Empty;
         private static bool _mutantFilePathCached;
+
+        // Memory-mapped view of the mutant-id file used by the MTP runner. The runner writes the active
+        // mutant id (a 4-byte int) to the file between runs; reading it through a memory-mapped view is a
+        // plain memory access (no syscall), so it is cheap enough for the IsActive hot path while still
+        // always reflecting the latest value the runner wrote. The test host process is reused across
+        // mutant runs and has no per-run reset hook, so reading every call (rather than caching) is what
+        // keeps this correct: any cached or event-based scheme would race the start of the next run.
+        // _mutantMmf / _mutantAccessor are typed as object and initialized to a non-null sentinel only to
+        // root them (and avoid nullable warnings); the accessor is cast back to its real type when read.
+        private static object _mutantMmf = new System.Object();
+        private static object _mutantAccessor = new System.Object();
+        private static bool _mutantMmfReady;
+        private static bool _mutantMmfFailed;
 
         // Coverage file path for MTP runner (file-based IPC)
         private static string _cachedCoverageFilePath = string.Empty;
@@ -87,25 +99,102 @@ namespace Stryker
                 _mutantFilePathCached = true;
             }
 
-            if (string.IsNullOrEmpty(_cachedMutantFilePath) || !System.IO.File.Exists(_cachedMutantFilePath))
+            if (string.IsNullOrEmpty(_cachedMutantFilePath))
+            {
+                return false;
+            }
+
+            // Fast path: read the active mutant id from a memory-mapped view of the file (see the field
+            // comments above). This is a plain memory read - no filesystem stat or content read per call.
+            if (!_mutantMmfFailed)
+            {
+                if (!_mutantMmfReady)
+                {
+                    EnsureMutantMmf();
+                }
+
+                if (_mutantMmfReady)
+                {
+                    try
+                    {
+                        mutantId = ((System.IO.MemoryMappedFiles.MemoryMappedViewAccessor)_mutantAccessor).ReadInt32(0);
+                        return true;
+                    }
+                    catch
+                    {
+                        // The mapping became unusable; fall back to reading the file directly from now on.
+                        _mutantMmfFailed = true;
+                    }
+                }
+            }
+
+            // Fallback (no memory-mapped view could be created): read the 4-byte mutant id straight from
+            // the file on every call. Correct but slower; only used if memory mapping is unavailable.
+            return TryReadMutantFromFileDirect(out mutantId);
+        }
+
+        private static void EnsureMutantMmf()
+        {
+            if (_mutantMmfReady || _mutantMmfFailed)
+            {
+                return;
+            }
+
+            // The runner creates the file (with the initial -1) before the test host starts, so it
+            // normally exists on the first call. If it is not there yet, leave things unmapped and retry
+            // on a later call rather than giving up permanently.
+            if (!System.IO.File.Exists(_cachedMutantFilePath))
+            {
+                return;
+            }
+
+            try
+            {
+                // FileShare.ReadWrite lets the runner keep writing the file while the test host keeps it
+                // mapped. leaveOpen: false means the mapping owns and disposes the stream with it.
+                System.IO.FileStream stream = new System.IO.FileStream(
+                    _cachedMutantFilePath,
+                    System.IO.FileMode.Open,
+                    System.IO.FileAccess.Read,
+                    System.IO.FileShare.ReadWrite);
+                System.IO.MemoryMappedFiles.MemoryMappedFile mmf = System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(
+                    stream,
+                    null,
+                    4,
+                    System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read,
+                    System.IO.HandleInheritability.None,
+                    false);
+                System.IO.MemoryMappedFiles.MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(
+                    0, 4, System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read);
+
+                _mutantMmf = mmf;
+                _mutantAccessor = accessor;
+                _mutantMmfReady = true;
+            }
+            catch
+            {
+                // Memory mapping is unavailable in this environment; the direct-read fallback keeps the
+                // active mutant correct (just slower).
+                _mutantMmfFailed = true;
+            }
+        }
+
+        private static bool TryReadMutantFromFileDirect(out int mutantId)
+        {
+            mutantId = -1;
+
+            if (!System.IO.File.Exists(_cachedMutantFilePath))
             {
                 return false;
             }
 
             try
             {
-                System.IO.FileInfo fileInfo = new System.IO.FileInfo(_cachedMutantFilePath);
-                long currentVersion = fileInfo.LastWriteTimeUtc.Ticks;
-
-                // Only re-read if file has changed or we haven't read it yet
-                if (currentVersion != _lastMutantFileVersion || ActiveMutant == ActiveMutantNotInitValue)
+                byte[] bytes = System.IO.File.ReadAllBytes(_cachedMutantFilePath);
+                if (bytes.Length >= 4)
                 {
-                    string content = System.IO.File.ReadAllText(_cachedMutantFilePath).Trim();
-                    if (int.TryParse(content, out mutantId))
-                    {
-                        _lastMutantFileVersion = currentVersion;
-                        return true;
-                    }
+                    mutantId = System.BitConverter.ToInt32(bytes, 0);
+                    return true;
                 }
             }
             catch

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
@@ -150,58 +150,31 @@ namespace Stryker
 
             try
             {
-                // FileShare.ReadWrite lets the runner keep writing the file while the test host keeps it
-                // mapped. leaveOpen: false means the mapping owns and disposes the stream with it.
-                System.IO.FileStream stream = null;
-                System.IO.MemoryMappedFiles.MemoryMappedFile mmf = null;
-                System.IO.MemoryMappedFiles.MemoryMappedViewAccessor accessor = null;
+                // FileShare.ReadWrite lets the runner keep writing the file while the test host keeps it mapped.
+                // leaveOpen: false means the mapping owns and disposes the stream with it.
+                System.IO.FileStream stream = new System.IO.FileStream(
+                    _cachedMutantFilePath,
+                    System.IO.FileMode.Open,
+                    System.IO.FileAccess.Read,
+                    System.IO.FileShare.ReadWrite);
 
-                try
-                {
-                    stream = new System.IO.FileStream(
-                        _cachedMutantFilePath,
-                        System.IO.FileMode.Open,
-                        System.IO.FileAccess.Read,
-                        System.IO.FileShare.ReadWrite);
+                System.IO.MemoryMappedFiles.MemoryMappedFile mmf = System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(
+                    stream,
+                    null,
+                    4,
+                    System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read,
+                    System.IO.HandleInheritability.None,
+                    false);
 
-                    mmf = System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(
-                        stream,
-                        null,
-                        4,
-                        System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read,
-                        System.IO.HandleInheritability.None,
-                        false);
+                System.IO.MemoryMappedFiles.MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(0, 4, System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read);
 
-                    accessor = mmf.CreateViewAccessor(0, 4, System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read);
-
-                    _mutantMmf = mmf;
-                    _mutantAccessor = accessor;
-                    _mutantMmfReady = true;
-                }
-                finally
-                {
-                    if (!_mutantMmfReady)
-                    {
-                        if (accessor != null)
-                        {
-                            accessor.Dispose();
-                        }
-
-                        if (mmf != null)
-                        {
-                            mmf.Dispose();
-                        }
-                        else if (stream != null)
-                        {
-                            stream.Dispose();
-                        }
-                    }
-                }
+                _mutantMmf = mmf;
+                _mutantAccessor = accessor;
+                _mutantMmfReady = true;
             }
             catch
             {
-                // Memory mapping is unavailable in this environment; the direct-read fallback keeps the
-                // active mutant correct (just slower).
+                // Memory mapping is unavailable in this environment; the direct-read fallback keeps the active mutant correct (just slower).
                 _mutantMmfFailed = true;
             }
         }

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
@@ -152,24 +152,51 @@ namespace Stryker
             {
                 // FileShare.ReadWrite lets the runner keep writing the file while the test host keeps it
                 // mapped. leaveOpen: false means the mapping owns and disposes the stream with it.
-                System.IO.FileStream stream = new System.IO.FileStream(
-                    _cachedMutantFilePath,
-                    System.IO.FileMode.Open,
-                    System.IO.FileAccess.Read,
-                    System.IO.FileShare.ReadWrite);
-                System.IO.MemoryMappedFiles.MemoryMappedFile mmf = System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(
-                    stream,
-                    null,
-                    4,
-                    System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read,
-                    System.IO.HandleInheritability.None,
-                    false);
-                System.IO.MemoryMappedFiles.MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(
-                    0, 4, System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read);
+                System.IO.FileStream stream = null;
+                System.IO.MemoryMappedFiles.MemoryMappedFile mmf = null;
+                System.IO.MemoryMappedFiles.MemoryMappedViewAccessor accessor = null;
 
-                _mutantMmf = mmf;
-                _mutantAccessor = accessor;
-                _mutantMmfReady = true;
+                try
+                {
+                    stream = new System.IO.FileStream(
+                        _cachedMutantFilePath,
+                        System.IO.FileMode.Open,
+                        System.IO.FileAccess.Read,
+                        System.IO.FileShare.ReadWrite);
+
+                    mmf = System.IO.MemoryMappedFiles.MemoryMappedFile.CreateFromFile(
+                        stream,
+                        null,
+                        4,
+                        System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read,
+                        System.IO.HandleInheritability.None,
+                        false);
+
+                    accessor = mmf.CreateViewAccessor(0, 4, System.IO.MemoryMappedFiles.MemoryMappedFileAccess.Read);
+
+                    _mutantMmf = mmf;
+                    _mutantAccessor = accessor;
+                    _mutantMmfReady = true;
+                }
+                finally
+                {
+                    if (!_mutantMmfReady)
+                    {
+                        if (accessor != null)
+                        {
+                            accessor.Dispose();
+                        }
+
+                        if (mmf != null)
+                        {
+                            mmf.Dispose();
+                        }
+                        else if (stream != null)
+                        {
+                            stream.Dispose();
+                        }
+                    }
+                }
             }
             catch
             {

--- a/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
@@ -23,7 +23,7 @@ public class Mutant : IMutant
 
     public string ResultStatusReason { get; set; }
 
-    public bool CountForStats => ResultStatus != MutantStatus.CompileError && ResultStatus != MutantStatus.Ignored;
+    public bool CountForStats => ResultStatus is not (MutantStatus.CompileError or MutantStatus.RuntimeError or MutantStatus.Ignored);
 
     public bool IsStaticValue { get; set; }
 
@@ -31,7 +31,7 @@ public class Mutant : IMutant
 
     public string DisplayName => $"{Id}: {Mutation?.DisplayName}";
 
-    public void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut)
+    public void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError = false)
     {
         if (AssessingTests.ContainsAny(failedTests))
         {
@@ -41,6 +41,13 @@ public class Mutant : IMutant
         else if (AssessingTests.ContainsAny(timedOutTests) || sessionTimedOut)
         {
             ResultStatus = MutantStatus.Timeout;
+        }
+        else if (sessionRuntimeError)
+        {
+            // The test host crashed (e.g. a mutation caused a fatal fault). The mutant cannot be
+            // conclusively tested, so it is a runtime error (excluded from the mutation score).
+            ResultStatus = MutantStatus.RuntimeError;
+            ResultStatusReason = "The test host crashed while testing this mutant";
         }
         else if (resultRanTests.IsEveryTest || !resultRanTests.IsEveryTest && AssessingTests.IsIncludedIn(resultRanTests))
         {

--- a/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
@@ -47,7 +47,7 @@ public class Mutant : IMutant
             // The test host crashed (e.g. a mutation caused a fatal fault). The mutant cannot be
             // conclusively tested, so it is a runtime error (excluded from the mutation score).
             ResultStatus = MutantStatus.RuntimeError;
-            ResultStatusReason = "The test host crashed while testing this mutant";
+            ResultStatusReason = "The test host crashed or became unreachable while testing this mutant";
         }
         else if (resultRanTests.IsEveryTest || !resultRanTests.IsEveryTest && AssessingTests.IsIncludedIn(resultRanTests))
         {

--- a/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/Mutant.cs
@@ -31,7 +31,7 @@ public class Mutant : IMutant
 
     public string DisplayName => $"{Id}: {Mutation?.DisplayName}";
 
-    public void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError = false)
+    public void AnalyzeTestRun(ITestIdentifiers failedTests, ITestIdentifiers resultRanTests, ITestIdentifiers timedOutTests, bool sessionTimedOut, bool sessionRuntimeError)
     {
         if (AssessingTests.ContainsAny(failedTests))
         {

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
@@ -57,26 +57,19 @@ public class MutationTestExecutor : IMutationTestExecutor
             var remainingMutants = mutantsToTest.Where((m) => m.ResultStatus == MutantStatus.Pending).ToList();
             if (remainingMutants.Count == mutantsToTest.Count)
             {
-                // the test failed to get any conclusive results
-                if (!result.SessionTimedOut)
+                // No mutant in this session got a conclusive result. A single mutant is already
+                // classified by Mutant.AnalyzeTestRun, so reaching here means the whole batch was
+                // inconclusive: rerun one mutant at a time to isolate the culprit, unless nothing
+                // ran at all.
+                if (result.SessionTimedOut || result.SessionRuntimeError)
+                {
+                    forceSingle = true;
+                }
+                else
                 {
                     // something bad happened.
                     Logger.LogError("Stryker failed to test {RemainingMutantsCount} mutant(s).", remainingMutants.Count);
                     return;
-                }
-
-                // test session's results have been corrupted by the time out
-                // we retry and run tests one by one, if necessary
-                if (remainingMutants.Count == 1)
-                {
-                    // only one mutant was tested, we mark it as timeout.
-                    remainingMutants[0].ResultStatus = MutantStatus.Timeout;
-                    remainingMutants.Clear();
-                }
-                else
-                {
-                    // we don't know which tests timed out, we rerun all tests in dedicated sessions
-                    forceSingle = true;
                 }
             }
 
@@ -100,12 +93,13 @@ public class MutationTestExecutor : IMutationTestExecutor
             {
                 var localResult =
                     await TestRunner.TestMultipleMutantsAsync(projectAndTests, timeoutMs, new[] { mutant }, updateHandler).ConfigureAwait(false);
-                if (updateHandler == null || localResult.SessionTimedOut)
+                if (updateHandler == null || localResult.SessionTimedOut || localResult.SessionRuntimeError)
                 {
                     mutant.AnalyzeTestRun(localResult.FailingTests,
                         localResult.ExecutedTests,
                         localResult.TimedOutTests,
-                        localResult.SessionTimedOut);
+                        localResult.SessionTimedOut,
+                        localResult.SessionRuntimeError);
                 }
             }
 
@@ -113,7 +107,7 @@ public class MutationTestExecutor : IMutationTestExecutor
         }
 
         var result = await TestRunner.TestMultipleMutantsAsync(projectAndTests, timeoutMs, mutantsToTest.ToList(), updateHandler).ConfigureAwait(false);
-        if (updateHandler != null && !result.SessionTimedOut)
+        if (updateHandler != null && !result.SessionTimedOut && !result.SessionRuntimeError)
         {
             return result;
         }
@@ -123,7 +117,8 @@ public class MutationTestExecutor : IMutationTestExecutor
             mutant.AnalyzeTestRun(result.FailingTests,
                 result.ExecutedTests,
                 result.TimedOutTests,
-                mutantsToTest.Count == 1 && result.SessionTimedOut);
+                mutantsToTest.Count == 1 && result.SessionTimedOut,
+                mutantsToTest.Count == 1 && result.SessionRuntimeError);
         }
 
         return result;

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestExecutor.cs
@@ -61,7 +61,7 @@ public class MutationTestExecutor : IMutationTestExecutor
                 // classified by Mutant.AnalyzeTestRun, so reaching here means the whole batch was
                 // inconclusive: rerun one mutant at a time to isolate the culprit, unless nothing
                 // ran at all.
-                if (result.SessionTimedOut || result.SessionRuntimeError)
+                if (result.SessionTimedOut || result.SessionHadRuntimeIssue)
                 {
                     forceSingle = true;
                 }
@@ -93,13 +93,13 @@ public class MutationTestExecutor : IMutationTestExecutor
             {
                 var localResult =
                     await TestRunner.TestMultipleMutantsAsync(projectAndTests, timeoutMs, new[] { mutant }, updateHandler).ConfigureAwait(false);
-                if (updateHandler == null || localResult.SessionTimedOut || localResult.SessionRuntimeError)
+                if (updateHandler == null || localResult.SessionTimedOut || localResult.SessionHadRuntimeIssue)
                 {
                     mutant.AnalyzeTestRun(localResult.FailingTests,
                         localResult.ExecutedTests,
                         localResult.TimedOutTests,
                         localResult.SessionTimedOut,
-                        localResult.SessionRuntimeError);
+                        localResult.SessionHadRuntimeIssue);
                 }
             }
 
@@ -107,7 +107,7 @@ public class MutationTestExecutor : IMutationTestExecutor
         }
 
         var result = await TestRunner.TestMultipleMutantsAsync(projectAndTests, timeoutMs, mutantsToTest.ToList(), updateHandler).ConfigureAwait(false);
-        if (updateHandler != null && !result.SessionTimedOut && !result.SessionRuntimeError)
+        if (updateHandler != null && !result.SessionTimedOut && !result.SessionHadRuntimeIssue)
         {
             return result;
         }
@@ -118,7 +118,7 @@ public class MutationTestExecutor : IMutationTestExecutor
                 result.ExecutedTests,
                 result.TimedOutTests,
                 mutantsToTest.Count == 1 && result.SessionTimedOut,
-                mutantsToTest.Count == 1 && result.SessionRuntimeError);
+                mutantsToTest.Count == 1 && result.SessionHadRuntimeIssue);
         }
 
         return result;

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -115,7 +115,7 @@ public class MutationTestProcess : IMutationTestProcess
 
         foreach (var mutant in testedMutants)
         {
-            mutant.AnalyzeTestRun(failedTests, ranTests, timedOutTest, false);
+            mutant.AnalyzeTestRun(failedTests, ranTests, timedOutTest, false, false);
 
             if (mutant.ResultStatus == MutantStatus.Pending)
             {

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
@@ -36,7 +36,7 @@ public abstract class ProjectComponent : IProjectComponent
         .Union(DetectedMutants());
 
     public IEnumerable<IReadOnlyMutant> InvalidMutants() => Mutants
-        .Where(m => m.ResultStatus == MutantStatus.CompileError);
+        .Where(m => m.ResultStatus is MutantStatus.CompileError or MutantStatus.RuntimeError);
 
     public IEnumerable<IReadOnlyMutant> UndetectedMutants() => Mutants
         .Where(m =>

--- a/src/Stryker.Core/Stryker.Core/Reporters/ClearTextReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ClearTextReporter.cs
@@ -112,7 +112,7 @@ public class ClearTextReporter : IReporter
         columns.Add(new Text(mutants.Count(m => m.ResultStatus == MutantStatus.Timeout).ToString()));
         columns.Add(new Text((inputComponent.TotalMutants().Count() - inputComponent.DetectedMutants().Count()).ToString()));
         columns.Add(new Text(mutants.Count(m => m.ResultStatus == MutantStatus.NoCoverage).ToString()));
-        columns.Add(new Text(mutants.Count(m => m.ResultStatus == MutantStatus.CompileError).ToString()));
+        columns.Add(new Text(mutants.Count(m => m.ResultStatus is MutantStatus.CompileError or MutantStatus.RuntimeError).ToString()));
 
         table.AddRow(columns);
     }

--- a/src/Stryker.Core/Stryker.Core/Reporters/ConsoleDotProgressReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ConsoleDotProgressReporter.cs
@@ -38,6 +38,9 @@ public class ConsoleDotProgressReporter : IReporter
             case MutantStatus.Timeout:
                 _console.Write("T");
                 break;
+            case MutantStatus.RuntimeError:
+                _console.Markup("[Yellow]E[/]");
+                break;
         }
     }
 

--- a/src/Stryker.Core/Stryker.Core/Reporters/FilteredMutantsLogger.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/FilteredMutantsLogger.cs
@@ -53,7 +53,7 @@ public class FilteredMutantsLogger
 
     private string FormatStatusReasonLogString(int mutantCount, MutantStatus resultStatus)
     {
-        // Pad for status CompileError length
+        // Pad for status CompileError/RuntimeError length
         var padForResultStatusLength = 13 - resultStatus.ToString().Length;
 
         var formattedString = LeftPadAndFormatForMutantCount(mutantCount, "mutants got status {1}.");

--- a/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/MarkdownSummaryReporter.cs
@@ -85,6 +85,7 @@ public class MarkdownSummaryReporter : IReporter
                 "No Coverage",
                 "Ignored",
                 "Compile Errors",
+                "Runtime Errors",
                 "Total Detected",
                 "Total Undetected",
                 "Total Mutants"
@@ -136,6 +137,9 @@ public class MarkdownSummaryReporter : IReporter
 
         // Compile Errors
         values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.CompileError).ToString());
+
+        // Runtime Errors
+        values.Add(mutants.Count(m => m.ResultStatus == MutantStatus.RuntimeError).ToString());
 
         // Total Detected
         values.Add(mutants

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
@@ -13,7 +13,7 @@ public interface IProgressBarReporter
 
 public class ProgressBarReporter : IProgressBarReporter, IDisposable
 {
-    private const string LoggingFormat = "│ Testing mutant {0} / {1} │ K {2} │ S {3} │ T {4} │ {5} │";
+    private const string LoggingFormat = "│ Testing mutant {0} / {1} │ K {2} │ S {3} │ T {4} │ E {5} │ {6} │";
 
     private readonly IProgressBar _progressBar;
     private readonly IStopWatchProvider _stopWatch;
@@ -26,6 +26,8 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
     private int _mutantsKilledCount;
     private int _mutantsSurvivedCount;
     private int _mutantsTimeoutCount;
+    private int _mutantsCompileErrorCount;
+    private int _mutantsRuntimeErrorCount;
 
     public ProgressBarReporter(IProgressBar progressBar, IStopWatchProvider stopWatch, IAnsiConsole console = null)
     {
@@ -39,7 +41,7 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
         _stopWatch.Start();
         _mutantsToBeTested = mutantsToBeTested;
 
-        _progressBar.Start(_mutantsToBeTested, string.Format(LoggingFormat, 0, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, RemainingTime()));
+        _progressBar.Start(_mutantsToBeTested, string.Format(LoggingFormat, 0, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, _mutantsRuntimeErrorCount, RemainingTime()));
     }
 
     public void ReportRunTest(IReadOnlyMutant mutantTestResult)
@@ -57,14 +59,20 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
             case MutantStatus.Timeout:
                 _mutantsTimeoutCount++;
                 break;
+            case MutantStatus.CompileError:
+                _mutantsCompileErrorCount++;
+                break;
+            case MutantStatus.RuntimeError:
+                _mutantsRuntimeErrorCount++;
+                break;
         }
 
-        _progressBar.Tick(string.Format(LoggingFormat, _numberOfMutantsRan, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, RemainingTime()));
+        _progressBar.Tick(string.Format(LoggingFormat, _numberOfMutantsRan, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, _mutantsRuntimeErrorCount, RemainingTime()));
     }
 
     public void ReportFinalState()
     {
-        _progressBar.Tick(string.Format(LoggingFormat, _numberOfMutantsRan, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, RemainingTime()));
+        _progressBar.Tick(string.Format(LoggingFormat, _numberOfMutantsRan, _mutantsToBeTested, _mutantsKilledCount, _mutantsSurvivedCount, _mutantsTimeoutCount, _mutantsRuntimeErrorCount, RemainingTime()));
         Dispose();
 
         var length = _mutantsToBeTested.ToString().Length;
@@ -73,6 +81,8 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
         _console.MarkupLine($"Killed:   [Magenta]{_mutantsKilledCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Survived: [Magenta]{_mutantsSurvivedCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Timeout:  [Magenta]{_mutantsTimeoutCount.ToString().PadLeft(length)}[/]");
+        _console.MarkupLine($"Compile Errors: [Magenta]{_mutantsCompileErrorCount.ToString().PadLeft(length)}[/]");
+        _console.MarkupLine($"Runtime Errors: [Magenta]{_mutantsRuntimeErrorCount.ToString().PadLeft(length)}[/]");
     }
 
     private string RemainingTime()

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
@@ -26,7 +26,6 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
     private int _mutantsKilledCount;
     private int _mutantsSurvivedCount;
     private int _mutantsTimeoutCount;
-    private int _mutantsCompileErrorCount;
     private int _mutantsRuntimeErrorCount;
 
     public ProgressBarReporter(IProgressBar progressBar, IStopWatchProvider stopWatch, IAnsiConsole console = null)
@@ -59,9 +58,6 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
             case MutantStatus.Timeout:
                 _mutantsTimeoutCount++;
                 break;
-            case MutantStatus.CompileError:
-                _mutantsCompileErrorCount++;
-                break;
             case MutantStatus.RuntimeError:
                 _mutantsRuntimeErrorCount++;
                 break;
@@ -81,8 +77,7 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
         _console.MarkupLine($"Killed:   [Magenta]{_mutantsKilledCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Survived: [Magenta]{_mutantsSurvivedCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Timeout:  [Magenta]{_mutantsTimeoutCount.ToString().PadLeft(length)}[/]");
-        _console.MarkupLine($"Compile Errors: [Magenta]{_mutantsCompileErrorCount.ToString().PadLeft(length)}[/]");
-        _console.MarkupLine($"Runtime Errors: [Magenta]{_mutantsRuntimeErrorCount.ToString().PadLeft(length)}[/]");
+        _console.MarkupLine($"Errors: [Magenta]{_mutantsRuntimeErrorCount.ToString().PadLeft(length)}[/]");
     }
 
     private string RemainingTime()

--- a/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Progress/ProgressBarReporter.cs
@@ -77,7 +77,7 @@ public class ProgressBarReporter : IProgressBarReporter, IDisposable
         _console.MarkupLine($"Killed:   [Magenta]{_mutantsKilledCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Survived: [Magenta]{_mutantsSurvivedCount.ToString().PadLeft(length)}[/]");
         _console.MarkupLine($"Timeout:  [Magenta]{_mutantsTimeoutCount.ToString().PadLeft(length)}[/]");
-        _console.MarkupLine($"Errors: [Magenta]{_mutantsRuntimeErrorCount.ToString().PadLeft(length)}[/]");
+        _console.MarkupLine($"Errors:  [Magenta]{_mutantsRuntimeErrorCount.ToString().PadLeft(length)}[/]");
     }
 
     private string RemainingTime()

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
@@ -429,7 +429,7 @@ public class AssemblyTestServerTests
         _processMock.SetupGet(p => p.HasExited).Returns(true);
 
         // A crash must be detected immediately as a runtime error, not waited out as a timeout.
-        await Should.ThrowAsync<TestHostCrashedException>(
+        await Should.ThrowAsync<Stryker.TestRunner.TestHostCrashedException>(
             async () => await server.RunTestsAsync(null, TimeSpan.FromSeconds(30)));
     }
 
@@ -448,7 +448,7 @@ public class AssemblyTestServerTests
         _processMock.Setup(p => p.WaitForExitAsync()).Returns(Task.CompletedTask);
         _processMock.SetupGet(p => p.HasExited).Returns(true);
 
-        await Should.ThrowAsync<TestHostCrashedException>(
+        await Should.ThrowAsync<Stryker.TestRunner.TestHostCrashedException>(
             async () => await server.RunTestsAsync(null));
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
@@ -412,6 +412,47 @@ public class AssemblyTestServerTests
     }
 
     [TestMethod]
+    public async Task RunTestsAsync_WithTimeout_ShouldThrowTestHostCrashed_WhenProcessExitsDuringRun()
+    {
+        SetupSuccessfulConnection();
+
+        // Listener that never completes (a crashed host never sends a completion signal)
+        var listener = new TestNodeUpdatesResponseListener(Guid.NewGuid(), _ => Task.CompletedTask);
+        _clientMock.Setup(c => c.RunTestsAsync(It.IsAny<Guid>(), It.IsAny<Func<TestNodeUpdate[], Task>>(), null))
+            .ReturnsAsync(listener);
+
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        // Simulate the test host crashing during the run: the process exits before completion.
+        _processMock.Setup(p => p.WaitForExitAsync()).Returns(Task.CompletedTask);
+        _processMock.SetupGet(p => p.HasExited).Returns(true);
+
+        // A crash must be detected immediately as a runtime error, not waited out as a timeout.
+        await Should.ThrowAsync<TestHostCrashedException>(
+            async () => await server.RunTestsAsync(null, TimeSpan.FromSeconds(30)));
+    }
+
+    [TestMethod]
+    public async Task RunTestsAsync_WithoutTimeout_ShouldThrowTestHostCrashed_WhenProcessExitsDuringRun()
+    {
+        SetupSuccessfulConnection();
+
+        var listener = new TestNodeUpdatesResponseListener(Guid.NewGuid(), _ => Task.CompletedTask);
+        _clientMock.Setup(c => c.RunTestsAsync(It.IsAny<Guid>(), It.IsAny<Func<TestNodeUpdate[], Task>>(), null))
+            .ReturnsAsync(listener);
+
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        _processMock.Setup(p => p.WaitForExitAsync()).Returns(Task.CompletedTask);
+        _processMock.SetupGet(p => p.HasExited).Returns(true);
+
+        await Should.ThrowAsync<TestHostCrashedException>(
+            async () => await server.RunTestsAsync(null));
+    }
+
+    [TestMethod]
     public async Task RunTestsAsync_WithTimeout_ShouldReturnTimedOutTrue_WhenRpcCallBlocks()
     {
         SetupSuccessfulConnection();

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/AssemblyTestServerTests.cs
@@ -141,6 +141,42 @@ public class AssemblyTestServerTests
     }
 
     [TestMethod]
+    public void Constructor_ShouldNotBeAlive()
+    {
+        using var server = CreateServer();
+
+        server.IsAlive.ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ShouldMakeServerAlive_WhenProcessIsRunning()
+    {
+        SetupSuccessfulConnection();
+
+        using var server = CreateServer();
+        await server.StartAsync();
+
+        server.IsAlive.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public async Task IsAlive_ShouldBeFalse_WhenProcessHasExitedAfterStart()
+    {
+        SetupSuccessfulConnection();
+
+        using var server = CreateServer();
+        await server.StartAsync();
+        server.IsAlive.ShouldBeTrue();
+
+        // Simulate the test host crashing after the server was started:
+        // it stays "initialized" but the underlying process is gone.
+        _processMock.SetupGet(p => p.HasExited).Returns(true);
+
+        server.IsInitialized.ShouldBeTrue();
+        server.IsAlive.ShouldBeFalse();
+    }
+
+    [TestMethod]
     public async Task StartAsync_ShouldReturnTrue_WhenAlreadyInitialized()
     {
         SetupSuccessfulConnection();

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
@@ -649,6 +649,70 @@ public class SingleMicrosoftTestPlatformRunnerTests
         result.ResultMessage.ShouldNotContain("passed");
     }
 
+    [TestMethod, Timeout(1000)]
+    public async Task RunAllTestsAsync_CrashedAssembly_DoesNotMarkMutantsAsExecuted()
+    {
+        // Regression: a crashed test host makes an assembly run return the failure sentinel
+        // (TestRunResult(false) => FailingTests == EveryTest). The accumulator must NOT fold that
+        // into "every test ran, none failed" (EveryTest.GetIdentifiers() is empty), which would
+        // mark otherwise-untested mutants as Survived. The mutants must be left untested instead:
+        // ranTests is not EveryTest and failedTests is empty, so Mutant.AnalyzeTestRun keeps Pending.
+        const string assembly = "/path/to/tests.dll";
+        var discovered = new List<TestNode>
+        {
+            new("uid-1", "Test1", "test", "passed"),
+            new("uid-2", "Test2", "test", "passed"),
+        };
+
+        using var runner = new CrashingAssemblyRunner(
+            _testsByAssembly, _testDescriptions, _testSet, _discoveryLock, discovered);
+
+        var mutant = new Mock<IMutant>();
+        mutant.Setup(m => m.Id).Returns(1);
+
+        ITestIdentifiers? capturedFailed = null;
+        ITestIdentifiers? capturedRan = null;
+        bool Update(IReadOnlyList<IMutant> _, ITestIdentifiers failed, ITestIdentifiers ran, ITestIdentifiers __)
+        {
+            capturedFailed = failed;
+            capturedRan = ran;
+            return true;
+        }
+
+        var result = await runner.RunAllTestsAsync(
+            new[] { assembly }, mutantId: 1, mutants: new[] { mutant.Object }, update: Update);
+
+        capturedRan.ShouldNotBeNull();
+        capturedRan!.IsEveryTest.ShouldBeFalse();              // would be true (=> Survived) before the fix
+        capturedFailed.ShouldNotBeNull();
+        capturedFailed!.GetIdentifiers().ShouldBeEmpty();
+        result.SessionTimedOut.ShouldBeFalse();
+        result.ResultMessage.ShouldContain("crash");           // failure reason is surfaced, not swallowed
+    }
+
+    /// <summary>
+    /// Simulates an assembly whose test host crashes: <see cref="RunAssemblyTestsAsync"/> returns the
+    /// failure sentinel produced by the real exception path, without starting any server process.
+    /// </summary>
+    private sealed class CrashingAssemblyRunner : SingleMicrosoftTestPlatformRunner
+    {
+        private readonly List<TestNode> _discovered;
+
+        public CrashingAssemblyRunner(
+            Dictionary<string, List<TestNode>> testsByAssembly,
+            Dictionary<string, MtpTestDescription> testDescriptions,
+            TestSet testSet,
+            object discoveryLock,
+            List<TestNode> discovered)
+            : base(0, testsByAssembly, testDescriptions, testSet, discoveryLock, NullLogger.Instance)
+            => _discovered = discovered;
+
+        internal override Task<(TestRunResult? Result, bool TimedOut, List<TestNode>? DiscoveredTests)> RunAssemblyTestsAsync(
+            string assembly, ITimeoutValueCalculator? timeoutCalc)
+            => Task.FromResult<(TestRunResult?, bool, List<TestNode>?)>(
+                (new TestRunResult(false, "simulated test host crash"), false, _discovered));
+    }
+
     [TestCleanup]
     public void Cleanup()
     {

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
@@ -682,7 +682,7 @@ public class SingleMicrosoftTestPlatformRunnerTests
         var result = await runner.RunAllTestsAsync(
             new[] { assembly }, mutantId: 1, mutants: new[] { mutant.Object }, update: Update);
 
-        result.SessionRuntimeError.ShouldBeTrue();             // signals the host crash to the executor
+        result.SessionHadRuntimeIssue.ShouldBeTrue();             // signals the host crash to the executor
         result.SessionTimedOut.ShouldBeFalse();
         capturedRan.ShouldNotBeNull();
         capturedRan!.IsEveryTest.ShouldBeFalse();              // would be true (=> Survived) before the fix

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
@@ -650,13 +650,13 @@ public class SingleMicrosoftTestPlatformRunnerTests
     }
 
     [TestMethod, Timeout(1000)]
-    public async Task RunAllTestsAsync_CrashedAssembly_DoesNotMarkMutantsAsExecuted()
+    public async Task RunAllTestsAsync_CrashedAssembly_ReportsRuntimeError()
     {
         // Regression: a crashed test host makes an assembly run return the failure sentinel
         // (TestRunResult(false) => FailingTests == EveryTest). The accumulator must NOT fold that
         // into "every test ran, none failed" (EveryTest.GetIdentifiers() is empty), which would
-        // mark otherwise-untested mutants as Survived. The mutants must be left untested instead:
-        // ranTests is not EveryTest and failedTests is empty, so Mutant.AnalyzeTestRun keeps Pending.
+        // mark otherwise-untested mutants as Survived. Instead it surfaces a runtime error so the
+        // mutants are classified as RuntimeError (excluded from the score) by the executor.
         const string assembly = "/path/to/tests.dll";
         var discovered = new List<TestNode>
         {
@@ -682,11 +682,12 @@ public class SingleMicrosoftTestPlatformRunnerTests
         var result = await runner.RunAllTestsAsync(
             new[] { assembly }, mutantId: 1, mutants: new[] { mutant.Object }, update: Update);
 
+        result.SessionRuntimeError.ShouldBeTrue();             // signals the host crash to the executor
+        result.SessionTimedOut.ShouldBeFalse();
         capturedRan.ShouldNotBeNull();
         capturedRan!.IsEveryTest.ShouldBeFalse();              // would be true (=> Survived) before the fix
         capturedFailed.ShouldNotBeNull();
         capturedFailed!.GetIdentifiers().ShouldBeEmpty();
-        result.SessionTimedOut.ShouldBeFalse();
         result.ResultMessage.ShouldContain("crash");           // failure reason is surfaced, not swallowed
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
@@ -165,13 +165,35 @@ internal sealed class AssemblyTestServer : IDisposable
                 return (testResults.ToList(), true);
             }
 
-            var completed = await executeTestsResponse.WaitCompletionAsync(timeout.Value).ConfigureAwait(false);
+            var completionTask = executeTestsResponse.WaitCompletionAsync(timeout.Value);
+            await Task.WhenAny(completionTask, _process!.WaitForExitAsync()).ConfigureAwait(false);
+            ThrowIfHostCrashed(completionTask);
+
+            var completed = await completionTask.ConfigureAwait(false);
             return (testResults.ToList(), !completed);
         }
 
         var response = await _client.RunTestsAsync(runId, onUpdate, testsToRun).ConfigureAwait(false);
-        await response.WaitCompletionAsync().ConfigureAwait(false);
+        var responseCompletion = response.WaitCompletionAsync();
+        await Task.WhenAny(responseCompletion, _process!.WaitForExitAsync()).ConfigureAwait(false);
+        ThrowIfHostCrashed(responseCompletion);
+
+        await responseCompletion.ConfigureAwait(false);
         return (testResults.ToList(), false);
+    }
+
+    /// <summary>
+    /// Throws a <see cref="TestHostCrashedException"/> when the test host process has exited before the
+    /// run completed. A crashed host never sends a completion signal, so without this check the run would
+    /// otherwise wait out the full timeout and be misreported as a timeout instead of a runtime error.
+    /// </summary>
+    private void ThrowIfHostCrashed(Task runCompletion)
+    {
+        if (_process is { HasExited: true } && !runCompletion.IsCompletedSuccessfully)
+        {
+            _logger.LogDebug("{RunnerId}: Test host for {Assembly} exited unexpectedly during the test run", _runnerId, _assembly);
+            throw new TestHostCrashedException($"The test host for {_assembly} exited unexpectedly during the test run.");
+        }
     }
 
     public async Task RestartAsync(bool force = false)

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
@@ -183,7 +183,7 @@ internal sealed class AssemblyTestServer : IDisposable
     }
 
     /// <summary>
-    /// Throws a <see cref="TestHostCrashedException"/> when the test host process has exited before the
+    /// Throws a <see cref="Stryker.TestRunner.TestHostCrashedException"/> when the test host process has exited before the
     /// run completed. A crashed host never sends a completion signal, so without this check the run would
     /// otherwise wait out the full timeout and be misreported as a timeout instead of a runtime error.
     /// </summary>
@@ -192,7 +192,7 @@ internal sealed class AssemblyTestServer : IDisposable
         if (_process is { HasExited: true } && !runCompletion.IsCompletedSuccessfully)
         {
             _logger.LogDebug("{RunnerId}: Test host for {Assembly} exited unexpectedly during the test run", _runnerId, _assembly);
-            throw new TestHostCrashedException($"The test host for {_assembly} exited unexpectedly during the test run.");
+            throw new Stryker.TestRunner.TestHostCrashedException($"The test host for {_assembly} exited unexpectedly during the test run.");
         }
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/AssemblyTestServer.cs
@@ -42,6 +42,14 @@ internal sealed class AssemblyTestServer : IDisposable
 
     public bool IsInitialized => _isInitialized;
 
+    /// <summary>
+    /// True when the server has been initialized and its underlying process is still running.
+    /// A test host that crashed mid-run (e.g. a mutation causing a fatal fault such as a
+    /// <see cref="StackOverflowException"/>) leaves <see cref="IsInitialized"/> true while the
+    /// process is gone; this flag detects that so the server can be recreated instead of reused.
+    /// </summary>
+    public bool IsAlive => _isInitialized && !_disposed && _process is { HasExited: false };
+
     public async Task<bool> StartAsync(CancellationToken cancellationToken = default)
     {
         if (_isInitialized)

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -235,17 +235,32 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
 
     private async Task<AssemblyTestServer> GetOrCreateServerAsync(string assembly)
     {
-        AssemblyTestServer? server;
+        AssemblyTestServer? deadServer = null;
         lock (_serverLock)
         {
-            if (_assemblyServers.TryGetValue(assembly, out server) && server.IsInitialized)
+            if (_assemblyServers.TryGetValue(assembly, out var existing))
             {
-                return server;
+                if (existing.IsAlive)
+                {
+                    return existing;
+                }
+
+                // The server process is no longer alive (e.g. it crashed during a previous run).
+                // Drop it so a fresh server is started rather than reusing a dead RPC connection,
+                // which would fail every subsequent test run instantly.
+                _logger.LogDebug("{RunnerId}: Test server for {Assembly} is no longer alive; recreating", RunnerId, assembly);
+                _assemblyServers.Remove(assembly);
+                deadServer = existing;
             }
         }
 
+        if (deadServer is not null)
+        {
+            await deadServer.StopAsync(force: true).ConfigureAwait(false);
+        }
+
         var environmentVariables = BuildEnvironmentVariables();
-        server = new AssemblyTestServer(assembly, environmentVariables, _logger, RunnerId, _options);
+        var server = new AssemblyTestServer(assembly, environmentVariables, _logger, RunnerId, _options);
 
         var started = await server.StartAsync().ConfigureAwait(false);
         if (!started)
@@ -259,6 +274,25 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         }
 
         return server;
+    }
+
+    /// <summary>
+    /// Force-stops and removes the server for the given assembly so the next run starts a fresh one.
+    /// Used after a run fails because the test host crashed and tore down the RPC connection.
+    /// </summary>
+    private async Task DiscardServerAsync(string assembly)
+    {
+        AssemblyTestServer? server;
+        lock (_serverLock)
+        {
+            _assemblyServers.TryGetValue(assembly, out server);
+            _assemblyServers.Remove(assembly);
+        }
+
+        if (server is not null)
+        {
+            await server.StopAsync(force: true).ConfigureAwait(false);
+        }
     }
 
     private async Task<bool> DiscoverTestsInternalAsync(string assembly)
@@ -360,10 +394,27 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
 
         public List<string> TimedOutTests { get; } = [];
         public bool HasTimeout { get; set; }
+        public bool HasError { get; private set; }
         public TimeSpan TotalDuration { get; private set; }
 
         public void Aggregate(TestRunResult result, List<TestNode>? discoveredTests)
         {
+            // A failure sentinel (FailingTests == EveryTest, produced only by the TestRunResult(false)
+            // path when an assembly run crashes) must NOT be folded into the executed/failed sets:
+            // EveryTest.GetIdentifiers() is empty, so doing so would record "every test ran, none
+            // failed" and report otherwise-untested mutants as Survived. Treat it as an error instead,
+            // leaving those mutants Pending so they are surfaced as "failed to test".
+            if (result.FailingTests.IsEveryTest)
+            {
+                HasError = true;
+                if (!string.IsNullOrWhiteSpace(result.ResultMessage))
+                {
+                    _errorMessages.Add(result.ResultMessage);
+                }
+                TotalDuration += result.Duration;
+                return;
+            }
+
             if (result.ExecutedTests.IsEveryTest)
             {
                 _totalExecutedTests += discoveredTests?.Count ?? 0;
@@ -433,6 +484,11 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
                 {
                     accumulator.Aggregate(result, discoveredTests);
                 }
+            }
+
+            if (accumulator.HasError)
+            {
+                _logger.LogWarning("{RunnerId}: One or more test assemblies could not be run (the test host likely crashed). The affected mutants are left untested instead of being reported as survived.", RunnerId);
             }
 
             var executedTests = accumulator.BuildExecutedTests();
@@ -505,35 +561,61 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         Func<TestNode, bool>? testUidFilter,
         TimeSpan? timeout = null)
     {
-        var startTime = DateTime.UtcNow;
+        // A crashed test host tears down the RPC connection, so the run throws (rather than timing out).
+        // Retry once on a freshly started server: a crash caused by a *previous* mutant then self-heals
+        // for the current mutant instead of corrupting its result.
+        const int maxRunAttempts = 2;
+        Exception? lastRunException = null;
 
-        try
+        for (var attempt = 1; attempt <= maxRunAttempts; attempt++)
         {
-            // Get or create the server for this assembly (reuses existing server)
-            var server = await GetOrCreateServerAsync(assembly).ConfigureAwait(false);
-
-            List<TestNode>? tests = null;
-            lock (_discoveryLock)
+            AssemblyTestServer server;
+            try
             {
-                if (_testsByAssembly.TryGetValue(assembly, out var assemblyTests))
-                {
-                    tests = assemblyTests;
-                }
+                // Get or create the server for this assembly (reuses an existing, live server)
+                server = await GetOrCreateServerAsync(assembly).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // The server could not be started at all; retrying immediately would not help.
+                return (new TestRunResult(false, ex.Message), false);
             }
 
-            var testsToRun = tests?.Where(t => testUidFilter is null || testUidFilter(t)).ToArray();
+            var startTime = DateTime.UtcNow;
+            try
+            {
+                List<TestNode>? tests = null;
+                lock (_discoveryLock)
+                {
+                    if (_testsByAssembly.TryGetValue(assembly, out var assemblyTests))
+                    {
+                        tests = assemblyTests;
+                    }
+                }
 
-            var (testResults, timedOut) = await server.RunTestsAsync(testsToRun, timeout).ConfigureAwait(false);
+                var testsToRun = tests?.Where(t => testUidFilter is null || testUidFilter(t)).ToArray();
 
-            var duration = DateTime.UtcNow - startTime;
-            var result = BuildTestRunResult(testResults, tests?.Count ?? 0, duration);
+                var (testResults, timedOut) = await server.RunTestsAsync(testsToRun, timeout).ConfigureAwait(false);
 
-            return (result, timedOut);
+                var duration = DateTime.UtcNow - startTime;
+                var result = BuildTestRunResult(testResults, tests?.Count ?? 0, duration);
+
+                return (result, timedOut);
+            }
+            catch (Exception ex)
+            {
+                lastRunException = ex;
+                _logger.LogDebug(ex, "{RunnerId}: Test run for {Assembly} failed on attempt {Attempt}/{MaxAttempts}; discarding crashed server",
+                    RunnerId, Path.GetFileName(assembly), attempt, maxRunAttempts);
+
+                // The server most likely crashed; drop it so the next attempt starts a fresh one.
+                await DiscardServerAsync(assembly).ConfigureAwait(false);
+            }
         }
-        catch (Exception ex)
-        {
-            return (new TestRunResult(false, ex.Message), false);
-        }
+
+        // Every attempt failed. Return the failure sentinel; the accumulator recognises it and keeps
+        // the affected mutants Pending (surfaced as "failed to test") rather than marking them Survived.
+        return (new TestRunResult(false, lastRunException?.Message ?? "Test run failed: the test host could not be reached."), false);
     }
 
     /// <summary>

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.MemoryMappedFiles;
 using Microsoft.Extensions.Logging;
 using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
@@ -110,13 +111,26 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
     {
         try
         {
-            File.WriteAllText(_mutantFilePath, mutantId.ToString());
-            _logger.LogDebug("{RunnerId}: Wrote mutant ID {MutantId} to file {FilePath}",
+            // Publish the active mutant id as a fixed 4-byte int through a file-backed memory-mapped view.
+            // The injected MutantControl maps the same file and reads the id on every IsActive call, so the
+            // reused test host always sees the current mutant with no per-call file I/O. Both sides use
+            // CreateFromFile with a null map name (file-backed maps work cross-platform, unlike named maps
+            // which are Windows-only), and FileShare.ReadWrite lets the host keep the file mapped while we
+            // update it between runs.
+            using (var stream = new FileStream(_mutantFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var mmf = MemoryMappedFile.CreateFromFile(stream, null, sizeof(int), MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, leaveOpen: true))
+            using (var accessor = mmf.CreateViewAccessor(0, sizeof(int), MemoryMappedFileAccess.Write))
+            {
+                accessor.Write(0, mutantId);
+                accessor.Flush();
+            }
+
+            _logger.LogDebug("{RunnerId}: Wrote mutant ID {MutantId} to memory-mapped file {FilePath}",
                 RunnerId, mutantId, _mutantFilePath);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "{RunnerId}: Failed to write mutant ID to file {FilePath}",
+            _logger.LogWarning(ex, "{RunnerId}: Failed to write mutant ID to memory-mapped file {FilePath}",
                 RunnerId, _mutantFilePath);
         }
     }

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -626,8 +626,8 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         }
 
         // Every attempt failed. Return the crash sentinel; the accumulator recognises it and flags the
-        // run as an error, so the affected mutants are reported as RuntimeError rather than Survived.
-        return (new TestRunResult(false, lastRunException?.Message ?? "Test run failed: the test host could not be reached."), false);
+        // run as crashed, so the affected mutants are reported as RuntimeError rather than Survived.
+        return (new TestRunResult(false, lastRunException!.Message), false);
     }
 
     /// <summary>

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -399,11 +399,12 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
 
         public void Aggregate(TestRunResult result, List<TestNode>? discoveredTests)
         {
-            // A failure sentinel (FailingTests == EveryTest, produced only by the TestRunResult(false)
+            // A crash sentinel (FailingTests == EveryTest, produced only by the TestRunResult(false)
             // path when an assembly run crashes) must NOT be folded into the executed/failed sets:
             // EveryTest.GetIdentifiers() is empty, so doing so would record "every test ran, none
-            // failed" and report otherwise-untested mutants as Survived. Treat it as an error instead,
-            // leaving those mutants Pending so they are surfaced as "failed to test".
+            // failed" and report otherwise-untested mutants as Survived. Flag it as an error instead;
+            // RunAllTestsAsync then returns a RuntimeError result so the affected mutants are
+            // classified as RuntimeError (excluded from the score) rather than Survived or Killed.
             if (result.FailingTests.IsEveryTest)
             {
                 HasError = true;
@@ -624,8 +625,8 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             }
         }
 
-        // Every attempt failed. Return the failure sentinel; the accumulator recognises it and keeps
-        // the affected mutants Pending (surfaced as "failed to test") rather than marking them Survived.
+        // Every attempt failed. Return the crash sentinel; the accumulator recognises it and flags the
+        // run as an error, so the affected mutants are reported as RuntimeError rather than Survived.
         return (new TestRunResult(false, lastRunException?.Message ?? "Test run failed: the test host could not be reached."), false);
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -486,11 +486,6 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
                 }
             }
 
-            if (accumulator.HasError)
-            {
-                _logger.LogWarning("{RunnerId}: One or more test assemblies could not be run (the test host likely crashed). The affected mutants are left untested instead of being reported as survived.", RunnerId);
-            }
-
             var executedTests = accumulator.BuildExecutedTests();
             var failedTestIds = accumulator.BuildFailedTests();
             var timedOutTestIds = accumulator.BuildTimedOutTests();
@@ -504,6 +499,22 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             if (update is not null && mutants is not null)
             {
                 update.Invoke(mutants, failedTestIds, executedTests, timedOutTestIds);
+            }
+
+            if (accumulator.HasError)
+            {
+                // The test host crashed (e.g. a mutation caused a fatal fault). Signal a runtime error
+                // so the affected mutants are classified as RuntimeError (excluded from the score)
+                // rather than reported as survived or logged as a test failure.
+                _logger.LogDebug("{RunnerId}: A test host crashed during this run; reporting a runtime error for the affected mutant(s).", RunnerId);
+                return TestRunResult.RuntimeError(
+                    testDescriptionValues,
+                    executedTests,
+                    failedTestIds,
+                    timedOutTestIds,
+                    accumulator.BuildErrorMessage(),
+                    accumulator.Messages,
+                    accumulator.TotalDuration);
             }
 
             if (accumulator.HasTimeout)

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/TestHostCrashedException.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/TestHostCrashedException.cs
@@ -1,0 +1,13 @@
+namespace Stryker.TestRunner.MicrosoftTestPlatform;
+
+/// <summary>
+/// Thrown when the test host process exits unexpectedly during a test run (e.g. a mutation caused a
+/// fatal fault such as a stack overflow). This is distinct from a timeout: the host is gone, so the
+/// run is reported as a runtime error rather than waiting out the full timeout.
+/// </summary>
+internal sealed class TestHostCrashedException : Exception
+{
+    public TestHostCrashedException(string message) : base(message)
+    {
+    }
+}

--- a/src/Stryker.TestRunner/Exceptions/TestHostCrashedException.cs
+++ b/src/Stryker.TestRunner/Exceptions/TestHostCrashedException.cs
@@ -1,11 +1,13 @@
-namespace Stryker.TestRunner.MicrosoftTestPlatform;
+using System;
+
+namespace Stryker.TestRunner;
 
 /// <summary>
 /// Thrown when the test host process exits unexpectedly during a test run (e.g. a mutation caused a
 /// fatal fault such as a stack overflow). This is distinct from a timeout: the host is gone, so the
 /// run is reported as a runtime error rather than waiting out the full timeout.
 /// </summary>
-internal sealed class TestHostCrashedException : Exception
+public sealed class TestHostCrashedException : Exception
 {
     public TestHostCrashedException(string message) : base(message)
     {

--- a/src/Stryker.TestRunner/Results/TestRunResult.cs
+++ b/src/Stryker.TestRunner/Results/TestRunResult.cs
@@ -46,10 +46,24 @@ public class TestRunResult : ITestRunResult
         IEnumerable<string> messages,
         TimeSpan duration) => new(vsTestDescriptions, ranTests, failedTest, timedOutTests, message, messages, duration) { SessionTimedOut = true };
 
+    /// <summary>
+    /// Creates a result signalling that the test host crashed and the run could not be completed.
+    /// The covered mutants cannot be conclusively tested and are reported as a runtime error.
+    /// </summary>
+    public static TestRunResult RuntimeError(
+        IEnumerable<IFrameworkTestDescription> vsTestDescriptions,
+        ITestIdentifiers ranTests,
+        ITestIdentifiers failedTest,
+        ITestIdentifiers timedOutTests,
+        string message,
+        IEnumerable<string> messages,
+        TimeSpan duration) => new(vsTestDescriptions, ranTests, failedTest, timedOutTests, message, messages, duration) { SessionRuntimeError = true };
+
     public ITestIdentifiers FailingTests { get; }
     public ITestIdentifiers ExecutedTests { get; }
     public ITestIdentifiers TimedOutTests { get; }
     public bool SessionTimedOut { get; private init; }
+    public bool SessionRuntimeError { get; private init; }
     public string ResultMessage { get; }
     public IEnumerable<string> Messages { get; } = [];
     public TimeSpan Duration { get; }

--- a/src/Stryker.TestRunner/Results/TestRunResult.cs
+++ b/src/Stryker.TestRunner/Results/TestRunResult.cs
@@ -57,15 +57,15 @@ public class TestRunResult : ITestRunResult
         ITestIdentifiers timedOutTests,
         string message,
         IEnumerable<string> messages,
-        TimeSpan duration) => new(vsTestDescriptions, ranTests, failedTest, timedOutTests, message, messages, duration) { SessionRuntimeError = true };
+        TimeSpan duration) => new(vsTestDescriptions, ranTests, failedTest, timedOutTests, message, messages, duration) { SessionHadRuntimeIssue = true };
 
     public ITestIdentifiers FailingTests { get; }
     public ITestIdentifiers ExecutedTests { get; }
     public ITestIdentifiers TimedOutTests { get; }
     public bool SessionTimedOut { get; private init; }
-    public bool SessionRuntimeError { get; private init; }
+    public bool SessionHadRuntimeIssue { get; private init; }
     public string ResultMessage { get; }
-    public IEnumerable<string> Messages { get; } = [];
+    public IEnumerable<string> Messages { get; }
     public TimeSpan Duration { get; }
     public IEnumerable<IFrameworkTestDescription> TestDescriptions { get; }
 }


### PR DESCRIPTION
fixes #3648 
relates to #3094
- The MTP runner now can handle mutations that cause a StackOverflowException. These mutants will be marked as `RuntimeError`.
- Fixes a performance issue where inter-process communication caused severer slowdown on large projects. Using `MemoryMappedFile` instead of a normal file fixes this issue while keeping results the same.

todo:

- [x] Integration tests
- [x] Update all reporters with new state
- [x] Fix performance issue