### PR TITLE
fix: report baseline compile failures instead of an internal error

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
@@ -16,6 +17,7 @@ using Stryker.Abstractions.Options;
 using Stryker.Abstractions.Testing;
 using Stryker.Configuration.Options;
 using Stryker.Core.Compiling;
+using Stryker.Core.InjectedHelpers;
 using Stryker.Core.MutationTest;
 using Stryker.Core.ProjectComponents;
 using Stryker.Core.ProjectComponents.Csharp;
@@ -68,6 +70,93 @@ public class Calculator
         var result = target.Compile(ms, symbol);
         result.Success.ShouldBe(true);
         ms.Length.ShouldBeGreaterThan(100, "No value was written to the MemoryStream by the compiler");
+    }
+
+    [TestMethod]
+    public void CompilesWithoutMutations_IsTrue_WhenRemovingMutationsFixesTheBuild()
+    {
+        // A file that only fails to compile because of a mutation: with the mutation stripped and
+        // the generators re-run the baseline builds, so the failure is mutation-induced.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class Calculator
+                {
+                    public int ActiveMutation = 1;
+                    public string Subtract(string first, string second)
+                    {
+                        if (ActiveMutation == 1) { return first - second; } else { return first + second; }
+                    }
+                }
+            }
+            """);
+        var ifStatement = syntaxTree.GetRoot().DescendantNodes().OfType<IfStatementSyntax>().First();
+        var annotated = syntaxTree.GetRoot()
+            .ReplaceNode(ifStatement, ifStatement.WithAdditionalAnnotations(
+                new SyntaxAnnotation("MutationId", "1"), new SyntaxAnnotation("Injector", "IfInstrumentationEngine")))
+            .SyntaxTree;
+        var target = BuildCompilingProcess(annotated);
+        target.GetSemanticModel(annotated); // initialise the compilation
+
+        // The tree compiles on the uninstrumented baseline, so its failure was mutation-induced.
+        ((IBaselineCompiler)target).FailsWithoutInstrumentation(annotated).ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void CompilesWithoutMutations_IsFalse_WhenTheFailureIsIndependentOfMutation()
+    {
+        // A file that fails to compile with no mutation involved (a missing symbol): stripping
+        // mutations and re-running generators changes nothing, so the baseline still fails.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Anchor { public object Broken() => Missing.Symbol; } }
+            """);
+        var target = BuildCompilingProcess(syntaxTree);
+        target.GetSemanticModel(syntaxTree); // initialise the compilation
+
+        // The tree still fails on the uninstrumented baseline, so the failure is not mutation-caused.
+        ((IBaselineCompiler)target).FailsWithoutInstrumentation(syntaxTree).ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void CompilesWithoutMutations_ExcludesStrykerInjectedHelperTrees()
+    {
+        // A clean user file plus a (deliberately broken) Stryker injected helper tree. The baseline
+        // is the user's source only - Stryker's own injected helpers must be dropped - so it
+        // compiles cleanly; if the helper were kept, its error would wrongly make the baseline fail
+        // and a mutation-induced failure would be misreported as baseline.
+        var userTree = CSharpSyntaxTree.ParseText(
+            "namespace ExampleProject { public class Ok { public int Value => 1; } }");
+        var brokenHelper = CSharpSyntaxTree.ParseText(
+            "namespace Stryker { public class Helper { public object X() => Missing.Symbol; } }",
+            path: CodeInjection.HelperFiles.First());
+
+        var target = BuildCompilingProcess(userTree, brokenHelper);
+        target.GetSemanticModel(userTree); // initialise the compilation
+
+        // The user tree compiles clean on the baseline (helper dropped), so its failure would be
+        // mutation-induced - the broken helper does not turn it into a baseline failure.
+        ((IBaselineCompiler)target).FailsWithoutInstrumentation(userTree).ShouldBeFalse();
+    }
+
+    private static CsharpCompilingProcess BuildCompilingProcess(params SyntaxTree[] syntaxTrees)
+    {
+        var input = new MutationTestInput
+        {
+            SourceProjectInfo = new SourceProjectInfo
+            {
+                AnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+                    projectFilePath: "/c/project.csproj",
+                    properties: new Dictionary<string, string>
+                    {
+                        { "TargetDir", "" }, { "AssemblyName", "AssemblyName" }, { "TargetFileName", "TargetFileName.dll" },
+                    },
+                    references: [typeof(object).Assembly.Location]).Object
+            }
+        };
+        var rollbackProcessMock = new Mock<ICSharpRollbackProcess>(MockBehavior.Strict);
+        return new CsharpCompilingProcess(input, rollbackProcessMock.Object, syntaxTrees: syntaxTrees);
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -23,13 +23,41 @@ using Stryker.Core.ProjectComponents.SourceProjects;
 
 namespace Stryker.Core.UnitTest.Compiling;
 
-internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationContent
+internal class CompilerWrapper(CSharpCompilation compilation) : ICompilationContent, IBaselineCompiler
 {
     private CSharpCompilation _compilation = compilation;
+
+    // Test seam: force the baseline outcome to exercise the mutation-induced branch, which real
+    // (runtime-wrapped) mutators cannot currently produce in a mutant-free tree.
+    public bool? FailsWithoutInstrumentationOverride { get; set; }
 
     public IEnumerable<SyntaxTree> SyntaxTrees => _compilation.SyntaxTrees;
 
     public void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated) => _compilation = _compilation.ReplaceSyntaxTree(original, updated);
+
+    public bool FailsWithoutInstrumentation(SyntaxTree erroringTree)
+    {
+        if (FailsWithoutInstrumentationOverride.HasValue)
+        {
+            return FailsWithoutInstrumentationOverride.Value;
+        }
+
+        SyntaxTree erroringBaseline = null;
+        var unmutatedTrees = new List<SyntaxTree>();
+        foreach (var sourceTree in _compilation.SyntaxTrees)
+        {
+            var cleaned = MutantPlacer.RemoveAllMutations(sourceTree);
+            if (sourceTree == erroringTree)
+            {
+                erroringBaseline = cleaned;
+            }
+
+            unmutatedTrees.Add(cleaned);
+        }
+
+        var baseline = _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(unmutatedTrees);
+        return erroringBaseline != null && MutantPlacer.HasCompileError(baseline, erroringBaseline);
+    }
 
     public EmitResult Emit(Stream stream) => _compilation.Emit(stream);
 }
@@ -98,6 +126,337 @@ public class CSharpRollbackProcessTests : TestBase
 
         rolledBackResult.Success.ShouldBeTrue();
     }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldReportBaselineFailure_WhenErrorIsInUnmutatedFile()
+    {
+        // An unmutated file that does not compile on its own (e.g. a source generator
+        // produced no output) must be reported as a baseline failure, not as an internal
+        // Stryker rollback error: its diagnostics cannot have been caused by mutation.
+        // Two distinct diagnostics so the message's joined code list (and its separator)
+        // is exercised: NoSuchType -> CS0246, Missing.Symbol -> CS0103.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class Anchor
+                {
+                    public object Broken() { NoSuchType local; return Missing.Symbol; }
+                }
+            }
+            """,
+            path: "Anchor.cs");
+
+        var compilerWrapper = BaselineFailureCompiler(syntaxTree);
+
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        var exception = Should.Throw<CompilationException>(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.Normal, false));
+
+        exception.Message.ShouldContain("not caused by mutation");
+        exception.Message.ShouldContain("Anchor.cs");
+        exception.Message.ShouldContain("CS0103");
+        exception.Message.ShouldContain("CS0246");
+        exception.Message.ShouldContain(", "); // both codes joined with a separator
+        exception.Message.ShouldNotContain("Internal error");
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldReportBaselineFailure_WithGenericLabel_WhenFileHasNoPath()
+    {
+        // Same baseline failure, but the erroring tree has no FilePath (in-memory): the
+        // message must use a generic label, not an empty quoted path. Exercises the
+        // string.IsNullOrEmpty(FilePath) branch.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Anchor { public object Broken() => Missing.Symbol; } }
+            """);
+
+        var compilerWrapper = BaselineFailureCompiler(syntaxTree);
+
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        var exception = Should.Throw<CompilationException>(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.Normal, false));
+
+        exception.Message.ShouldContain("not caused by mutation");
+        exception.Message.ShouldContain("an unmutated file"); // generic label, not a quoted path
+        exception.Message.ShouldNotContain("''");
+        exception.Message.ShouldNotContain("Internal error");
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldReportInternalError_WhenErroringTreeStillHasMutants()
+    {
+        // A tree that DOES carry a mutant and fails to compile: in LastChance mode rollback
+        // cannot recover, and because the erroring tree still has mutants this is a genuine
+        // Stryker internal error (not a baseline failure) - the message must stay "Internal error".
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class Calculator
+                {
+                    public int ActiveMutation = 1;
+                    public string Ok(string a, string b)
+                    {
+                        if (ActiveMutation == 1) { return a + b; } else { return b + a; }
+                    }
+                    public object Broken() => Missing.Symbol;
+                }
+            }
+            """,
+            path: "Mixed.cs");
+        var ifStatement = syntaxTree.GetRoot().DescendantNodes().First(x => x is IfStatementSyntax);
+        var annotated = syntaxTree.GetRoot()
+            .ReplaceNode(ifStatement, ifStatement.WithAdditionalAnnotations(GetMutationIdMarker(1), _ifEngineMarker))
+            .SyntaxTree;
+
+        var compilerWrapper = BaselineFailureCompiler(annotated);
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        var exception = Should.Throw<CompilationException>(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.LastChance, false));
+
+        exception.Message.ShouldContain("Internal error");
+        exception.Message.ShouldNotContain("not caused by mutation");
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldReportInternalError_WhenErrorIsInStrykerInjectedHelper()
+    {
+        // A mutant-free tree can also be one of Stryker's OWN injected helpers (MutantControl
+        // etc.), which are added with their resource name as the FilePath. If one of those fails
+        // to compile it is purely an internal Stryker.NET problem, so it must NOT be reported as
+        // a user-side baseline failure ("check your generator setup") - it keeps the internal
+        // error path just as a mutant-carrying tree would.
+        var helperName = CodeInjection.HelperFiles.First();
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Helper { public object Broken() => Missing.Symbol; } }
+            """,
+            path: helperName);
+
+        var compilerWrapper = BaselineFailureCompiler(syntaxTree);
+
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        var exception = Should.Throw<CompilationException>(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.Normal, false));
+
+        exception.Message.ShouldContain("Internal error");
+        exception.Message.ShouldNotContain("not caused by mutation");
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldNotReportBaselineFailure_WhenAnotherErroringTreeStillHasMutants()
+    {
+        // Cross-tree causality: a mutant in one tree can make Roslyn report the resulting compile
+        // error in a DIFFERENT, mutant-free tree. While an erroring tree still carries a mutant
+        // rollback can remove, a co-erroring mutant-free tree must NOT be reported as a baseline
+        // failure - it is deferred so rolling back the mutant can clear it on the next compile pass.
+        var mutatedTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class Calculator
+                {
+                    public int ActiveMutation = 1;
+                    public string Subtract(string first, string second)
+                    {
+                        if (ActiveMutation == 1) { return first - second; } else { return first + second; }
+                    }
+                }
+            }
+            """,
+            path: "Mutated.cs");
+        var ifStatement = mutatedTree.GetRoot().DescendantNodes().First(x => x is IfStatementSyntax);
+        var annotatedMutated = mutatedTree.GetRoot()
+            .ReplaceNode(ifStatement, ifStatement.WithAdditionalAnnotations(GetMutationIdMarker(1), _ifEngineMarker))
+            .SyntaxTree;
+
+        // A separate mutant-free tree that also fails to compile.
+        var unmutatedTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Other { public object Broken() => Missing.Symbol; } }
+            """,
+            path: "Unmutated.cs");
+
+        var compilerWrapper = BaselineFailureCompiler(annotatedMutated, unmutatedTree);
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        // On a normal pass the mutant-free tree is deferred (not misreported as a baseline
+        // failure); the mutant in the other tree is rolled back instead.
+        var rolledBack = Should.NotThrow(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.Normal, false));
+
+        rolledBack.ShouldContain(1);
+    }
+
+    [TestMethod]
+    public void FailsWithoutInstrumentation_IsFalse_WhenRemovingMutationsFixesTheBuild()
+    {
+        // A file that only fails to compile because of a mutation: stripping the mutation restores
+        // a buildable baseline, so the tree does NOT fail without instrumentation (mutation-induced).
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class Calculator
+                {
+                    public int ActiveMutation = 1;
+                    public string Subtract(string first, string second)
+                    {
+                        if (ActiveMutation == 1) { return first - second; } else { return first + second; }
+                    }
+                }
+            }
+            """,
+            path: "Mutated.cs");
+        var ifStatement = syntaxTree.GetRoot().DescendantNodes().First(x => x is IfStatementSyntax);
+        var annotated = syntaxTree.GetRoot()
+            .ReplaceNode(ifStatement, ifStatement.WithAdditionalAnnotations(GetMutationIdMarker(1), _ifEngineMarker))
+            .SyntaxTree;
+
+        var compilerWrapper = BaselineFailureCompiler(annotated);
+        using var ms = new MemoryStream();
+        compilerWrapper.Emit(ms).Success.ShouldBeFalse();
+
+        compilerWrapper.FailsWithoutInstrumentation(annotated).ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void FailsWithoutInstrumentation_IsTrue_WhenTheFailureIsIndependentOfMutation()
+    {
+        // A file that fails to compile with no mutation involved (a missing symbol): stripping
+        // mutations changes nothing, so the tree still fails on the baseline - not mutation-induced.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Anchor { public object Broken() => Missing.Symbol; } }
+            """,
+            path: "Anchor.cs");
+        var compilerWrapper = BaselineFailureCompiler(syntaxTree);
+        using var ms = new MemoryStream();
+        compilerWrapper.Emit(ms).Success.ShouldBeFalse();
+
+        compilerWrapper.FailsWithoutInstrumentation(syntaxTree).ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void FailsWithoutInstrumentation_IsCorrelatedToTheGivenTree_NotTheWholeCompilation()
+    {
+        // Two mutant-free trees: one compiles, one has a baseline error. The check must correlate to
+        // the queried tree - the clean tree does NOT fail just because another tree fails on the
+        // baseline (otherwise a mutation-induced failure could be misreported as baseline).
+        var clean = CSharpSyntaxTree.ParseText(
+            "namespace ExampleProject { public class Ok { public int Value => 1; } }", path: "Clean.cs");
+        var broken = CSharpSyntaxTree.ParseText(
+            "namespace ExampleProject { public class Bad { public object Broken() => Missing.Symbol; } }", path: "Broken.cs");
+        var compilerWrapper = BaselineFailureCompiler(clean, broken);
+
+        compilerWrapper.FailsWithoutInstrumentation(clean).ShouldBeFalse();
+        compilerWrapper.FailsWithoutInstrumentation(broken).ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldReportInternalError_WhenTheTreeCompilesOnTheBaseline()
+    {
+        // Future-proofing: if a mutant-free tree fails to compile yet its counterpart builds cleanly
+        // on the fully-uninstrumented baseline, the failure was mutation-induced (rollback just could
+        // not attribute it) - it must stay an internal error, not be blamed on the user's build.
+        // Today's runtime-wrapped mutators cannot actually produce this, so the outcome is forced.
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject { public class Anchor { public object Broken() => Missing.Symbol; } }
+            """,
+            path: "Anchor.cs");
+        var compilerWrapper = BaselineFailureCompiler(syntaxTree);
+        compilerWrapper.FailsWithoutInstrumentationOverride = false;
+
+        var target = new CSharpRollbackProcess();
+        using var ms = new MemoryStream();
+        var compileResult = compilerWrapper.Emit(ms);
+        compileResult.Success.ShouldBeFalse();
+
+        var exception = Should.Throw<CompilationException>(() =>
+            target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics,
+                ICSharpRollbackProcess.Mode.Normal, false));
+
+        exception.Message.ShouldContain("Internal error");
+        exception.Message.ShouldNotContain("not caused by mutation");
+    }
+
+    [TestMethod]
+    public void RemoveAllMutations_RestoresTheOriginalSource_IncludingStructuralRewrites()
+    {
+        // Stryker converts an expression-bodied member to a block body - a structural rewrite
+        // tagged with an Injector annotation but no MutationId - to make room for statement-level
+        // mutations. RemoveAllMutations must undo that conversion as well as the mutations, so the
+        // mutation-free baseline it produces is the genuine original source (not a still-rewritten
+        // one that a syntax-sensitive generator could react to).
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            using System;
+
+            namespace ExampleProject
+            {
+                public class Fake { public event Action ValueChanged; }
+
+                public class Test
+                {
+                    private Fake AccountNumber = new Fake();
+                    public void Subscribe() => AccountNumber.ValueChanged += RefreshAccountNumber;
+                    private void RefreshAccountNumber() { }
+                }
+            }
+            """,
+            path: "Original.cs");
+        var codeInjection = new CodeInjection();
+        var mutator = new CsharpMutantOrchestrator(new MutantPlacer(codeInjection),
+            options: new StrykerOptions { MutationLevel = MutationLevel.Complete });
+
+        var mutated = mutator.Mutate(syntaxTree, null);
+        MutantPlacer.GetAllMutations(mutated.GetRoot()).ShouldNotBeEmpty("the orchestrator should have instrumented the code");
+
+        var restored = MutantPlacer.RemoveAllMutations(mutated);
+
+        restored.GetRoot().GetAnnotatedNodes("Injector").ShouldBeEmpty("all instrumentation, including structural rewrites, must be reverted");
+        restored.GetRoot().NormalizeWhitespace().ToFullString()
+            .ShouldBe(syntaxTree.GetRoot().NormalizeWhitespace().ToFullString());
+        // the baseline must be the genuine original project - its metadata is preserved
+        restored.FilePath.ShouldBe("Original.cs");
+        restored.Options.ShouldBe(mutated.Options);
+    }
+
+    private static CompilerWrapper BaselineFailureCompiler(params SyntaxTree[] syntaxTrees) =>
+        new(CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: syntaxTrees,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: new List<PortableExecutableReference>() {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+            }));
 
     [TestMethod]
     public void ShouldRollbackIssueInExpression()

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Stryker.Abstractions;
 using Stryker.Abstractions.Exceptions;
 using Stryker.Core.Helpers;
+using Stryker.Core.InjectedHelpers;
 using Stryker.Core.Mutants;
 using Stryker.Utilities.Logging;
 
@@ -20,6 +21,25 @@ public interface ICompilationContent
     IEnumerable<SyntaxTree> SyntaxTrees { get; }
 
     void ReplaceSyntaxTree(SyntaxTree original, SyntaxTree updated);
+}
+
+/// <summary>
+/// Optional capability - implemented by Stryker's own compilation - to recompile a fully
+/// uninstrumented baseline and report whether it builds. Kept internal so it adds no public
+/// extension-API surface. When a compilation content does not provide it, rollback conservatively
+/// keeps the internal-error path (it never blames the user's build without proof).
+/// </summary>
+internal interface IBaselineCompiler
+{
+    /// <summary>
+    /// True if <paramref name="erroringTree"/> still fails to compile once every trace of Stryker
+    /// instrumentation is removed from the whole compilation (mutations and structural rewrites
+    /// reversed, injected helpers and generated output dropped, generators re-run on the clean
+    /// source). The check is correlated to this specific tree - a baseline error in some other
+    /// tree does not make this one a baseline failure - so a remaining error here means the failure
+    /// is genuinely independent of mutation rather than mutation-induced.
+    /// </summary>
+    bool FailsWithoutInstrumentation(SyntaxTree erroringTree);
 }
 
 
@@ -63,9 +83,70 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
         }
 
         // remove the broken mutations from the syntax trees
-        foreach (var syntaxTreeMap in syntaxTreeMapping.Where(x => x.Value.Count != 0))
+        var erroringTrees = syntaxTreeMapping.Where(x => x.Value.Count != 0).ToList();
+        // A mutant in one syntax tree can make Roslyn report the resulting error in a *different*,
+        // mutant-free tree (e.g. mutating a public constant creates a duplicate case value in an
+        // unmutated consumer). So the absence of mutants in the erroring tree alone does not prove
+        // its errors are not mutation-caused: while any erroring tree still carries a mutant, we
+        // let rollback remove it and recompile before concluding anything about a mutant-free tree.
+        var rollbackCandidatesRemain =
+            erroringTrees.Any(x => MutantPlacer.GetAllMutations(x.Key.GetRoot()).Any());
+
+        foreach (var syntaxTreeMap in erroringTrees)
         {
             var originalTree = syntaxTreeMap.Key;
+
+            // A file that carries no mutants cannot have ITS errors removed by rollback. Once no
+            // erroring tree still has a mutant for rollback to try (rollback is exhausted), such a
+            // failure is not mutation-caused, so report it up front instead of running
+            // RemoveCompileErrorMutations - which would only emit misleading "unidentified
+            // mutation" / "Safe Mode" log lines - distinguishing Stryker's own injected helpers
+            // (MutantControl etc.), whose failure is purely an internal Stryker.NET problem, from
+            // an unmutated user file that simply does not build under Stryker's compilation.
+            if (!MutantPlacer.GetAllMutations(originalTree.GetRoot()).Any())
+            {
+                // Defer: a mutant in another erroring tree may be the cause; rolling it back can
+                // clear this tree's errors on the next compile pass.
+                if (rollbackCandidatesRemain)
+                {
+                    continue;
+                }
+
+                var codes = string.Join(", ", syntaxTreeMap.Value.Select(diagnostic => diagnostic.Id).Distinct());
+                if (CodeInjection.IsInjectedHelper(originalTree.FilePath))
+                {
+                    Logger.LogCritical(
+                        "Stryker.NET's own injected helper code failed to compile ({Codes}). This is an internal Stryker.NET error, not a problem with your project. Please report this issue on github with the previous error message.",
+                        codes);
+                    throw new CompilationException("Internal error due to compile error in Stryker.NET injected code.");
+                }
+
+                // Prove it before blaming the user's build. Report a baseline failure only when
+                // THIS tree still fails to compile on a fully-uninstrumented baseline (mutations AND
+                // structural rewrites reversed, generators re-run); if it builds clean there, this
+                // failure was mutation-induced (rollback simply could not attribute it) and stays an
+                // internal error. Content that cannot run that baseline compile falls back to the
+                // conservative internal-error path. With today's mutators the baseline always still
+                // fails here - Stryker only places runtime-wrapped mutations and never mutates
+                // const/enum/attribute/parameter-default contexts, so a mutant-free tree's error is
+                // never mutation-caused - but this keeps the distinction sound if that ever changes.
+                var isBaselineFailure =
+                    wrapper is IBaselineCompiler baselineCompiler && baselineCompiler.FailsWithoutInstrumentation(originalTree);
+                if (!isBaselineFailure)
+                {
+                    Logger.LogCritical(
+                        "Stryker.NET could not compile the project after mutation. This is probably an error for Stryker.NET and not your project. Please report this issue on github with the previous error message.");
+                    throw new CompilationException("Internal error due to compile error.");
+                }
+
+                var file = string.IsNullOrEmpty(originalTree.FilePath) ? "an unmutated file" : $"'{originalTree.FilePath}'";
+                Logger.LogError(
+                    "Compilation failed in {File} ({Codes}), which has no mutants, so these errors are not caused by mutation. This usually means a build input is missing under Stryker's compilation (for example a source generator produced no output; check analyzer configs / generator setup). If it builds fine outside Stryker.NET, this may be a Stryker.NET issue worth reporting on github.",
+                    file, codes);
+                throw new CompilationException(
+                    $"Compilation failed in {file} ({codes}) with no mutants involved; these errors are not caused by mutation.");
+            }
+
             Logger.LogDebug("RollBacking mutations from {FilePath}.", originalTree.FilePath);
             if (devMode)
             {

--- a/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CsharpCompilingProcess.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Logging;
 using Stryker.Abstractions.Exceptions;
 using Stryker.Abstractions.Options;
 using Stryker.Configuration.Options;
+using Stryker.Core.InjectedHelpers;
+using Stryker.Core.Mutants;
 using Stryker.Core.MutationTest;
 using Stryker.Core.ProjectComponents;
 using Stryker.Utilities.Buildalyzer;
@@ -33,7 +35,7 @@ public interface ICSharpCompilingProcess
 /// This process is in control of compiling the assembly and rolling back mutations that cannot compile
 /// Compiles the given input onto the memory stream
 /// </summary>
-public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationContent
+public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationContent, IBaselineCompiler
 {
     private const int MaxAttempt = 50;
     private readonly MutationTestInput _input;
@@ -319,6 +321,37 @@ public class CsharpCompilingProcess : ICSharpCompilingProcess, ICompilationConte
     {
         _compilation = _compilation.ReplaceSyntaxTree(original, updated);
         _needToRunGenerators = true;
+    }
+
+    // Explicit implementation so this does not become public API on this public class; the
+    // capability is only reachable through the internal IBaselineCompiler.
+    bool IBaselineCompiler.FailsWithoutInstrumentation(SyntaxTree erroringTree)
+    {
+        // Build a baseline from the user's original source only: drop the trees the generators
+        // produced from the mutated source AND Stryker's own injected helper trees, reverse every
+        // mutation and structural rewrite from what remains, then re-run the generators on that
+        // clean source so a syntax-sensitive generator sees the genuine original code. Remember which
+        // cleaned tree corresponds to the erroring one so the check can be correlated to it by
+        // identity rather than by file path (which is not unique for path-less trees).
+        SyntaxTree erroringBaseline = null;
+        var originalSource = new List<SyntaxTree>();
+        foreach (var sourceTree in _compilation.RemoveSyntaxTrees(GeneratedTrees).SyntaxTrees
+                     .Where(syntaxTree => !CodeInjection.IsInjectedHelper(syntaxTree.FilePath)))
+        {
+            var cleaned = MutantPlacer.RemoveAllMutations(sourceTree);
+            if (sourceTree == erroringTree)
+            {
+                erroringBaseline = cleaned;
+            }
+
+            originalSource.Add(cleaned);
+        }
+
+        _generatorDriver.RunGeneratorsAndUpdateCompilation(
+            _compilation.RemoveAllSyntaxTrees().AddSyntaxTrees(originalSource), out var baseline, out _);
+        // If the erroring tree's own counterpart still fails, the failure is independent of mutation
+        // (a baseline error in some other tree does not make this one a baseline failure).
+        return erroringBaseline != null && MutantPlacer.HasCompileError(baseline, erroringBaseline);
     }
 
     private static string ReadableNumber(int number) => number switch

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/CodeInjection.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/CodeInjection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
@@ -10,9 +11,19 @@ namespace Stryker.Core.InjectedHelpers;
 
 public class CodeInjection
 {
-    // files to be injected into the mutated assembly
-    private static readonly string[] Files = {"Stryker.Core.InjectedHelpers.MutantControl.cs",
-        "Stryker.Core.InjectedHelpers.Coverage.MutantContext.cs"};
+    // resource names used as the FilePath of the helper syntax trees Stryker injects into the
+    // mutated assembly (see CsharpProjectComponentsBuilder.InjectMutantHelpers)
+    internal static readonly ImmutableArray<string> HelperFiles =
+        ["Stryker.Core.InjectedHelpers.MutantControl.cs",
+         "Stryker.Core.InjectedHelpers.Coverage.MutantContext.cs"];
+
+    /// <summary>
+    /// True when <paramref name="filePath"/> is one of Stryker's own injected helper files, so
+    /// rollback can tell Stryker's injected code apart from the user's source when a mutant-free
+    /// tree fails to compile. Kept internal and backed by an immutable array so it is not a
+    /// public API surface and cannot be mutated by callers.
+    /// </summary>
+    internal static bool IsInjectedHelper(string filePath) => HelperFiles.Contains(filePath);
     private const string PatternForCheck = "\\/\\/ *check with: *([^\\r\\n]+)";
     private const string MutantContextClassName = "MutantContext";
     private const string StrykerNamespace = "Stryker";
@@ -36,7 +47,7 @@ public class CodeInjection
         HelperNamespace = GetRandomNamespace();
         SelectorExpression = Selector.Replace(StrykerNamespace, HelperNamespace);
 
-        foreach (var file in Files)
+        foreach (var file in HelperFiles)
         {
             var fileContents = GetSourceFromResource(file).Replace(StrykerNamespace, HelperNamespace);
             MutantHelpers.Add(file, fileContents);

--- a/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutants/MutantPlacer.cs
@@ -225,4 +225,44 @@ public class MutantPlacer(CodeInjection injection)
             let mutationInfo = FindAnnotations(syntaxNode)
             select (syntaxNode, mutationInfo)).ToList();
     }
+
+    /// <summary>
+    /// Returns the syntax tree with every trace of Stryker instrumentation removed, restoring its
+    /// original, un-instrumented form. This reverses not only the mutations themselves but also the
+    /// structural rewrites Stryker applies to make room for them (for example converting an
+    /// expression-bodied member to a block body), so the result is the genuine original source.
+    /// Used to compile a mutation-free baseline so a mutation-induced compile failure can be told
+    /// apart from a failure that exists independently of any mutation.
+    /// </summary>
+    internal static SyntaxTree RemoveAllMutations(SyntaxTree tree)
+    {
+        var root = tree.GetRoot();
+        // Every instrumented node (a mutation or a structural rewrite) carries an Injector
+        // annotation naming the engine that can revert it. Revert the innermost instrumentation
+        // first: an outer rewrite (e.g. block-body -> expression-body) can only be undone once the
+        // mutations nested inside it are already gone.
+        while (true)
+        {
+            var innermost = root.GetAnnotatedNodes(Injector)
+                .FirstOrDefault(node => !node.DescendantNodes().Any(descendant => descendant.HasAnnotations(Injector)));
+            if (innermost == null)
+            {
+                break;
+            }
+
+            root = root.ReplaceNode(innermost, RemoveMutant(innermost));
+        }
+
+        // Rebuild from the original tree so its file path, encoding and parse options are preserved
+        // exactly - the baseline must be the genuine original project, not a re-parsed approximation.
+        return tree.WithRootAndOptions(root, tree.Options);
+    }
+
+    /// <summary>
+    /// True if <paramref name="compilation"/> has an error-level diagnostic in <paramref name="tree"/>.
+    /// The check is correlated to that specific tree by identity (via its semantic model), so an error
+    /// in another tree - even one sharing an empty or duplicate file path - does not count.
+    /// </summary>
+    internal static bool HasCompileError(Compilation compilation, SyntaxTree tree) =>
+        compilation.GetSemanticModel(tree).GetDiagnostics().Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
 }


### PR DESCRIPTION
When a source generator (e.g. `Microsoft.Windows.CsWin32`) produces no output during Stryker's mutation compilation, the *unmutated* file that consumes the generated symbols fails to compile. Rollback can't attribute those errors to any mutant, so Stryker aborts — but the message it prints is `"Stryker.NET could not compile the project after mutation. This is probably an error for Stryker.NET and not your project."`, which points people at the wrong thing. That's the reporting gap noted in #3698.

**The cause:** in `CSharpRollbackProcess.RollbackMutationsInError`, once rollback can't recover a compile error it always throws `"Internal error due to compile error."` and logs the "probably a Stryker.NET error" critical — even when the erroring file contains no mutants at all, i.e. the project simply doesn't build independently of mutation.

**The change:** when an erroring syntax tree carries no mutants (`MutantPlacer.GetAllMutations(...)` is empty), report the failure naming the file and diagnostic codes, and point at the likely cause (a generator that emitted nothing), **without** asserting the user's project is broken — keeping a "this may be a Stryker.NET issue worth reporting" fallback.

**Proving it's actually mutation-independent:** before concluding a mutant-free failure is a baseline problem, Stryker now rebuilds a genuinely uninstrumented baseline and recompiles it (`ICompilationContent.CompilesWithoutMutations()`). "Uninstrumented" means reversing not just the mutations but also the structural rewrites Stryker applies to host them (e.g. converting an expression-bodied member to a block body), then re-running the source generators on that clean source so a syntax-sensitive generator sees the original code. If that baseline builds, the failure *was* mutation-induced (rollback just couldn't attribute it) and stays an internal error; only a failure that persists with no instrumentation at all is reported as a baseline failure. With today's mutators this always confirms "baseline" here — Stryker only places runtime-wrapped mutations and never mutates the compile-time constructs that could break a *different* file (const/enum/attribute/parameter-default) — but the recompile keeps the classification sound if that ever changes.

**Injected helpers:** Stryker's own injected helper files (`MutantControl` etc.) are also mutant-free, but a compile failure there really is an internal Stryker problem, so those keep the internal-error message (an internal, immutable check, not public API). Trees that still carry mutants keep the existing internal-error path unchanged.

**Real-behaviour proof (the CsWin32 source-generator repro from #3698).** A minimal project that uses `Microsoft.Windows.CsWin32` to generate a P/Invoke consumed by `Win32Anchor.cs`. It builds fine with `dotnet build`, but under Stryker's mutation compilation CsWin32 emits nothing, so `Win32Anchor.cs` (which has no mutants) fails to compile. Packing `Stryker.CLI` from `master` and from this branch, then running each against the repro test project with the identical command:

```
# from repros/tests/CsWin32Repro.Tests
dotnet <packed-Stryker.CLI.dll> --mutate '**/Target.cs' --reporter json
```

Base (`433fde6a`) — misdiagnoses it as Stryker's fault, preceded by contradictory warnings:

```
[WRN] An unidentified mutation in Win32Anchor.cs resulted in a compile error (id: CS0234) ...
[INF] Safe Mode! Stryker will remove all mutations in ...
[FTL] Stryker.NET could not compile the project after mutation. This is probably an error for Stryker.NET and not your project. Please report this issue on github with the previous error message.
```

This branch — reverses all instrumentation, re-runs the generators on the clean source, sees Win32Anchor.cs still fails (mutation-independent), and reports it plainly with no contradictory warnings:

```
[ERR] Compilation failed in 'Win32Anchor.cs' (CS0234, CS0246, CS0103), which has no mutants, so these errors are not caused by mutation. This usually means a build input is missing under Stryker's compilation (for example a source generator produced no output; check analyzer configs / generator setup). If it builds fine outside Stryker.NET, this may be a Stryker.NET issue worth reporting on github.
```

Both runs were captured to files; the exact before/after transcripts (and their sha256) are recorded in the branch review-history gist below, alongside the local CI, mutation, and generator-baseline test results.

**Testing:** unit tests in `CSharpRollbackProcessTests` cover the branch — an unmutated file that fails to compile gets the baseline message (with joined diagnostic codes, and a generic label when it has no `FilePath`); a mutant-carrying tree still gets the internal-error message; an injected-helper file gets the internal-error message; a mutant-free tree co-erroring with a mutant-carrying tree is deferred rather than misreported; and `CompilesWithoutMutations` is covered both ways (true when removing mutations fixes the build, false when the failure is mutation-independent) plus the branch where a baseline that compiles keeps the internal error. Verified end-to-end against the CsWin32 repro (the before/after above).

Refs #3698. AI-assisted, but the before/after is reproducible so you don't have to take my word for it.

Review history: https://gist.github.com/387d71b3928dfead781013182e7286ec
