### PR TITLE
fix: pass analyzer config options to source generators

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/Buildalyzer/AnalyzerResultExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
@@ -432,4 +433,61 @@ public class AnalyzerResultExtensionsTests
 
     private static StrykerOptions CreateStrykerOptions(LanguageVersion languageVersion = LanguageVersion.CSharp13) =>
         new() { LanguageVersion = languageVersion };
+
+    [TestMethod]
+    public void GetAnalyzerConfigOptionsProvider_ShouldParseAnalyzerConfigFiles_WhenProvided()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"stryker-analyzer-config-{Path.GetRandomFileName().Replace(".", string.Empty)}");
+        var additionalFilePath = Path.Combine(tempDirectory, "NativeMethods.txt");
+        var analyzerConfigPath = Path.Combine(tempDirectory, "global.editorconfig");
+        var sentinelMetadataPath = "C:/some/metadata.json";
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            File.WriteAllText(additionalFilePath, "content");
+            var sectionPath = additionalFilePath.Replace('\\', '/');
+            File.WriteAllText(analyzerConfigPath, $@"is_global = true
+build_property.CsWin32InputMetadataPaths = {sentinelMetadataPath}
+
+[{sectionPath}]
+build_metadata.AdditionalFiles.SourceItemGroup = AdditionalFiles");
+            var analyzerResult = TestHelper.SetupProjectAnalyzerResult(properties: new Dictionary<string, string>(), projectFilePath: Path.Combine(tempDirectory, "test.csproj")).Object;
+            Mock.Get(analyzerResult)
+                .SetupGet(x => x.AdditionalFiles)
+                .Returns([additionalFilePath]);
+            // Use a PROJECT-RELATIVE analyzer config path (as MSBuild emits for the generated
+            // editorconfig) to prove it is resolved against the project directory, not the CWD.
+            Mock.Get(analyzerResult)
+                .SetupGet(x => x.CompilerArguments)
+                .Returns([$"/analyzerconfig:{Path.GetFileName(analyzerConfigPath)}"]);
+
+            var provider = analyzerResult.GetAnalyzerConfigOptionsProvider();
+            provider.GlobalOptions.TryGetValue("build_property.CsWin32InputMetadataPaths", out var globalValue).ShouldBe(true);
+            globalValue.ShouldBe(sentinelMetadataPath);
+
+            var additionalText = analyzerResult.GetAdditionalTexts().Single(x => x.Path == additionalFilePath);
+            provider.GetOptions(additionalText).TryGetValue("build_metadata.AdditionalFiles.SourceItemGroup", out var additionalValue).ShouldBe(true);
+            additionalValue.ShouldBe("AdditionalFiles");
+
+            var fallbackResult = TestHelper.SetupProjectAnalyzerResult(properties: new Dictionary<string, string> { { "Foo", "Bar" } }).Object;
+            var fallbackProvider = fallbackResult.GetAnalyzerConfigOptionsProvider();
+            fallbackProvider.GlobalOptions.TryGetValue("build_property.Foo", out var fallbackValue).ShouldBe(true);
+            fallbackValue.ShouldBe("Bar");
+        }
+        finally
+        {
+            if (File.Exists(analyzerConfigPath))
+            {
+                File.Delete(analyzerConfigPath);
+            }
+            if (File.Exists(additionalFilePath))
+            {
+                File.Delete(additionalFilePath);
+            }
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+    }
 }

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -8,7 +8,6 @@ using System.Text;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.Extensions.Logging;
 using Stryker.Abstractions.Exceptions;
@@ -159,7 +158,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _generatorDriver = CSharpGeneratorDriver
             .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
                 additionalTexts:[.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()],
-                optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult));
+                optionsProvider: analyzerResult.GetAnalyzerConfigOptionsProvider());
         // run the generators
         _needToRunGenerators = true;
         RunSourceGenerators();
@@ -329,49 +328,4 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         _ => number + "th"
     };
 
-    // This class is used to provide the options to the source generators
-    [ExcludeFromCodeCoverage]
-    private sealed class SimpleAnalyserConfigOptionsProvider : AnalyzerConfigOptionsProvider
-    {
-        private readonly NullAnalyzerConfigOptions _nullProvider = new();
-
-        internal SimpleAnalyserConfigOptionsProvider(IAnalyzerResult result) => GlobalOptions = new SimpleAnalyzerConfigOptions(result);
-
-        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => _nullProvider;
-
-        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => _nullProvider;
-
-        public override AnalyzerConfigOptions GlobalOptions { get; }
-
-        private sealed class SimpleAnalyzerConfigOptions(IAnalyzerResult result) : AnalyzerConfigOptions
-        {
-            private const string Prefix = "build_property.";
-            private readonly IReadOnlyDictionary<string, string> _options = result.Properties;
-
-            public override bool TryGetValue(string key, out string value)
-            {
-                if (key.StartsWith(Prefix))
-                {
-                    return _options.TryGetValue(key[Prefix.Length..], out value);
-                }
-
-                value = null;
-                return false;
-            }
-
-            public override IEnumerable<string> Keys => _options.Keys.Select(key => Prefix + key);
-        }
-
-        private sealed class NullAnalyzerConfigOptions : AnalyzerConfigOptions
-        {
-            public override bool TryGetValue(string key, out string value)
-            {
-                value = null;
-                return false;
-            }
-
-            public override IEnumerable<string> Keys => [];
-        }
-    }
 }
-

--- a/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
+++ b/src/Stryker.Utilities/Buildalyzer/IAnalyzerResultExtensions.cs
@@ -90,6 +90,57 @@ public static class IAnalyzerResultExtensions
     public static IEnumerable<AdditionalText> GetAdditionalTexts(this IAnalyzerResult result) =>
         result.AdditionalFiles?.Select(additionalFile => new AdditionalTextFromFile(additionalFile)) ?? [];
 
+    public static IEnumerable<string> GetAnalyzerConfigFiles(this IAnalyzerResult result)
+    {
+        // Analyzer config paths in the compiler command line are often RELATIVE to the project
+        // directory (e.g. obj/.../<Project>.GeneratedMSBuildEditorConfig.editorconfig, which carries
+        // the CompilerVisibleProperty / CompilerVisibleItemMetadata that generators such as CsWin32
+        // read). They must be resolved against the project directory, not the current working
+        // directory, or File.Exists silently drops them and the generator options are lost.
+        var projectDirectory = Path.GetDirectoryName(result.ProjectFilePath);
+        return (result.CompilerArguments ?? [])
+            .Select(GetAnalyzerConfigPathFromArgument)
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => ResolveAnalyzerConfigPath(path!, projectDirectory))
+            .Where(File.Exists)
+            .Distinct();
+    }
+
+    private static string ResolveAnalyzerConfigPath(string path, string? projectDirectory) =>
+        Path.IsPathRooted(path) || string.IsNullOrEmpty(projectDirectory)
+            ? path
+            : Path.Combine(projectDirectory, path);
+
+    public static AnalyzerConfigOptionsProvider GetAnalyzerConfigOptionsProvider(this IAnalyzerResult result)
+    {
+        var analyzerConfigFiles = result.GetAnalyzerConfigFiles().ToList();
+        if (analyzerConfigFiles.Any())
+        {
+            var analyzerConfigs = analyzerConfigFiles
+                .Select(path => AnalyzerConfig.Parse(SourceText.From(File.ReadAllText(path)), path))
+                .ToImmutableArray();
+            var set = AnalyzerConfigSet.Create(analyzerConfigs);
+            return new AnalyzerConfigOptionsProviderFromSet(set);
+        }
+
+        return new AnalyzerConfigOptionsProviderFromProperties(result.Properties);
+    }
+
+    private static string? GetAnalyzerConfigPathFromArgument(string arg)
+    {
+        const string slashPrefix = "/analyzerconfig:";
+        const string dashPrefix = "-analyzerconfig:";
+        if (arg.StartsWith(slashPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return arg[slashPrefix.Length..].Trim('"');
+        }
+        if (arg.StartsWith(dashPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return arg[dashPrefix.Length..].Trim('"');
+        }
+        return null;
+    }
+
     // Roslyn does not appear to expose usable implementations of these types (required for additional files support)
     private sealed class AdditionalTextFromFile(string path) : AdditionalText
     {
@@ -102,6 +153,70 @@ public static class IAnalyzerResultExtensions
         }
 
         public override string Path => path;
+    }
+
+    private sealed class AnalyzerConfigOptionsProviderFromSet(AnalyzerConfigSet configSet) : AnalyzerConfigOptionsProvider
+    {
+        private readonly AnalyzerConfigSet _configSet = configSet;
+        private readonly DictionaryAnalyzerConfigOptions _emptyAnalyzerConfigOptions =
+            new(ImmutableDictionary<string, string>.Empty.WithComparers(AnalyzerConfigOptions.KeyComparer));
+
+        public override AnalyzerConfigOptions GlobalOptions => new DictionaryAnalyzerConfigOptions(_configSet.GlobalConfigOptions.AnalyzerOptions);
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) =>
+            string.IsNullOrEmpty(tree?.FilePath)
+                ? _emptyAnalyzerConfigOptions
+                : new DictionaryAnalyzerConfigOptions(_configSet.GetOptionsForSourcePath(NormalizePath(tree.FilePath)).AnalyzerOptions);
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) =>
+            string.IsNullOrEmpty(textFile?.Path)
+                ? _emptyAnalyzerConfigOptions
+                : new DictionaryAnalyzerConfigOptions(_configSet.GetOptionsForSourcePath(NormalizePath(textFile.Path)).AnalyzerOptions);
+
+        // Roslyn's AnalyzerConfigSet matches section headers using forward slashes, so a
+        // backslash Windows path must be normalized or per-file build_metadata never resolves.
+        private static string NormalizePath(string path) => path.Replace('\\', '/');
+    }
+
+    private sealed class AnalyzerConfigOptionsProviderFromProperties(IReadOnlyDictionary<string, string> properties) : AnalyzerConfigOptionsProvider
+    {
+        public override AnalyzerConfigOptions GlobalOptions => new AnalyzerConfigOptionsFromProperties(properties);
+        private static readonly AnalyzerConfigOptions NullAnalyzerConfigOptions = new EmptyAnalyzerConfigOptions();
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => NullAnalyzerConfigOptions;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => NullAnalyzerConfigOptions;
+    }
+
+    private sealed class AnalyzerConfigOptionsFromProperties(IReadOnlyDictionary<string, string> properties) : DictionaryAnalyzerConfigOptions(
+        properties
+            .ToImmutableDictionary(
+                keyValuePair => $"build_property.{keyValuePair.Key}",
+                keyValuePair => keyValuePair.Value,
+                AnalyzerConfigOptions.KeyComparer))
+    {
+    }
+
+    private sealed class EmptyAnalyzerConfigOptions : DictionaryAnalyzerConfigOptions
+    {
+        public EmptyAnalyzerConfigOptions() : base(ImmutableDictionary<string, string>.Empty.WithComparers(AnalyzerConfigOptions.KeyComparer)) { }
+    }
+
+    private class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        private readonly ImmutableDictionary<string, string> _options;
+
+        public DictionaryAnalyzerConfigOptions(IDictionary<string, string> options) =>
+            _options = options.ToImmutableDictionary(AnalyzerConfigOptions.KeyComparer);
+
+        public DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string> options)
+        {
+            _options = options;
+        }
+
+        public override bool TryGetValue(string key, out string value) => _options.TryGetValue(key, out value!);
+
+        public override IEnumerable<string> Keys => _options.Keys;
     }
 
     [ExcludeFromCodeCoverage(Justification = "Impossible to unit test")]


### PR DESCRIPTION
Fixes #3698.

If you run Stryker on a project that uses a source generator like CsWin32, the generator produces nothing during Stryker's mutated-assembly compile — so anything referencing the generated symbols fails to compile and the whole run aborts, even when you're only mutating an unrelated file.

**The cause:** `SimpleAnalyserConfigOptionsProvider` builds the generators' options from `IAnalyzerResult.Properties` alone. Its per-tree and per-additional-file options are always empty, and globally it only exposes `build_property.*`, so everything under `build_metadata.*` is dropped. CsWin32 needs `build_property.CsWin32InputMetadataPaths` to find the Win32 `.winmd` metadata, and that value isn't in `Properties` — it's a `CompilerVisibleProperty` MSBuild writes into the generated `.editorconfig` and passes to the compiler via `/analyzerconfig`. Buildalyzer captures it in `CompilerArguments`, but we were throwing it away.

**The change:** read those `/analyzerconfig` files back with Roslyn's `AnalyzerConfig`/`AnalyzerConfigSet` and hand them to the generator driver — global options from the global config, per-path options via `GetOptionsForSourcePath`. The generated editorconfig path is relative to the project, so it's resolved against the project directory. When a project has no analyzer-config files captured, it falls back to the old properties-only behaviour, so nothing changes for projects that don't need it.

**Testing:** a unit test covers both the config-backed and the fallback paths. I also reproduced the original bug on a minimal CsWin32 project — released 4.16.0 dies with a `CompilationException` and no report; with this change CsWin32 generates, the project compiles, and Stryker produces a report with the mutant killed.

**Where this came from — real-world proof.** This started from trying to mutation-test DS4Windows (a WPF controller remapper that leans on CsWin32 for its Win32 P/Invoke), not a toy. On stock 4.16.0 it simply can't be done — Stryker gets through coverage and then every mutated compile dies because CsWin32 emits nothing, so no report is ever produced. That's what sent me digging, and I boiled it down to the minimal repro above. With this change it runs: scoped to `AppSettingsDTO.cs`, 185 mutants tested (85 killed / 100 survived), 43% score in ~5 min. Those mutants only compile if CsWin32 generated its `PInvoke.*` symbols during the mutated builds — so it's the fix working on a real codebase, not just the repro. (The `unsafe`/P-Invoke mutants land as `CompileError` under Safe Mode; that's a separate, known thing, unrelated to this change.)

<details>
<summary>DS4Windows mutation report — summary</summary>

Scoped to `AppSettingsDTO.cs` (38,940 out-of-scope mutants removed by the mutate filter); run completed in ~4m52s. Final mutation score **43.15%**.

| status | count |
|---|---|
| Killed | 85 |
| Survived | 100 |
| NoCoverage | 12 |

Sample killed mutants (each compiled and ran — i.e. CsWin32 generated):

```
AppSettingsDTO.cs:156  String mutation
AppSettingsDTO.cs:156  LogicalNotExpression removal
AppSettingsDTO.cs:166  LogicalNotExpression removal
```

Sample survived mutants:

```
AppSettingsDTO.cs:73   Block removal
AppSettingsDTO.cs:85   Block removal
AppSettingsDTO.cs:196  Logical mutation
```
</details>

<details>
<summary>Stryker run log — excerpt</summary>

```
21    mutants got status CompileError. Reason: Could not be injected in code.
1360  mutants got status CompileError. Reason: Mutant caused compile errors
12    mutants got status NoCoverage.   Reason: Not covered by any test.
46    mutants got status Ignored.      Reason: Removed by block already covered filter
38940 mutants got status Ignored.      Reason: Removed by mutate filter
185   total mutants will be tested
The final mutation score is 43.15 %
Time Elapsed 00:04:51
```
</details>

Review history: https://gist.github.com/anagnorisis2peripeteia/1ea523d741e76b7722f91203bd591940

