### PR TITLE
Feat: improve diagnostic when mutated compilation fails

### DIFF
--- a/src/Stryker.Abstractions/Exceptions/CompilationException.cs
+++ b/src/Stryker.Abstractions/Exceptions/CompilationException.cs
@@ -3,17 +3,7 @@ using System;
 namespace Stryker.Abstractions.Exceptions;
 
 /// <summary>
-/// Represents errors which are related to roslyn compilation errors that we cannot fix, 
+/// Represents errors which are related to roslyn compilation errors that we cannot fix,
 /// but the user might also might not be able to fix
 /// </summary>
-public class CompilationException : Exception
-{
-    public CompilationException()
-    {
-    }
-
-    public CompilationException(string message)
-        : base(message)
-    {
-    }
-}
+public class CompilationException(string message) : Exception(message);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -123,20 +123,9 @@ public class Calculator
     }
 
     [TestMethod]
-    public void CompilingProcessTests_ShouldCallRollbackProcess_OnCompileError()
+    public void ShouldReportWhenProjectCantBeBuiltWhen()
     {
-        var syntaxTree = CSharpSyntaxTree.ParseText(@"using System;
-
-namespace ExampleProject
-{
-public class Calculator
-{
-    public int Subtract(string first, string second)
-    {
-        return first - second;
-    }
-}
-}");
+        var syntaxTree = CSharpSyntaxTree.ParseText(GetExampleCode(false));
         var input = new MutationTestInput()
         {
             SourceProjectInfo = new SourceProjectInfo
@@ -152,7 +141,47 @@ public class Calculator
                     // add a reference to system so the example code can compile
                     references: [typeof(object).Assembly.Location]
                 ).Object,
-                ProjectContents = new CsharpFileLeaf{SyntaxTree = syntaxTree, MutatedSyntaxTree = syntaxTree, SourceCode = syntaxTree.ToString()}
+                ProjectContents = new CsharpFileLeaf{SyntaxTree = syntaxTree, MutatedSyntaxTree = syntaxTree, SourceCode = GetExampleCode(false)}
+            }
+        };
+        var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
+        rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
+                        .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) =>
+                            []);
+
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions(
+        ), [syntaxTree]);
+
+        using (var ms = new MemoryStream())
+        {
+            Should.Throw<CompilationException>(() => target.Compile(ms, null)).Message.ShouldBe("Failed to build mutated version.");
+        }
+        rollbackProcessMock.Verify(x =>
+                x.RollbackMutationsInError(It.IsAny<ICompilationContent>(),
+                It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
+            Times.AtLeast(2));
+    }
+
+    [TestMethod]
+    public void ShouldReportWhenProjectCantBeBuiltWhenDiagMode()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(GetExampleCode(false));
+        var input = new MutationTestInput()
+        {
+            SourceProjectInfo = new SourceProjectInfo
+            {
+                AnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                    projectFilePath: "/c/project.csproj",
+                    properties: new Dictionary<string, string>()
+                    {
+                        { "TargetDir", "" },
+                        { "AssemblyName", "AssemblyName"},
+                        { "TargetFileName", "TargetFileName.dll"},
+                    },
+                    // add a reference to system so the example code can compile
+                    references: [typeof(object).Assembly.Location]
+                ).Object,
+                ProjectContents = new CsharpFileLeaf{SyntaxTree = syntaxTree, MutatedSyntaxTree = syntaxTree, SourceCode = GetExampleCode(false)}
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
@@ -164,13 +193,65 @@ public class Calculator
 
         using (var ms = new MemoryStream())
         {
-            Should.Throw<CompilationException>(() => target.Compile(ms, null));
+            Should.Throw<CompilationException>(() => target.Compile(ms, null)).Message.ShouldBe("Stryker is unable to build this project.");
         }
         rollbackProcessMock.Verify(x =>
                 x.RollbackMutationsInError(It.IsAny<ICompilationContent>(),
                 It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, true),
             Times.AtLeast(2));
     }
+
+    [TestMethod]
+    public void ShouldReportWhenProjectCantBeBuiltWhenMutatedWhenDiagMode()
+    {
+        var mutated = CSharpSyntaxTree.ParseText(GetExampleCode(false));
+        var original = CSharpSyntaxTree.ParseText(GetExampleCode(true));
+        var input = new MutationTestInput()
+        {
+            SourceProjectInfo = new SourceProjectInfo
+            {
+                AnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                    projectFilePath: "/c/project.csproj",
+                    properties: new Dictionary<string, string>()
+                    {
+                        { "TargetDir", "" },
+                        { "AssemblyName", "AssemblyName"},
+                        { "TargetFileName", "TargetFileName.dll"},
+                    },
+                    // add a reference to system so the example code can compile
+                    references: [typeof(object).Assembly.Location]
+                ).Object,
+                ProjectContents = new CsharpFileLeaf{SyntaxTree = original, MutatedSyntaxTree = mutated, SourceCode = GetExampleCode(true)}
+            }
+        };
+        var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
+        rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), true))
+                        .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) =>
+                            []);
+
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions{DiagMode = true}, [mutated]);
+
+        using (var ms = new MemoryStream())
+        {
+            Should.Throw<CompilationException>(() => target.Compile(ms, null)).Message.ShouldBe("Failed to restore the project to a buildable state.");
+        }
+    }
+
+    private static string GetExampleCode(bool isBuildable) =>
+        $$"""
+          using System;
+
+          namespace ExampleProject
+          {
+          public class Calculator
+          {
+              public string Subtract(string first, string second)
+              {
+                  return first {{(isBuildable ? "+" : "-")}} second;
+              }
+          }
+          }
+          """;
 
     [TestMethod]
     public void CompilingProcessTests_ShouldOnlyRollbackErrors()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -156,7 +156,8 @@ public class Calculator
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
         rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
-                        .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) => null);
+                        .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) =>
+                            []);
 
         var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions(), [syntaxTree]);
 
@@ -164,7 +165,9 @@ public class Calculator
         {
             Should.Throw<CompilationException>(() => target.Compile(ms, null));
         }
-        rollbackProcessMock.Verify(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
+        rollbackProcessMock.Verify(x =>
+                x.RollbackMutationsInError(It.IsAny<ICompilationContent>(),
+                It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
             Times.AtLeast(2));
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -151,15 +151,16 @@ public class Calculator
                     },
                     // add a reference to system so the example code can compile
                     references: [typeof(object).Assembly.Location]
-                ).Object
+                ).Object,
+                ProjectContents = new CsharpFileLeaf{SyntaxTree = syntaxTree, MutatedSyntaxTree = syntaxTree, SourceCode = syntaxTree.ToString()}
             }
         };
         var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
-        rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), false))
+        rollbackProcessMock.Setup(x => x.RollbackMutationsInError(It.IsAny<ICompilationContent>(), It.IsAny<ImmutableArray<Diagnostic>>(), It.IsAny<ICSharpRollbackProcess.Mode>(), true))
                         .Returns((ICompilationContent _, ImmutableArray<Diagnostic> _, ICSharpRollbackProcess.Mode _, bool _) =>
                             []);
 
-        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions(), [syntaxTree]);
+        var target = new CsharpCompilingProcess(input, rollbackProcessMock.Object, new StrykerOptions{DiagMode = true}, [syntaxTree]);
 
         using (var ms = new MemoryStream())
         {
@@ -167,7 +168,7 @@ public class Calculator
         }
         rollbackProcessMock.Verify(x =>
                 x.RollbackMutationsInError(It.IsAny<ICompilationContent>(),
-                It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, false),
+                It.IsAny<ImmutableArray<Diagnostic>>(), ICSharpRollbackProcess.Mode.Normal, true),
             Times.AtLeast(2));
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -123,7 +123,7 @@ public class Calculator
     }
 
     [TestMethod]
-    public void ShouldReportWhenProjectCantBeBuiltWhen()
+    public void ShouldReportWhenProjectCantBeBuilt()
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(GetExampleCode(false));
         var input = new MutationTestInput()

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -1046,9 +1046,9 @@ public class CSharpRollbackProcessTests : TestBase
         var compilerWrapper = new CompilerWrapper(compiler);
 
         // first compilation will roll back the mutation
-        var fixedCompilation = target.RollbackMutationsInError(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        target.RollbackMutationsInError(compilerWrapper, compiler.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.Normal, false).ShouldNotBeEmpty();
 
         // next attempt cannot roll back anything, so it assumes this is not fixable
-        Should.Throw<CompilationException>(() => target.RollbackMutationsInError(compilerWrapper, compilerWrapper.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false));
+        target.RollbackMutationsInError(compilerWrapper, compilerWrapper.Emit(ms).Diagnostics, ICSharpRollbackProcess.Mode.LastChance, false).ShouldBeNull();
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -44,7 +44,7 @@ public class InitialBuildProcessTests : TestBase
 
         var target = new InitialBuildProcess(processMock.Object, _mockFileSystem, TestLoggerFactory.CreateLogger<InitialBuildProcess>());
 
-        Should.Throw<InputException>(() => target.InitialBuild(true, null, _cProjectsExampleCsproj, null, targetFramework: null,
+        Should.Throw<InputException>(() => target.InitialBuild(true, null, _cProjectsExampleCsproj, targetFramework: null,
                 msbuildPath: @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
             .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
                               @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" " + Path.GetFileName(_cProjectsExampleCsproj) + "\"");
@@ -60,7 +60,7 @@ public class InitialBuildProcessTests : TestBase
 
         var target = new InitialBuildProcess(processMock.Object, _mockFileSystem, TestLoggerFactory.CreateLogger<InitialBuildProcess>());
 
-        Should.Throw<InputException>(() => target.InitialBuild(false, null, _cProjectsExampleCsproj, null, targetFramework: null, msbuildPath: @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
+        Should.Throw<InputException>(() => target.InitialBuild(false, null, _cProjectsExampleCsproj, targetFramework: null, msbuildPath: @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"))
             .Details.ShouldBe("Initial build of targeted project failed. Please make sure the targeted project is buildable. You can reproduce this error yourself using: \"\"" +
                               @"C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" + "\" " + _mockFileSystem.Path.GetFileName(_cProjectsExampleCsproj) + "\"");
 
@@ -124,7 +124,7 @@ public class InitialBuildProcessTests : TestBase
 
         var target = new InitialBuildProcess(processMock.Object, mockFileSystem, TestLoggerFactory.CreateLogger<InitialBuildProcess>());
 
-        target.InitialBuild(true, "/", "./ExampleProject.sln", null, targetFramework: null, msbuildPath: CustomMsBuildPath);
+        target.InitialBuild(true, "/", "./ExampleProject.sln", targetFramework: null, msbuildPath: CustomMsBuildPath);
         processMock.Verify(x => x.Start(It.IsAny<string>(),
                 It.Is<string>(applicationParam => applicationParam == CustomMsBuildPath),
                 It.Is<string>(argumentsParam => argumentsParam.Contains("ExampleProject.sln")),

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -22,10 +22,9 @@ public interface ICompilationContent
     void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated);
 }
 
-
 public interface ICSharpRollbackProcess
 {
-    IEnumerable<int> RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
+    IEnumerable<int>? RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics,
         Mode mode, bool devMode);
 
     enum Mode
@@ -44,7 +43,7 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
     private List<int> RollBackedIds { get; } = [];
     private ILogger Logger { get; } = ApplicationLogging.LoggerFactory.CreateLogger<CSharpRollbackProcess>();
 
-    public IEnumerable<int> RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics, ICSharpRollbackProcess.Mode mode, bool devMode)
+    public IEnumerable<int>? RollbackMutationsInError(ICompilationContent wrapper, ImmutableArray<Diagnostic> diagnostics, ICSharpRollbackProcess.Mode mode, bool devMode)
     {
         // match the diagnostics with their syntax trees
         var syntaxTreeMapping =
@@ -75,11 +74,10 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
 
             var updatedSyntaxTree = RemoveCompileErrorMutations(originalTree, syntaxTreeMap.Value, mode).SyntaxTree;
 
-            if (updatedSyntaxTree == originalTree || mode == ICSharpRollbackProcess.Mode.LastChance)
+            if (updatedSyntaxTree == originalTree)
             {
-                Logger.LogCritical(
-                    "Stryker.NET could not compile the project after mutation. This is probably an error for Stryker.NET and not your project. Please report this issue on github with the previous error message.");
-                throw new CompilationException("Internal error due to compile error.");
+                Logger.LogWarning("Unable to fix error(s) in file {FilePath}.", originalTree.FilePath);
+                return null;
             }
 
             Logger.LogTrace("RolledBack to {UpdatedSyntaxTree}", updatedSyntaxTree.ToString());

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -86,6 +86,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         }
 
         _logger.LogInformation("Diagnostic mode is enabled, attempting to build the non-mutated project to help identify the cause of the compilation failure.");
+        _compilation = null;
         InitCSharpCompilation(((ProjectComponent) _input.SourceProjectInfo.ProjectContents).UnmutatedSyntaxTrees);
         var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
 

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -87,7 +87,11 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
 
         _logger.LogInformation("Diagnostic mode is enabled, attempting to build the non-mutated project to help identify the cause of the compilation failure.");
         _compilation = null;
-        InitCSharpCompilation(((ProjectComponent) _input.SourceProjectInfo.ProjectContents).UnmutatedSyntaxTrees);
+        if (_input.SourceProjectInfo.ProjectContents is not ProjectComponent projectContents)
+        {
+            throw new CompilationException("Internal error: project contents type does not support unmutated compilation.");
+        }
+        InitCSharpCompilation(projectContents.UnmutatedSyntaxTrees);
         var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
 
         // reset the memoryStreams
@@ -107,9 +111,10 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         }
     }
 
-    private IEnumerable<int> CompileAndFixUntilSuccess(Stream ilStream, Stream symbolStream, out EmitResult emitResult)
+    private IEnumerable<int>? CompileAndFixUntilSuccess(Stream ilStream, Stream symbolStream, out EmitResult emitResult)
     {
         InitCSharpCompilation(_originalSyntaxTrees);
+        RunSourceGenerators();
         // first try compiling
         var retryCount = 1;
         (var rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -68,8 +68,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     /// </summary>
     public CompilingProcessResult Compile(Stream ilStream, Stream symbolStream)
     {
-        InitCSharpCompilation();
-        RunSourceGenerators();
+        InitCSharpCompilation(_originalSyntaxTrees);
         // first try compiling
         var retryCount = 1;
         var (rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);
@@ -83,7 +82,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         }
 
         var mode = ICSharpRollbackProcess.Mode.Normal;
-        for (var count = 1; !emitResult.Success && count < MaxAttempt; count++)
+        for (var count = 1; !emitResult.Success && count < MaxAttempt && rollbackProcessResult != null; count++)
         {
             mode = count switch
             {
@@ -105,7 +104,32 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         // compiling failed
         _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
         DumpErrorDetails(emitResult.Diagnostics);
-        throw new CompilationException("Failed to restore build able state.");
+        if (_options.DiagMode && _input.SourceProjectInfo.ProjectContents != null)
+        {
+            _logger.LogInformation("Diagnostic mode is enabled, attempting to build the non-mutated project to help identify the cause of the compilation failure.");
+            TryBuildNonMutated(ilStream);
+        }
+        throw new CompilationException("Failed to restore the project to a buildable state.");
+    }
+
+    private void TryBuildNonMutated(Stream ilStream)
+    {
+        InitCSharpCompilation(((ProjectComponent) _input.SourceProjectInfo.ProjectContents).UnmutatedSyntaxTrees);
+        var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
+
+        // reset the memoryStreams
+        ilStream.SetLength(0);
+        var emitResult = ActualCompilation(ilStream, null, resourceDescriptions, null);
+
+        if (!emitResult.Success)
+        {
+            _logger.LogError("Unable to build the original project, this means project analysis failed. Please report this issue on GitHub.");
+            LogEmitResult(emitResult);
+        }
+        else
+        {
+            _logger.LogError("Able to build the original project, this means mutation and/or rollback logic corrupted the project. Please report this issue on GitHub.");
+        }
     }
 
     /// <summary>
@@ -115,7 +139,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     /// <returns>Semantic models</returns>
     public SemanticModel GetSemanticModel(SyntaxTree syntaxTree)
     {
-        InitCSharpCompilation();
+        InitCSharpCompilation(_originalSyntaxTrees);
         // extract semantic models from compilation
         return _compilation.GetSemanticModel(syntaxTree);
     }
@@ -142,7 +166,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         throw new CompilationException("Source Generator Failure");
     }
 
-    private void InitCSharpCompilation()
+    private void InitCSharpCompilation(IEnumerable<SyntaxTree> originalSyntaxTrees)
     {
         if (_compilation != null)
         {
@@ -152,13 +176,14 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         var analyzerResult = _input.SourceProjectInfo.AnalyzerResult;
         // create the compilation context
         _compilation= CSharpCompilation.Create(AssemblyName,
-            _originalSyntaxTrees,
-            _input.SourceProjectInfo.AnalyzerResult.LoadReferences(),
+            originalSyntaxTrees,
+            analyzerResult.LoadReferences(),
             analyzerResult.GetCompilationOptions());
         // create the driver for source generators
         _generatorDriver = CSharpGeneratorDriver
-            .Create(analyzerResult.GetSourceGenerators(_logger), parseOptions: analyzerResult.GetParseOptions(_options),
-                additionalTexts:[.._input.SourceProjectInfo.AnalyzerResult.GetAdditionalTexts()],
+            .Create(analyzerResult.GetSourceGenerators(_logger),
+                parseOptions: analyzerResult.GetParseOptions(_options),
+                additionalTexts:[..analyzerResult.GetAdditionalTexts()],
                 optionsProvider: new SimpleAnalyserConfigOptionsProvider(analyzerResult));
         // run the generators
         _needToRunGenerators = true;
@@ -172,7 +197,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         ICSharpRollbackProcess.Mode mode,
         int retryCount)
     {
-        IEnumerable<int> rollbackProcessResult = null;
+        IEnumerable<int> rollbackProcessResult = [];
 
         _logger.LogDebug("Trying compilation for the {retryCount} time.", ReadableNumber(retryCount));
         var emitOptions = symbolStream == null ? null : new EmitOptions(false, DebugInformationFormat.PortablePdb,
@@ -182,6 +207,11 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
         {
             // remove broken mutations
             rollbackProcessResult = _rollbackProcess.RollbackMutationsInError(this, previousEmitResult.Diagnostics, mode, _options.DiagMode);
+            if (rollbackProcessResult == null)
+            {
+                // nothing to be rolled back
+                return (null, previousEmitResult);
+            }
             RunSourceGenerators();
         }
 
@@ -198,7 +228,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     private EmitResult ActualCompilation(Stream ms, Stream symbolStream, IEnumerable<ResourceDescription> resourceDescriptions,
         EmitOptions emitOptions)
     {
-        EmitResult emitResult = null;
+        EmitResult emitResult;
 
         try
         {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -68,10 +68,50 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     /// </summary>
     public CompilingProcessResult Compile(Stream ilStream, Stream symbolStream)
     {
+        var rollbackProcessResult = CompileAndFixUntilSuccess(ilStream, symbolStream, out var emitResult);
+
+        if (emitResult.Success)
+        {
+            return new CompilingProcessResult(
+                true,
+                rollbackProcessResult ?? []);
+        }
+
+        // compiling failed
+        _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
+        DumpErrorDetails(emitResult.Diagnostics);
+        if (!_options.DiagMode || _input.SourceProjectInfo.ProjectContents == null)
+        {
+            throw new CompilationException("Failed to build mutated version.");
+        }
+
+        _logger.LogInformation("Diagnostic mode is enabled, attempting to build the non-mutated project to help identify the cause of the compilation failure.");
+        InitCSharpCompilation(((ProjectComponent) _input.SourceProjectInfo.ProjectContents).UnmutatedSyntaxTrees);
+        var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
+
+        // reset the memoryStreams
+        ilStream.SetLength(0);
+        var emitResult1 = ActualCompilation(ilStream, null, resourceDescriptions, null);
+
+        if (!emitResult1.Success)
+        {
+            _logger.LogError("Unable to build the original project, this means project analysis failed. Please report this issue on GitHub.");
+            LogEmitResult(emitResult1);
+            throw new CompilationException("Stryker is unable to build this project.");
+        }
+        else
+        {
+            _logger.LogError("Able to build the original project, this means mutation and/or rollback logic corrupted the project. Please report this issue on GitHub.");
+            throw new CompilationException("Failed to restore the project to a buildable state.");
+        }
+    }
+
+    private IEnumerable<int> CompileAndFixUntilSuccess(Stream ilStream, Stream symbolStream, out EmitResult emitResult)
+    {
         InitCSharpCompilation(_originalSyntaxTrees);
         // first try compiling
         var retryCount = 1;
-        var (rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);
+        (var rollbackProcessResult, emitResult) = TryCompilation(ilStream, symbolStream, null, ICSharpRollbackProcess.Mode.Normal, retryCount++);
         // If compiling failed and the error has no location, log and throw exception.
         if (!emitResult.Success && emitResult.Diagnostics.Any(diagnostic => diagnostic.Location == Location.None && diagnostic.Severity == DiagnosticSeverity.Error))
         {
@@ -95,41 +135,7 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
                 emitResult, mode, retryCount++);
         }
 
-        if (emitResult.Success)
-        {
-            return new CompilingProcessResult(
-                true,
-                rollbackProcessResult ?? []);
-        }
-        // compiling failed
-        _logger.LogError("Failed to restore the project to a buildable state. Please report the issue. Stryker can not proceed further");
-        DumpErrorDetails(emitResult.Diagnostics);
-        if (_options.DiagMode && _input.SourceProjectInfo.ProjectContents != null)
-        {
-            _logger.LogInformation("Diagnostic mode is enabled, attempting to build the non-mutated project to help identify the cause of the compilation failure.");
-            TryBuildNonMutated(ilStream);
-        }
-        throw new CompilationException("Failed to restore the project to a buildable state.");
-    }
-
-    private void TryBuildNonMutated(Stream ilStream)
-    {
-        InitCSharpCompilation(((ProjectComponent) _input.SourceProjectInfo.ProjectContents).UnmutatedSyntaxTrees);
-        var resourceDescriptions = _input.SourceProjectInfo.AnalyzerResult.GetResources(_logger);
-
-        // reset the memoryStreams
-        ilStream.SetLength(0);
-        var emitResult = ActualCompilation(ilStream, null, resourceDescriptions, null);
-
-        if (!emitResult.Success)
-        {
-            _logger.LogError("Unable to build the original project, this means project analysis failed. Please report this issue on GitHub.");
-            LogEmitResult(emitResult);
-        }
-        else
-        {
-            _logger.LogError("Able to build the original project, this means mutation and/or rollback logic corrupted the project. Please report this issue on GitHub.");
-        }
+        return rollbackProcessResult;
     }
 
     /// <summary>

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -25,7 +25,6 @@ public interface IInputFileResolver
     IFileSystem FileSystem { get; }
 }
 
-
 /// <summary>
 ///  - Reads .csproj to find project under test
 ///  - Scans project under test and store files to mutate

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Csharp/CsharpFileLeaf.cs
@@ -7,23 +7,24 @@ namespace Stryker.Core.ProjectComponents.Csharp;
 
 public class CsharpFileLeaf : ProjectComponent, IFileLeaf
 {
-    public string SourceCode { get; set; }
+    public string? SourceCode { get; set; }
 
     /// <summary>
     /// The original unmutated syntax tree
     /// </summary>
-    public SyntaxTree SyntaxTree { get; set; }
+    public SyntaxTree? SyntaxTree { get; set; }
 
     /// <summary>
     /// The mutated syntax tree
     /// </summary>
-    public SyntaxTree MutatedSyntaxTree { get; set; }
+    public SyntaxTree? MutatedSyntaxTree { get; set; }
 
     public override IEnumerable<IMutant> Mutants { get; set; }
 
     public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => MutatedSyntaxTrees;
 
-    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => [MutatedSyntaxTree ?? SyntaxTree ];
+    public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => [MutatedSyntaxTree ?? SyntaxTree];
+    public override IEnumerable<SyntaxTree> UnmutatedSyntaxTrees => [SyntaxTree];
 
     public override string ToString() => SourceCode ?? "<empty>";
 

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/FolderComposite.cs
@@ -27,6 +27,7 @@ public class FolderComposite : ProjectComponent, IFolderComposite
     public override IEnumerable<SyntaxTree> CompilationSyntaxTrees => _compilationSyntaxTrees.Union(ChildCompilationSyntaxTree);
     private IEnumerable<SyntaxTree> ChildCompilationSyntaxTree => _children.SelectMany(c => c.CompilationSyntaxTrees);
     public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => _children.SelectMany(c => c.MutatedSyntaxTrees);
+    public override IEnumerable<SyntaxTree> UnmutatedSyntaxTrees => _children.SelectMany(c => c.UnmutatedSyntaxTrees).Union(_compilationSyntaxTrees);
 
     public void Add(IProjectComponent child)
     {

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/ProjectComponent.cs
@@ -62,6 +62,11 @@ public abstract class ProjectComponent : IProjectComponent
     public abstract IEnumerable<SyntaxTree> MutatedSyntaxTrees { get; }
 
     /// <summary>
+    /// All syntax trees needed to build the original project
+    /// </summary>
+    public abstract IEnumerable<SyntaxTree> UnmutatedSyntaxTrees { get; }
+
+    /// <summary>
     /// Returns the mutation score for this folder / file
     /// </summary>
     /// <returns>double between 0 and 1 or NaN when no score could be calculated</returns>

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/Solution.cs
@@ -50,5 +50,7 @@ public class Solution : ProjectComponent, IFolderComposite
 
     public override IEnumerable<SyntaxTree> MutatedSyntaxTrees => _children.SelectMany(c => c.MutatedSyntaxTrees);
 
+    public override IEnumerable<SyntaxTree> UnmutatedSyntaxTrees => _children.SelectMany(c => c.UnmutatedSyntaxTrees);
+
     public override IEnumerable<IFileLeaf> GetAllFiles() => Children.SelectMany(x => x.GetAllFiles());
 }

--- a/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
+++ b/src/Stryker.Core/Stryker.Core/StrykerRunner.cs
@@ -60,8 +60,10 @@ public class StrykerRunner : IStrykerRunner
             // Mutate
             _mutationTestProcesses = (await _projectOrchestrator.MutateProjectsAsync(options, reporters)).ToList();
 
-            var rootComponent = AddRootFolderIfMultiProject(_mutationTestProcesses.Select(x => x.Input.SourceProjectInfo.ProjectContents).ToList(), options);
-            var combinedTestProjectsInfo = _mutationTestProcesses.Select(mtp => mtp.Input.TestProjectsInfo).Aggregate((a, b) => (TestProjectsInfo)a + (TestProjectsInfo)b);
+            var rootComponent = AddRootFolderIfMultiProject(
+                _mutationTestProcesses.Select(x => x.Input.SourceProjectInfo.ProjectContents).ToList(), options);
+            var combinedTestProjectsInfo = _mutationTestProcesses.Select(mtp => mtp.Input.TestProjectsInfo)
+                .Aggregate((a, b) => (TestProjectsInfo)a + (TestProjectsInfo)b);
 
             _logger.LogInformation("{MutantsCount} mutants created", rootComponent.Mutants.Count());
 
@@ -83,16 +85,22 @@ public class StrykerRunner : IStrykerRunner
             {
                 if (allMutants.Any(x => x.ResultStatus == MutantStatus.Ignored))
                 {
-                    _logger.LogWarning("It looks like all mutants with tests were ignored. Try a re-run with less ignoring!");
+                    _logger.LogWarning(
+                        "It looks like all mutants with tests were ignored. Try a re-run with less ignoring!");
                 }
+
                 if (allMutants.Any(x => x.ResultStatus == MutantStatus.NoCoverage))
                 {
-                    _logger.LogWarning("It looks like all non-ignored mutants are not covered by a test. Go add some tests!");
+                    _logger.LogWarning(
+                        "It looks like all non-ignored mutants are not covered by a test. Go add some tests!");
                 }
+
                 if (allMutants.Any(x => x.ResultStatus == MutantStatus.CompileError))
                 {
-                    _logger.LogWarning("It looks like all mutants resulted in compile errors. Mutants sure are strange!");
+                    _logger.LogWarning(
+                        "It looks like all mutants resulted in compile errors. Mutants sure are strange!");
                 }
+
                 if (!allMutants.Any())
                 {
                     _logger.LogWarning("It\'s a mutant-free world, nothing to test.");
@@ -109,8 +117,11 @@ public class StrykerRunner : IStrykerRunner
             // Test
             foreach (var project in _mutationTestProcesses)
             {
-                await project.TestAsync(project.Input.SourceProjectInfo.ProjectContents.Mutants.Where(x => x.ResultStatus == MutantStatus.Pending).ToList()).ConfigureAwait(false);
+                await project
+                    .TestAsync(project.Input.SourceProjectInfo.ProjectContents.Mutants
+                        .Where(x => x.ResultStatus == MutantStatus.Pending).ToList()).ConfigureAwait(false);
             }
+
             // dispose and stop runners
             _projectOrchestrator.Dispose();
 
@@ -125,7 +136,16 @@ public class StrykerRunner : IStrykerRunner
             return new StrykerRunResult(options, rootComponent.GetMutationScore());
         }
 #if !DEBUG
-        catch (Exception ex) when (!(ex is InputException))
+        catch (AggregateException ex) when  (ex.InnerException is CompilationException)
+        {
+            _logger.LogCritical("Compilation failed: {Message}.", ex.Message);
+            if (!options.DiagMode)
+            {
+                _logger.LogCritical("Run with --diag to get more diagnotic information.");
+            }
+            return new StrykerRunResult(options, 0);
+        }
+        catch (Exception ex) when (ex is not InputException && ex is not CompilationException)
         // let the exception be caught by the debugger when in debug
         {
             _logger.LogError(ex, "An error occurred during the mutation test run ");


### PR DESCRIPTION
In a diagnostic mode (`--diag` option), Stryker attempts a build of the original source code when mutated code build fails.
If it succeeds, it means mutation/rollback logic failed, otherwise it signals analysis went wrong. 
This will diagnose complex issues.

Also: remove exception stack trace on compilation exception, as these have limited value and tend to hide the interesting part of the problem. Hence people often open an issue containing only said exception while previous lines are important.