### PR TITLE
feat(reporters): Add GitLab Code Quality reporter

### DIFF
--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -105,7 +105,7 @@ dotnet stryker --reporter "json"
 This reporter outputs a json file named `gitlab_quality.json` with all mutation testrun info of the last run. The json structure follows the GitLab Code Quality report format defined in [GitLab Docs](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format).
 
 ```bash
-dotnet stryker --reporter "gitlabqualityreport"
+dotnet stryker --reporter "gitlab"
 ```
 
 ## Markdown summary reporter

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -102,7 +102,7 @@ dotnet stryker --reporter "json"
 ```
 
 ## GitLab Code Quality reporter
-This reporter outputs a json file named `gitlab_quality.json` with all mutation testrun info of the last run. The json structure follows the GitLab Code Quality report format defined in (GitLab Docs)[https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format].
+This reporter outputs a json file named `gitlab_quality.json` with all mutation testrun info of the last run. The json structure follows the GitLab Code Quality report format defined in [GitLab Docs](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format).
 
 ```bash
 dotnet stryker --reporter "gitlabqualityreport"

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -101,6 +101,13 @@ This reporter outputs a json file with all mutation testrun info of the last run
 dotnet stryker --reporter "json"
 ```
 
+## GitLab Code Quality reporter
+This reporter outputs a json file named `gitlab_quality.json` with all mutation testrun info of the last run. The json structure follows the GitLab Code Quality report format defined in (GitLab Docs)[https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format].
+
+```bash
+dotnet stryker --reporter "gitlabqualityreport"
+```
+
 ## Markdown summary reporter
 This reporter outputs a Markdown formatted summary file called `mutation-report.md` (by default) in the `StrykerOutput/{date-time}/reports` directory.  
 

--- a/src/Stryker.Abstractions/Options/Reporter.cs
+++ b/src/Stryker.Abstractions/Options/Reporter.cs
@@ -12,5 +12,6 @@ public enum Reporter
     Dashboard,
     RealTimeDashboard,
     Markdown,
-    Baseline
+    Baseline,
+    GitlabQualityReport
 }

--- a/src/Stryker.Abstractions/Options/Reporter.cs
+++ b/src/Stryker.Abstractions/Options/Reporter.cs
@@ -13,5 +13,5 @@ public enum Reporter
     RealTimeDashboard,
     Markdown,
     Baseline,
-    GitlabQualityReport
+    Gitlab
 }

--- a/src/Stryker.Configuration/Options/InputDefinition.cs
+++ b/src/Stryker.Configuration/Options/InputDefinition.cs
@@ -72,26 +72,26 @@ public abstract class Input<TInput> : IInput<TInput>
             if (Default is not string && enumerable is not null)
             {
 
-                optionsString.Append("[");
+                optionsString.Append('[');
                 var count = 0;
                 foreach (var item in enumerable)
                 {
-                    optionsString.Append("'");
+                    optionsString.Append('\'');
                     optionsString.Append(item);
-                    optionsString.Append("'");
+                    optionsString.Append('\'');
                     if (++count < enumerable.Count())
                     {
                         optionsString.Append(", ");
                     }
                 }
 
-                optionsString.Append("]");
+                optionsString.Append(']');
 
                 return optionsString.ToString();
             }
-            optionsString.Append("'");
+            optionsString.Append('\'');
             optionsString.Append(Default.ToString());
-            optionsString.Append("'");
+            optionsString.Append('\'');
             return optionsString.ToString();
         }
         return "";

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
@@ -14,7 +14,7 @@ public class ReportersInputTests : TestBase
     public void ShouldHaveHelpText()
     {
         var target = new ReportersInput();
-        target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, RealTimeDashboard, Markdown, Baseline");
+        target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, RealTimeDashboard, Markdown, Baseline, GitlabQualityReport");
     }
 
     [TestMethod]
@@ -45,20 +45,21 @@ public class ReportersInputTests : TestBase
         var target = new ReportersInput
         {
             SuppliedInput = new[] {
-            Reporter.Html.ToString(),
-            Reporter.Json.ToString(),
-            Reporter.Progress.ToString(),
-            Reporter.Baseline.ToString(),
-            Reporter.ClearText.ToString(),
-            Reporter.ClearTextTree.ToString(),
-            Reporter.Dashboard.ToString(),
-            Reporter.Dots.ToString(),
-        }
+                Reporter.Html.ToString(),
+                Reporter.Json.ToString(),
+                Reporter.Progress.ToString(),
+                Reporter.Baseline.ToString(),
+                Reporter.ClearText.ToString(),
+                Reporter.ClearTextTree.ToString(),
+                Reporter.Dashboard.ToString(),
+                Reporter.Dots.ToString(),
+                Reporter.GitlabQualityReport.ToString(),
+            }
         };
 
         var result = target.Validate(false);
 
-        result.Count().ShouldBe(8);
+        result.Count().ShouldBe(9);
         result.ShouldContain(Reporter.Html);
         result.ShouldContain(Reporter.Json);
         result.ShouldContain(Reporter.Progress);
@@ -67,6 +68,7 @@ public class ReportersInputTests : TestBase
         result.ShouldContain(Reporter.ClearTextTree);
         result.ShouldContain(Reporter.Dashboard);
         result.ShouldContain(Reporter.Dots);
+        result.ShouldContain(Reporter.GitlabQualityReport);
     }
 
     [TestMethod]
@@ -76,7 +78,7 @@ public class ReportersInputTests : TestBase
 
         var ex = Should.Throw<InputException>(() => target.Validate(false));
 
-        ex.Message.ShouldBe($"These reporter values are incorrect: Gibberish, Test.");
+        ex.Message.ShouldBe("These reporter values are incorrect: Gibberish, Test.");
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Options/Inputs/ReportersInputTests.cs
@@ -14,7 +14,7 @@ public class ReportersInputTests : TestBase
     public void ShouldHaveHelpText()
     {
         var target = new ReportersInput();
-        target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, RealTimeDashboard, Markdown, Baseline, GitlabQualityReport");
+        target.HelpText.ShouldBe("Reporters inform about various stages in the mutation testrun. | default: ['Progress', 'Html'] | allowed: All, Progress, Dots, ClearText, ClearTextTree, Json, Html, Dashboard, RealTimeDashboard, Markdown, Baseline, Gitlab");
     }
 
     [TestMethod]
@@ -53,7 +53,7 @@ public class ReportersInputTests : TestBase
                 Reporter.ClearTextTree.ToString(),
                 Reporter.Dashboard.ToString(),
                 Reporter.Dots.ToString(),
-                Reporter.GitlabQualityReport.ToString(),
+                Reporter.Gitlab.ToString(),
             }
         };
 
@@ -68,7 +68,7 @@ public class ReportersInputTests : TestBase
         result.ShouldContain(Reporter.ClearTextTree);
         result.ShouldContain(Reporter.Dashboard);
         result.ShouldContain(Reporter.Dots);
-        result.ShouldContain(Reporter.GitlabQualityReport);
+        result.ShouldContain(Reporter.Gitlab);
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/GitlabQualityReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/GitlabQualityReporterTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text.Json;
+using DotUtils.StreamUtils;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+using Stryker.Configuration.Options;
+using Stryker.Core.ProjectComponents.TestProjects;
+using Stryker.Core.Reporters;
+
+namespace Stryker.Core.UnitTest.Reporters;
+
+[TestClass]
+public class GitlabQualityReporterTests : TestBase
+{
+    private readonly IFileSystem _fileSystemMock = new MockFileSystem();
+    private readonly string _testFilePath = "c:\\mytestfile.cs";
+    private readonly string _testFileContents = @"using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    namespace ExtraProject.XUnit
+    {
+        public class UnitTest1
+        {
+            [TestMethod]
+            public void Test1()
+            {
+                // example test
+            }
+        }
+    }
+    ";
+
+    public GitlabQualityReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
+
+    [TestMethod]
+    public void GitlabQualityReporter_OnAllMutantsTestedShouldWriteJsonToFile()
+    {
+        // arrange
+        var reportName = "gitlab_quality.json";
+        var mockFileSystem = new MockFileSystem();
+        var options = new StrykerOptions
+        {
+            Thresholds = new Thresholds { High = 80, Low = 60, Break = 0 },
+            OutputPath = Directory.GetCurrentDirectory(),
+            ReportFileName = reportName
+        };
+
+        var testProjectsInfo = new TestProjectsInfo(_fileSystemMock)
+        {
+            TestProjects = new List<TestProject>
+            {
+                new(_fileSystemMock, TestHelper.SetupProjectAnalyzerResult(
+                    sourceFiles: new[] { _testFilePath }).Object)
+            }
+        };
+        var node = CSharpSyntaxTree.ParseText(_testFileContents).GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        testProjectsInfo.TestProjects.First().TestFiles.First().AddTest(Guid.Empty.ToString(), "myUnitTestName", node);
+
+        var reporter = new GitlabQualityReporter(options, mockFileSystem);
+
+        // act
+        reporter.OnAllMutantsTested(ReportTestHelper.CreateProjectWith(), testProjectsInfo);
+
+        // assert
+        var reportPath = Path.Combine(options.ReportPath, reportName);
+        mockFileSystem.FileExists(reportPath).ShouldBeTrue($"Path {reportPath} should exist but it does not.");
+        var fileContents = mockFileSystem.File.OpenRead(reportPath);
+        var content = fileContents.ReadToEnd();
+
+        var report = JsonSerializer.Deserialize<dynamic[]>(content);
+
+        report.ShouldNotBeNull();
+        report.Length.ShouldBe(72);
+    }
+}

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -23,7 +23,7 @@ using Stryker.Core.Reporters.Json.SourceFiles;
 namespace Stryker.Core.UnitTest.Reporters.Json;
 
 [TestClass]
-public class JsonReporterTests : TestBase
+public class GitlabQualityReporterTests : TestBase
 {
     private readonly IFileSystem _fileSystemMock = new MockFileSystem();
     private readonly string _testFilePath = "c:\\mytestfile.cs";
@@ -41,7 +41,7 @@ namespace ExtraProject.XUnit
     }
 }
 ";
-    public JsonReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
+    public GitlabQualityReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
 
     [TestMethod]
     public void JsonMutantPositionLine_ThrowsArgumentExceptionWhenSetToLessThan1()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -41,7 +41,7 @@ namespace ExtraProject.XUnit
     }
 }
 ";
-    public GitlabQualityReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
+    public JsonReporterTests() => _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
 
     [TestMethod]
     public void JsonMutantPositionLine_ThrowsArgumentExceptionWhenSetToLessThan1()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -23,7 +23,7 @@ using Stryker.Core.Reporters.Json.SourceFiles;
 namespace Stryker.Core.UnitTest.Reporters.Json;
 
 [TestClass]
-public class GitlabQualityReporterTests : TestBase
+public class JsonReporterTests : TestBase
 {
     private readonly IFileSystem _fileSystemMock = new MockFileSystem();
     private readonly string _testFilePath = "c:\\mytestfile.cs";

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/ReporterFactoryTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
-using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
 using Stryker.Configuration.Options;
 using Stryker.Core.Baseline.Providers;
@@ -52,7 +51,8 @@ public class ReporterFactoryTests : TestBase
         broadcastReporter.Reporters.ShouldContain(r => r is DashboardReporter);
         broadcastReporter.Reporters.ShouldContain(r => r is MarkdownSummaryReporter);
         broadcastReporter.Reporters.ShouldContain(r => r is BaselineReporter);
+        broadcastReporter.Reporters.ShouldContain(r => r is GitlabQualityReporter);
 
-        result.Reporters.Count().ShouldBe(10);
+        result.Reporters.Count().ShouldBe(11);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/GitlabQualityReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/GitlabQualityReporter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Spectre.Console;
+using Stryker.Abstractions;
+using Stryker.Abstractions.Options;
+using Stryker.Abstractions.ProjectComponents;
+using Stryker.Abstractions.Reporting;
+using Stryker.Core.Reporters.Json;
+
+namespace Stryker.Core.Reporters;
+
+public class GitlabQualityReporter : IReporter
+{
+    private readonly IStrykerOptions _options;
+    private readonly IFileSystem _fileSystem;
+    private readonly IAnsiConsole _console;
+
+    public GitlabQualityReporter(
+        IStrykerOptions options,
+        IFileSystem fileSystem = null,
+        IAnsiConsole console = null)
+    {
+        _options = options;
+        _fileSystem = fileSystem ?? new FileSystem();
+        _console = console ?? AnsiConsole.Console;
+    }
+
+    public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent, ITestProjectsInfo testProjectsInfo)
+    {
+        var jsonReport = JsonReport.Build(_options, reportComponent, testProjectsInfo);
+        var filename = "gitlab_quality.json";
+        var reportPath = Path.Combine(_options.ReportPath, filename);
+        var reportUri = "file://" + reportPath.Replace("\\", "/");
+
+        IEnumerable<GitlabJsonItem> mutationReport = ConvertJsonReportToGitlabReport(jsonReport);
+        WriteReportToJsonFile(reportPath, mutationReport);
+
+        var green = new Style(Color.Green);
+        _console.WriteLine();
+        _console.WriteLine("Your Gitlab Quality Report has been generated at:", green);
+
+        if (_console.Profile.Capabilities.Links)
+        {
+            // We must print the report path as the link text because on some terminals links might be supported but not actually clickable: https://github.com/spectreconsole/spectre.console/issues/764
+            _console.Write(new Paragraph(reportPath, green, new Link(reportUri)));
+            _console.WriteLine();
+        }
+        else
+        {
+            _console.WriteLine(reportUri, green);
+        }
+    }
+
+    private void WriteReportToJsonFile(string reportPath, IEnumerable<GitlabJsonItem> mutationReport)
+    {
+        _fileSystem.Directory.CreateDirectory(Path.GetDirectoryName(reportPath));
+        using var file = _fileSystem.File.Create(reportPath);
+        using var writer = new Utf8JsonWriter(file);
+        JsonSerializer.Serialize(writer, mutationReport, JsonReportSerialization.Options);
+    }
+
+    private static List<GitlabJsonItem> ConvertJsonReportToGitlabReport(IJsonReport jsonReport)
+    {
+        var items = new List<GitlabJsonItem>();
+        foreach (var file in jsonReport.Files)
+        {
+            var fileName = file.Key.Replace(jsonReport.ProjectRoot + "\\", "").Replace("\\", "/");
+            var fileContent = file.Value;
+            foreach (var mutant in fileContent.Mutants)
+            {
+                var mutantStatus = Enum.Parse<MutantStatus>(mutant.Status, true);
+                var severity = mutantStatus switch
+                {
+                    MutantStatus.Killed => "info",
+                    MutantStatus.Survived => "major",
+                    _ => "minor"
+                };
+                //var fingerprint = SHA1.HashData();
+                items.Add(new GitlabJsonItem
+                {
+                    Description = !string.IsNullOrEmpty(mutant.Description) ? mutant.Description : mutant.MutatorName,
+                    CheckName = mutant.MutatorName,
+                    Fingerprint = mutant.Id,
+                    Location = new GitlabJsonLocation
+                    {
+                        Path = fileName,
+                        Lines = new GitlabJsonLine
+                        {
+                            Begin = mutant.Location.Start.Line
+                        }
+                    },
+                    Severity = severity
+                });
+            }
+        }
+        return items;
+    }
+
+    public void OnMutantsCreated(IReadOnlyProjectComponent reportComponent, ITestProjectsInfo testProjectsInfo)
+    {
+        // This reporter does not report during the testrun
+    }
+
+    public void OnMutantTested(IReadOnlyMutant result)
+    {
+        // This reporter does not report during the testrun
+    }
+
+    public void OnStartMutantTestRun(IEnumerable<IReadOnlyMutant> mutantsToBeTested)
+    {
+        // This reporter does not report during the testrun
+    }
+
+    protected record GitlabJsonItem
+    {
+        public string Description { get; set; }
+        [JsonPropertyName("check_name")]
+        public string CheckName { get; set; }
+        public string Fingerprint { get; set; }
+        public GitlabJsonLocation Location { get; set; }
+        public string Severity { get; set; }
+    }
+
+    protected record GitlabJsonLocation
+    {
+        public string Path { get; set; }
+        public GitlabJsonLine Lines { get; set; }
+    }
+
+    protected record GitlabJsonLine
+    {
+        public int Begin { get; set; }
+    }
+}

--- a/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
@@ -35,7 +35,7 @@ public class ReporterFactory : IReporterFactory
             { Reporter.RealTimeDashboard, new DashboardReporter(options) },
             { Reporter.Markdown, new MarkdownSummaryReporter(options) },
             { Reporter.Baseline, new BaselineReporter(options) },
-            { Reporter.GitlabQualityReport, new GitlabQualityReporter(options) },
+            { Reporter.Gitlab, new GitlabQualityReporter(options) },
         };
     }
 

--- a/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/ReporterFactory.cs
@@ -34,7 +34,8 @@ public class ReporterFactory : IReporterFactory
             { Reporter.Dashboard, new DashboardReporter(options) },
             { Reporter.RealTimeDashboard, new DashboardReporter(options) },
             { Reporter.Markdown, new MarkdownSummaryReporter(options) },
-            { Reporter.Baseline, new BaselineReporter(options) }
+            { Reporter.Baseline, new BaselineReporter(options) },
+            { Reporter.GitlabQualityReport, new GitlabQualityReporter(options) },
         };
     }
 


### PR DESCRIPTION
Adds the ability for Stryker to output a report that follows GitLab's Code Quality report format.
With this feature, the code quality can be added as an artifact and the results viewed in GitLab's pipeline run (and other GitLab pages).

Killed mutations are informed as "info".
Survived ones are informed as "major".
The rest are informed as "minor".

For more information on GitLab's Code Quality format, check the [doc page](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format).