### PR TITLE
fix(mtp): write one coverage file per test assembly host to prevent nondeterministic coverage loss

### DIFF
--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -197,7 +197,11 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 360);
+        // Coverage is the union over all four test projects, so the Timeout.cs mutants covered only
+        // by the MSTest project count as covered (1 survived + 2 timeout), like in the MSTestMTP run.
+        // Before coverage files were split per test host, the final flush overwrote the shared
+        // file, usually losing exactly those three mutants to NoCoverage.
+        CheckReportMutants(report, total: 670, ignored: 274, survived: 2, killed: 1, timeout: 2, nocoverage: 357);
         CheckReportTestCounts(report, total: 0); // MTP doesn't report tests yet
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerCoverageTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerCoverageTests.cs
@@ -22,29 +22,32 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
         _discoveryLock = new object();
     }
 
+    private SingleMicrosoftTestPlatformRunner CreateRunner(int runnerId) =>
+        new(runnerId,
+            _testsByAssembly,
+            _testDescriptions,
+            _testSet,
+            _discoveryLock,
+            NullLogger.Instance);
+
     [TestMethod]
     public async Task SetCoverageMode_ShouldEnableCoverageMode()
     {
         var runnerId = 600;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
-        
+        string? coverageFilePath = null;
+
         try
         {
-            // Create an existing coverage file that should be deleted
-            await File.WriteAllTextAsync(coverageFilePath, "1,2,3");
-            File.Exists(coverageFilePath).ShouldBeTrue("Setup: coverage file should exist before test");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
+            using var runner = CreateRunner(runnerId);
 
             // Create a test assembly to trigger server creation
             var testAssembly = typeof(SingleMicrosoftTestPlatformRunnerCoverageTests).Assembly.Location;
             await runner.DiscoverTestsAsync(testAssembly);
+
+            // Create an existing coverage file for the assembly that should be deleted
+            coverageFilePath = runner.GetCoverageFilePath(testAssembly);
+            await File.WriteAllTextAsync(coverageFilePath, "1,2,3");
+            File.Exists(coverageFilePath).ShouldBeTrue("Setup: coverage file should exist before test");
 
             // Enable coverage mode
             runner.SetCoverageMode(true);
@@ -64,7 +67,7 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
         }
         finally
         {
-            if (File.Exists(coverageFilePath))
+            if (coverageFilePath is not null && File.Exists(coverageFilePath))
             {
                 File.Delete(coverageFilePath);
             }
@@ -75,25 +78,20 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     public async Task SetCoverageMode_ShouldDisableCoverageMode()
     {
         var runnerId = 601;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
-        
+        string? coverageFilePath = null;
+
         try
         {
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
+            using var runner = CreateRunner(runnerId);
 
             var testAssembly = typeof(SingleMicrosoftTestPlatformRunnerCoverageTests).Assembly.Location;
 
             // Enable coverage mode first
             runner.SetCoverageMode(true);
             await runner.DiscoverTestsAsync(testAssembly);
-            
-            // Create a coverage file
+
+            // Create a coverage file for the assembly
+            coverageFilePath = runner.GetCoverageFilePath(testAssembly);
             await File.WriteAllTextAsync(coverageFilePath, "1,2,3");
             File.Exists(coverageFilePath).ShouldBeTrue("Setup: coverage file should exist");
 
@@ -114,7 +112,7 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
         }
         finally
         {
-            if (File.Exists(coverageFilePath))
+            if (coverageFilePath is not null && File.Exists(coverageFilePath))
             {
                 File.Delete(coverageFilePath);
             }
@@ -125,20 +123,15 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     public async Task SetCoverageMode_ShouldNoOp_WhenModeIsAlreadySet()
     {
         var runnerId = 602;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
-        
+        string? coverageFilePath = null;
+
         try
         {
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
+            using var runner = CreateRunner(runnerId);
 
             var testAssembly = typeof(SingleMicrosoftTestPlatformRunnerCoverageTests).Assembly.Location;
             await runner.DiscoverTestsAsync(testAssembly);
+            coverageFilePath = runner.GetCoverageFilePath(testAssembly);
 
             // Enable coverage mode
             runner.SetCoverageMode(true);
@@ -146,7 +139,7 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
 
             // Create a coverage file to verify no-op doesn't delete it
             await File.WriteAllTextAsync(coverageFilePath, "test-data");
-            
+
             // Try to enable again - should do nothing (no server disposal, no file deletion)
             runner.SetCoverageMode(true);
             File.Exists(coverageFilePath).ShouldBeTrue("Coverage file should NOT be deleted when mode already enabled");
@@ -155,20 +148,20 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
             // Verify servers are still functional (not disposed)
             var result = await runner.DiscoverTestsAsync(testAssembly);
             result.ShouldBeTrue("Servers should still be functional after no-op");
-            
+
             // Disable coverage mode
             runner.SetCoverageMode(false);
-            
+
             // Try to disable again - should do nothing (no server disposal)
             runner.SetCoverageMode(false);
-            
+
             // Verify servers are still functional
             result = await runner.DiscoverTestsAsync(testAssembly);
             result.ShouldBeTrue("Servers should still be functional after no-op disable");
         }
         finally
         {
-            if (File.Exists(coverageFilePath))
+            if (coverageFilePath is not null && File.Exists(coverageFilePath))
             {
                 File.Delete(coverageFilePath);
             }
@@ -180,13 +173,7 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     {
         var runnerId = 603;
 
-        using var runner = new SingleMicrosoftTestPlatformRunner(
-            runnerId,
-            _testsByAssembly,
-            _testDescriptions,
-            _testSet,
-            _discoveryLock,
-            NullLogger.Instance);
+        using var runner = CreateRunner(runnerId);
 
         var testAssembly = typeof(SingleMicrosoftTestPlatformRunnerCoverageTests).Assembly.Location;
 
@@ -206,15 +193,46 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     }
 
     [TestMethod]
+    public void GetCoverageFilePath_ShouldBeStablePerAssembly_AndUniqueAcrossAssemblies()
+    {
+        using var runner = CreateRunner(508);
+        using var otherRunner = CreateRunner(509);
+        using var sameIdRunner = CreateRunner(508);
+
+        var pathA = runner.GetCoverageFilePath("/some/dir/Tests.dll");
+        var pathASecondCall = runner.GetCoverageFilePath("/some/dir/Tests.dll");
+        var pathB = runner.GetCoverageFilePath("/some/dir/OtherTests.dll");
+        // Same file name in a different directory must still get its own coverage file
+        var pathC = runner.GetCoverageFilePath("/another/dir/Tests.dll");
+        var pathOtherRunner = otherRunner.GetCoverageFilePath("/some/dir/Tests.dll");
+        var pathSameIdRunner = sameIdRunner.GetCoverageFilePath("/some/dir/Tests.dll");
+
+        pathASecondCall.ShouldBe(pathA, "path should be stable for the same assembly");
+        pathB.ShouldNotBe(pathA, "different assemblies should get different coverage files");
+        pathC.ShouldNotBe(pathA, "same assembly file name in another directory should get its own coverage file");
+        pathOtherRunner.ShouldNotBe(pathA, "different runners should get different coverage files");
+        pathSameIdRunner.ShouldNotBe(pathA, "the per-instance nonce should separate runner instances even when they share an id");
+
+        // The base name embeds the process id and a per-instance nonce so a run does not pick up
+        // files written by an earlier (possibly crashed) run or a concurrent Stryker process
+        Path.GetFileName(pathA).ShouldStartWith($"stryker-coverage-{Environment.ProcessId}-");
+
+        // Long assembly names are truncated (the hash keeps the name unique), so the file name
+        // stays well clear of path-length limits
+        var longName = new string('a', 200) + ".dll";
+        var longPath = runner.GetCoverageFilePath($"/some/dir/{longName}");
+        var longPathOtherDir = runner.GetCoverageFilePath($"/another/dir/{longName}");
+        Path.GetFileName(longPath).Length.ShouldBeLessThan(90);
+        longPathOtherDir.ShouldNotBe(longPath, "truncated names must still be distinct via the path hash");
+    }
+
+    [TestMethod]
     public void ReadCoverageData_ShouldReturnEmpty_WhenFileDoesNotExist()
     {
-        using var runner = new SingleMicrosoftTestPlatformRunner(
-            500,
-            _testsByAssembly,
-            _testDescriptions,
-            _testSet,
-            _discoveryLock,
-            NullLogger.Instance);
+        using var runner = CreateRunner(500);
+
+        // Assign a coverage file for an assembly but never create the file
+        runner.GetCoverageFilePath("Tests.dll");
 
         var result = runner.ReadCoverageData();
 
@@ -225,20 +243,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldReturnEmpty_WhenFileIsEmpty()
     {
-        var runnerId = 501;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(501);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, string.Empty);
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -257,20 +267,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldReturnEmpty_WhenFileContainsWhitespace()
     {
-        var runnerId = 502;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(502);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, "   \n\t  ");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -289,20 +291,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldParseCoveredMutants()
     {
-        var runnerId = 503;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(503);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, "1,2,3");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -324,20 +318,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldParseCoveredAndStaticMutants()
     {
-        var runnerId = 504;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(504);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, "1,2,3;10,20");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -345,7 +331,7 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
             result.CoveredMutants.ShouldContain(1);
             result.CoveredMutants.ShouldContain(2);
             result.CoveredMutants.ShouldContain(3);
-            
+
             result.StaticMutants.Count.ShouldBe(2);
             result.StaticMutants.ShouldContain(10);
             result.StaticMutants.ShouldContain(20);
@@ -362,20 +348,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldHandleSingleMutant()
     {
-        var runnerId = 505;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(505);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, "42");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -395,20 +373,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldReturnEmptyCovered_WhenOnlyStaticMutantsPresent()
     {
-        var runnerId = 506;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(506);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, ";5,6,7");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -430,20 +400,12 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     [TestMethod]
     public void ReadCoverageData_ShouldHandleTrailingSemicolon()
     {
-        var runnerId = 507;
-        var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{runnerId}.txt");
+        using var runner = CreateRunner(507);
+        var coverageFilePath = runner.GetCoverageFilePath("Tests.dll");
 
         try
         {
             File.WriteAllText(coverageFilePath, "1,2,3;");
-
-            using var runner = new SingleMicrosoftTestPlatformRunner(
-                runnerId,
-                _testsByAssembly,
-                _testDescriptions,
-                _testSet,
-                _discoveryLock,
-                NullLogger.Instance);
 
             var result = runner.ReadCoverageData();
 
@@ -460,15 +422,52 @@ public class SingleMicrosoftTestPlatformRunnerCoverageTests
     }
 
     [TestMethod]
+    public void ReadCoverageData_ShouldUnionCoverageAcrossAssemblies()
+    {
+        // Regression test: every test assembly's host writes its own coverage file (the injected
+        // MutantControl overwrites its file on process exit), and the runner must union them.
+        // With a single shared file, the final flush replaced the others, so only one assembly's
+        // coverage survived a multi-assembly run.
+        using var runner = CreateRunner(510);
+        var firstFilePath = runner.GetCoverageFilePath("FirstTests.dll");
+        var secondFilePath = runner.GetCoverageFilePath("SecondTests.dll");
+        var thirdFilePath = runner.GetCoverageFilePath("ThirdTests.dll");
+
+        try
+        {
+            File.WriteAllText(firstFilePath, "1,2,3;10");
+            File.WriteAllText(secondFilePath, "3,4;10,20");
+            // The third assembly's host never wrote coverage (e.g. it crashed); it must not
+            // prevent the other files from being read.
+
+            var result = runner.ReadCoverageData();
+
+            result.CoveredMutants.Count.ShouldBe(4);
+            result.CoveredMutants.ShouldContain(1);
+            result.CoveredMutants.ShouldContain(2);
+            result.CoveredMutants.ShouldContain(3);
+            result.CoveredMutants.ShouldContain(4);
+
+            result.StaticMutants.Count.ShouldBe(2);
+            result.StaticMutants.ShouldContain(10);
+            result.StaticMutants.ShouldContain(20);
+        }
+        finally
+        {
+            foreach (var path in new[] { firstFilePath, secondFilePath, thirdFilePath })
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+
+    [TestMethod]
     public async Task ResetServerAsync_ShouldDisposeAndClearAllServers()
     {
-        using var runner = new SingleMicrosoftTestPlatformRunner(
-            0,
-            _testsByAssembly,
-            _testDescriptions,
-            _testSet,
-            _discoveryLock,
-            NullLogger.Instance);
+        using var runner = CreateRunner(0);
 
         // Populate _assemblyServers by discovering tests against the real test assembly
         var testAssembly = typeof(SingleMicrosoftTestPlatformRunnerCoverageTests).Assembly.Location;

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/SingleMicrosoftTestPlatformRunnerTests.cs
@@ -717,13 +717,13 @@ public class SingleMicrosoftTestPlatformRunnerTests
     [TestCleanup]
     public void Cleanup()
     {
-        // Clean up any temporary coverage files created during tests
+        // Clean up any temporary coverage files created during tests (one file per assembly,
+        // named stryker-coverage-{processId}-{runnerId}-{assembly}-{hash}.txt)
         for (int id = 1; id <= 20; id++)
         {
-            var coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{id}.txt");
             try
             {
-                if (File.Exists(coverageFilePath))
+                foreach (var coverageFilePath in Directory.GetFiles(Path.GetTempPath(), $"stryker-coverage-{Environment.ProcessId}-{id}-*.txt"))
                 {
                     File.Delete(coverageFilePath);
                 }
@@ -1409,8 +1409,6 @@ public class SingleMicrosoftTestPlatformRunnerTests
 
     private class TestableRunnerForCoverage : SingleMicrosoftTestPlatformRunner
     {
-        private readonly int _id;
-
         public TestableRunnerForCoverage(
             int id,
             Dictionary<string, List<TestNode>> testsByAssembly,
@@ -1420,10 +1418,9 @@ public class SingleMicrosoftTestPlatformRunnerTests
             ILogger logger)
             : base(id, testsByAssembly, testDescriptions, testSet, discoveryLock, logger)
         {
-            _id = id;
         }
 
-        public string CoverageFilePath => Path.Combine(Path.GetTempPath(), $"stryker-coverage-{_id}.txt");
+        public string CoverageFilePath => GetCoverageFilePath("TestableCoverage.dll");
 
         public bool IsCoverageModeEnabled
         {

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/SingleMicrosoftTestPlatformRunner.cs
@@ -1,5 +1,8 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Stryker.Abstractions;
 using Stryker.Abstractions.Options;
@@ -26,7 +29,13 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
     private readonly object _discoveryLock;
     private readonly ILogger _logger;
     private readonly string _mutantFilePath;
-    private readonly string _coverageFilePath;
+    private readonly string _coverageFilePathBase;
+    // One coverage file per test assembly. The injected MutantControl flushes coverage with an
+    // unconditional overwrite on process exit, so with test hosts sharing a single file the last
+    // flush to land replaces all the others: only one assembly's coverage survives, and which one
+    // depends on server stop order and process shutdown timing. Giving every assembly's host its
+    // own file and unioning them at read time makes coverage independent of both.
+    private readonly ConcurrentDictionary<string, string> _coverageFilePaths = new();
     private readonly IStrykerOptions? _options;
 
     private readonly Dictionary<string, AssemblyTestServer> _assemblyServers = new();
@@ -53,9 +62,16 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         _logger = logger;
         _options = options;
 
-        // Create unique file paths for this runner to communicate with the test process
+        // Create unique file paths for this runner to communicate with the test process.
+        // The coverage base name embeds the process id plus a per-instance nonce: coverage files
+        // are only deleted once their path has been assigned, so a predictable name could let a
+        // run read a stale file left behind by a crashed earlier run (same runner id, same
+        // assembly), and concurrent Stryker processes could clobber each other's files. The nonce
+        // covers what the process id alone does not (pid reuse, several runner instances with the
+        // same id in one process).
         _mutantFilePath = Path.Combine(Path.GetTempPath(), $"stryker-mutant-{_id}.txt");
-        _coverageFilePath = Path.Combine(Path.GetTempPath(), $"stryker-coverage-{_id}.txt");
+        _coverageFilePathBase = Path.Combine(Path.GetTempPath(),
+            $"stryker-coverage-{Environment.ProcessId}-{_id}-{Guid.NewGuid().ToString("N")[..8]}");
 
         // Initialize with no active mutation
         WriteMutantIdToFile(-1);
@@ -135,7 +151,7 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         }
     }
 
-    private Dictionary<string, string?> BuildEnvironmentVariables()
+    private Dictionary<string, string?> BuildEnvironmentVariables(string assembly)
     {
         var envVars = new Dictionary<string, string?>
         {
@@ -147,11 +163,29 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
         // Add coverage filename when in coverage mode (MutantControl will combine with temp path)
         if (_coverageMode)
         {
-            envVars["STRYKER_COVERAGE_FILE"] = Path.GetFileName(_coverageFilePath);
+            envVars["STRYKER_COVERAGE_FILE"] = Path.GetFileName(GetCoverageFilePath(assembly));
         }
 
         return envVars;
     }
+
+    /// <summary>
+    /// Returns the coverage file path assigned to the given test assembly, assigning one on first
+    /// use. The base embeds the process id, runner id and a per-instance nonce (files from other
+    /// processes, runners and runner instances must not collide); the hash of the assembly path
+    /// distinguishes assemblies in different directories that share a file name. The assembly name
+    /// itself is only included, truncated, to keep the file recognizable when debugging.
+    /// </summary>
+    internal string GetCoverageFilePath(string assembly) =>
+        _coverageFilePaths.GetOrAdd(assembly, static (path, basePath) =>
+        {
+            var name = new string(Path.GetFileNameWithoutExtension(path)
+                .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+                .Take(32)
+                .ToArray());
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(path)))[..8];
+            return $"{basePath}-{name}-{hash}.txt";
+        }, _coverageFilePathBase);
 
     /// <summary>
     /// Enables or disables coverage capture mode. When enabled, the test process will track
@@ -178,43 +212,51 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             _assemblyServers.Clear();
         }
 
-        // Clean up any existing coverage file, even when enabling, to ensure we start fresh
-        DeleteCoverageFile();
+        // Clean up any existing coverage files, even when enabling, to ensure we start fresh
+        DeleteCoverageFiles();
     }
 
     /// <summary>
-    /// Reads coverage data from the coverage file written by the test process.
+    /// Reads coverage data from the per-assembly coverage files written by the test processes,
+    /// unioned across all assemblies this runner started a server for.
     /// Returns the covered mutants and static mutants as separate lists.
     /// </summary>
     public (IReadOnlyList<int> CoveredMutants, IReadOnlyList<int> StaticMutants) ReadCoverageData()
     {
-        if (!File.Exists(_coverageFilePath))
-        {
-            _logger.LogDebug("{RunnerId}: Coverage file not found at {Path}", RunnerId, _coverageFilePath);
-            return (Array.Empty<int>(), Array.Empty<int>());
-        }
+        var coveredMutants = new HashSet<int>();
+        var staticMutants = new HashSet<int>();
 
-        try
+        foreach (var (assembly, coverageFilePath) in _coverageFilePaths)
         {
-            var content = File.ReadAllText(_coverageFilePath).Trim();
-            _logger.LogDebug("{RunnerId}: Read coverage data: {Content}", RunnerId, content);
-
-            if (string.IsNullOrEmpty(content))
+            if (!File.Exists(coverageFilePath))
             {
-                return (Array.Empty<int>(), Array.Empty<int>());
+                _logger.LogDebug("{RunnerId}: Coverage file for {Assembly} not found at {Path}",
+                    RunnerId, Path.GetFileName(assembly), coverageFilePath);
+                continue;
             }
 
-            var parts = content.Split(';');
-            var coveredMutants = ParseMutantIds(parts.Length > 0 ? parts[0] : string.Empty);
-            var staticMutants = ParseMutantIds(parts.Length > 1 ? parts[1] : string.Empty);
+            try
+            {
+                var content = File.ReadAllText(coverageFilePath).Trim();
+                _logger.LogDebug("{RunnerId}: Read coverage data for {Assembly}: {Content}",
+                    RunnerId, Path.GetFileName(assembly), content);
 
-            return (coveredMutants, staticMutants);
+                if (string.IsNullOrEmpty(content))
+                {
+                    continue;
+                }
+
+                var parts = content.Split(';');
+                coveredMutants.UnionWith(ParseMutantIds(parts.Length > 0 ? parts[0] : string.Empty));
+                staticMutants.UnionWith(ParseMutantIds(parts.Length > 1 ? parts[1] : string.Empty));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "{RunnerId}: Failed to read coverage file at {Path}", RunnerId, coverageFilePath);
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "{RunnerId}: Failed to read coverage file at {Path}", RunnerId, _coverageFilePath);
-            return (Array.Empty<int>(), Array.Empty<int>());
-        }
+
+        return (coveredMutants.ToList(), staticMutants.ToList());
     }
 
     private static IReadOnlyList<int> ParseMutantIds(string idString)
@@ -232,18 +274,21 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             .ToList();
     }
 
-    private void DeleteCoverageFile()
+    private void DeleteCoverageFiles()
     {
-        try
+        foreach (var coverageFilePath in _coverageFilePaths.Values)
         {
-            if (File.Exists(_coverageFilePath))
+            try
             {
-                File.Delete(_coverageFilePath);
+                if (File.Exists(coverageFilePath))
+                {
+                    File.Delete(coverageFilePath);
+                }
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "{RunnerId}: Failed to delete coverage file at {Path}", RunnerId, _coverageFilePath);
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "{RunnerId}: Failed to delete coverage file at {Path}", RunnerId, coverageFilePath);
+            }
         }
     }
 
@@ -273,7 +318,7 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
             await deadServer.StopAsync(force: true).ConfigureAwait(false);
         }
 
-        var environmentVariables = BuildEnvironmentVariables();
+        var environmentVariables = BuildEnvironmentVariables(assembly);
         var server = new AssemblyTestServer(assembly, environmentVariables, _logger, RunnerId, _options);
 
         var started = await server.StartAsync().ConfigureAwait(false);
@@ -758,16 +803,13 @@ public class SingleMicrosoftTestPlatformRunner : IDisposable
                 {
                     File.Delete(_mutantFilePath);
                 }
-                if (File.Exists(_coverageFilePath))
-                {
-                    File.Delete(_coverageFilePath);
-                }
             }
             catch (Exception ex)
             {
                 // Ignore cleanup errors
                 _logger.LogWarning(ex, "{RunnerId}: Failed to clean up temp files", RunnerId);
             }
+            DeleteCoverageFiles();
         }
         _disposed = true;
     }


### PR DESCRIPTION
# fix(mtp): write one coverage file per test assembly host to prevent nondeterministic coverage loss

### Summary

MTP solution runs start one test host per test assembly, but all hosts currently receive the same `STRYKER_COVERAGE_FILE`. The injected `MutantControl` flushes coverage with `File.WriteAllText` on process exit, so each host replaces the previous contents instead of merging with them. In a multi-assembly run, the final successful flush determines which assembly's coverage survives.

This PR assigns each assembly host its own coverage file and unions those files when reading coverage. `MutantControl` is unchanged.

### Symptom

The `integration-test (windows-latest, MTPSolution, netcore)` job failed intermittently with:

```text
actualSurvived   should be 1  but was 2
actualTimeout    should be 0  but was 2
actualNoCoverage should be 360 but was 357
```

Example: Integration Tests run `28915858912`, job `85782638342`, on #3695. That PR changed MTP runner isolation behavior, but not the coverage-file plumbing.

### Root Cause

The three moved mutants are the relational mutants of `while (1 < 0)` in `StrykerFeatures/Timeout.cs`:

- `<` -> `<=` still never enters the loop, so it survives.
- `<` -> `>` and `<` -> `>=` loop forever, so they time out.

Of the four MTP sample projects, only `UnitTests.MSTest` covers `Timeout.cs`; the XUnit, NUnit, and TUnit samples do not touch it. Since every sample covers the same `KilledMutants.IsExpiredBool` mutants, the MSTest host's covered set is a superset of the others.

Observed fingerprints from `Coverage capture complete: N mutations covered`:

- Clobbered outcome: `3 covered`, `NoCoverage: 360`, matching the checked-in baseline.
- Failing Windows job: `14 covered`, `NoCoverage: 357`, with `Timeout.cs` tested.
- With this fix: `14 covered` on successful coverage captures, independent of flush order.

So the old `MTPSolution` baseline was green because coverage from one or more hosts was being lost. Single-project MTP categories have one host and nothing to overwrite, which is why `MSTestMTP` already expects `timeout: 2` from these same mutants.

### Fix

- `SingleMicrosoftTestPlatformRunner` assigns a coverage file per assembly:
  `stryker-coverage-{processId}-{runnerId}-{nonce8}-{assemblyName<=32}-{pathHash8}.txt`
- The path is stable per assembly for the runner's lifetime.
- `ReadCoverageData()` unions covered/static ids across all assigned per-assembly files.
- Missing files are skipped, so one crashed host does not erase coverage from the others.
- `SetCoverageMode` and `Dispose` clean up all assigned coverage files.

### Reviewer Notes

1. Baseline update vs ignore rule

   The second commit changes `CSharp_NetCore_MTPSolution` to:

   ```text
   survived: 2
   killed: 1
   timeout: 2
   nocoverage: 357
   ```

   These are the values produced when the MSTest coverage survives, and they are consistent with `MSTestMTP` already expecting `timeout: 2` for the same `Timeout.cs` mutants. The trade-off is two timeout mutants in the MTPSolution job. If maintainers prefer keeping that integration job faster, an ignore rule for `Timeout.cs` in the solution config would also work, with `nocoverage` adjusted accordingly.

2. Process id + nonce in the file name

   Coverage files are only deleted after their paths have been assigned. With predictable names, a run could read a stale file left by a crashed earlier run, and concurrent Stryker processes could share names. The process id handles ordinary cross-process cases; the nonce covers pid reuse and same-id runner instances in one process.

   Hard-crash leftovers may remain in temp instead of being overwritten by a later run, but these files are tiny and the existing mutant-id file already behaves similarly on crash.

3. Mutant-id file intentionally unchanged

   `stryker-mutant-{runnerId}.txt` has an analogous concurrent-process collision risk, but it is a live control channel with different failure modes and existing tests. I left it unchanged to keep this PR focused on coverage loss.

4. No merge-on-write in `MutantControl`

   An alternative fix would be read-union-write under a cross-process lock in the injected helper. That would add locking/retry logic to C# 2-compatible code that runs inside every user's test process. Once each coverage file has one owning host, merge-on-write is unnecessary.

### Verification

- `Stryker.TestRunner.MicrosoftTestPlatform.UnitTest` passes, including:
  - `ReadCoverageData_ShouldUnionCoverageAcrossAssemblies`
  - path stability/uniqueness tests
  - name truncation test
  - same-id runner nonce separation test
- Local before/after on `MTPSolution` with packed CLI and `--solution MicrosoftTestPlatform.slnx --test-runner mtp`:
  - pre-fix: `3 covered`, `NoCoverage: 360`
  - post-fix: `14 covered`, `NoCoverage: 357`
- `MSTestMTP` passes against its unchanged baseline, confirming single-assembly behavior is unaffected.

### Related

- #3689 / #3629: the cumulative "every test covers every covered mutant" model is unchanged. This PR only makes the cumulative set complete and deterministic.
- #3516: per-test coverage via host restarts reuses the same `ProcessExit` flush. Per-assembly coverage files compose with it, though both PRs touch `SingleMicrosoftTestPlatformRunner.cs`, so whichever lands second will need a small rebase.
- Explains the Windows CI flake observed on #3695.