### PR TITLE
fix(dashboard): do not delete the dashboard report

### DIFF
--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -98,9 +98,6 @@ public class DashboardClient : IDashboardClient
                 batchResponse.EnsureSuccessStatusCode();
                 _batch.Clear();
             }
-
-            var deleteResponse = await _httpClient.DeleteAsync(url);
-            deleteResponse.EnsureSuccessStatusCode();
         }
         catch (Exception exception)
         {

--- a/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
+++ b/src/Stryker.Core/Stryker.Core/Clients/DashboardClient.cs
@@ -98,6 +98,9 @@ public class DashboardClient : IDashboardClient
                 batchResponse.EnsureSuccessStatusCode();
                 _batch.Clear();
             }
+
+            var deleteResponse = await _httpClient.DeleteAsync(url);
+            deleteResponse.EnsureSuccessStatusCode();
         }
         catch (Exception exception)
         {

--- a/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/DashboardReporter.cs
@@ -35,13 +35,13 @@ public class DashboardReporter : IReporter
 
     public void OnAllMutantsTested(IReadOnlyProjectComponent reportComponent, ITestProjectsInfo testProjectsInfo)
     {
-        var mutationReport = JsonReport.Build(_options, reportComponent, testProjectsInfo);
-        _dashboardClient.PublishReport(mutationReport, _options.ProjectVersion).Wait();
-
         if (ShouldPublishInRealTime())
         {
             _dashboardClient.PublishFinished().Wait();
         }
+
+        var mutationReport = JsonReport.Build(_options, reportComponent, testProjectsInfo);
+        _dashboardClient.PublishReport(mutationReport, _options.ProjectVersion).Wait();
     }
 
     private void OpenDashboardReport(string reportUri)


### PR DESCRIPTION
For the past two years I have wondered why I would get "Report could not be found..." error on the dashboard when performing this command:

```sh
dotnet tool run dotnet-stryker --reporter dashboard --open-report:dashboard --version main --dashboard-api-key ******
````

Today I looked at the code and it turns out that the HTTP client performs a DELETE request on the report when all the mutants are tested, obviously deleting it!

Note: this regression was introduced in #2563.