### PR TITLE
chore: cover rollback mutation selection paths

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Pipes;
@@ -43,6 +44,9 @@ public class CSharpRollbackProcessTests : TestBase
     private SyntaxAnnotation GetMutationIdMarker(int id) => new("MutationId", id.ToString());
 
     private SyntaxAnnotation GetMutationTypeMarker(Mutator type) => new("MutationType", type.ToString());
+
+    private static Diagnostic CreateErrorDiagnostic(string id, SyntaxNode node) =>
+        Diagnostic.Create(new DiagnosticDescriptor(id, id, id, "Compiler", DiagnosticSeverity.Error, true), node.GetLocation());
 
     [TestMethod]
     public void RollbackProcess_ShouldRollbackError_RollbackedCompilationShouldCompile()
@@ -514,6 +518,193 @@ public class CSharpRollbackProcessTests : TestBase
         rollbackedResult.Success.ShouldBeTrue();
         // validate that only the block mutation was rolled back
         ids.ShouldBe(new Collection<int> { 1 });
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldPreferBlockMutationsWhenSafeModeFindsMixedMutationTypes()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class StringMagic
+                {
+                    public int ActiveMutation = 1;
+
+                    public string Value()
+                    {
+                        if (ActiveMutation == 1) { } else { }
+                        if (ActiveMutation == 2) { } else { }
+                        var broken = "a" - "b";
+                        return broken;
+                    }
+                }
+            }
+            """);
+        var root = syntaxTree.GetRoot();
+        var blockMutation = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(
+            blockMutation,
+            blockMutation.WithAdditionalAnnotations(GetMutationIdMarker(1), GetMutationTypeMarker(Mutator.Block), _ifEngineMarker));
+        var stringMutation = root.DescendantNodes().OfType<IfStatementSyntax>().Last();
+        root = root.ReplaceNode(
+            stringMutation,
+            stringMutation.WithAdditionalAnnotations(GetMutationIdMarker(2), GetMutationTypeMarker(Mutator.String), _ifEngineMarker));
+
+        var annotatedSyntaxTree = root.SyntaxTree;
+        var brokenStatement = annotatedSyntaxTree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().Single();
+        var compiler = CSharpCompilation.Create("TestCompilation", syntaxTrees: [annotatedSyntaxTree]);
+        var compilerWrapper = new CompilerWrapper(compiler);
+
+        var ids = new CSharpRollbackProcess().RollbackMutationsInError(
+            compilerWrapper,
+            ImmutableArray.Create(CreateErrorDiagnostic("TEST0001", brokenStatement)),
+            ICSharpRollbackProcess.Mode.Normal,
+            false);
+
+        ids.ShouldBe([1]);
+    }
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void RollbackProcess_ShouldOnlyScanChildMutationsForExpressionDiagnostics(bool diagnosticOnExpression)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class StringMagic
+                {
+                    public int ActiveMutation = 1;
+
+                    public string Value()
+                    {
+                        var first = (ActiveMutation == 1 ? "first" : "fallback") + "";
+                        var second = (ActiveMutation == 2 ? "second" : "fallback") + "";
+                        return first + second;
+                    }
+                }
+            }
+            """);
+        var root = syntaxTree.GetRoot();
+        var firstMutation = root.DescendantNodes().OfType<ParenthesizedExpressionSyntax>().First();
+        root = root.ReplaceNode(
+            firstMutation,
+            firstMutation.WithAdditionalAnnotations(GetMutationIdMarker(1), _conditionalEngineMarker));
+        var secondMutation = root.DescendantNodes().OfType<ParenthesizedExpressionSyntax>().Last();
+        root = root.ReplaceNode(
+            secondMutation,
+            secondMutation.WithAdditionalAnnotations(GetMutationIdMarker(2), _conditionalEngineMarker));
+
+        var annotatedSyntaxTree = root.SyntaxTree;
+        var secondDeclaration = annotatedSyntaxTree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().Last();
+        SyntaxNode diagnosticNode = diagnosticOnExpression
+            ? secondDeclaration.Declaration.Variables.Single().Initializer!.Value
+            : secondDeclaration;
+        var compiler = CSharpCompilation.Create("TestCompilation", syntaxTrees: [annotatedSyntaxTree]);
+        var compilerWrapper = new CompilerWrapper(compiler);
+
+        var ids = new CSharpRollbackProcess().RollbackMutationsInError(
+            compilerWrapper,
+            ImmutableArray.Create(CreateErrorDiagnostic("TEST0002", diagnosticNode)),
+            ICSharpRollbackProcess.Mode.Normal,
+            false);
+
+        var expectedIds = diagnosticOnExpression ? new[] { 2 } : new[] { 1, 2 };
+        ids.OrderBy(id => id).ShouldBe(expectedIds);
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldRollbackNearestMutationErasingAssignment()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class StringMagic
+                {
+                    public int ActiveMutation = 1;
+
+                    public string Value()
+                    {
+                        string result;
+                        if (ActiveMutation == 1) { } else { result = "first"; }
+                        if (ActiveMutation == 2) { } else { result = "second"; }
+                        return result;
+                    }
+                }
+            }
+            """);
+        var root = syntaxTree.GetRoot();
+        var firstMutation = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(firstMutation, firstMutation.WithAdditionalAnnotations(GetMutationIdMarker(1), _ifEngineMarker));
+        var secondMutation = root.DescendantNodes().OfType<IfStatementSyntax>().Last();
+        root = root.ReplaceNode(secondMutation, secondMutation.WithAdditionalAnnotations(GetMutationIdMarker(2), _ifEngineMarker));
+
+        var annotatedSyntaxTree = root.SyntaxTree;
+        var compiler = CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: [annotatedSyntaxTree],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var compilerWrapper = new CompilerWrapper(compiler);
+        using var initialStream = new MemoryStream();
+        var diagnostic = compiler.Emit(initialStream).Diagnostics.Single(item => item.Id == "CS0165");
+
+        var ids = new CSharpRollbackProcess().RollbackMutationsInError(
+            compilerWrapper,
+            ImmutableArray.Create(diagnostic),
+            ICSharpRollbackProcess.Mode.Normal,
+            false);
+
+        ids.ShouldBe([2]);
+        using var stream = new MemoryStream();
+        compilerWrapper.Emit(stream).Success.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldRollbackNearestMutationErasingReturn()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            """
+            namespace ExampleProject
+            {
+                public class StringMagic
+                {
+                    public int ActiveMutation = 1;
+
+                    public string Value()
+                    {
+                        if (ActiveMutation == 1) { } else { return "first"; }
+                        if (ActiveMutation == 2) { } else { return "second"; }
+                        var marker = 0;
+                    }
+                }
+            }
+            """);
+        var root = syntaxTree.GetRoot();
+        var firstMutation = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(firstMutation, firstMutation.WithAdditionalAnnotations(GetMutationIdMarker(1), _ifEngineMarker));
+        var secondMutation = root.DescendantNodes().OfType<IfStatementSyntax>().Last();
+        root = root.ReplaceNode(secondMutation, secondMutation.WithAdditionalAnnotations(GetMutationIdMarker(2), _ifEngineMarker));
+
+        var annotatedSyntaxTree = root.SyntaxTree;
+        var method = annotatedSyntaxTree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var compiler = CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: [annotatedSyntaxTree],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var compilerWrapper = new CompilerWrapper(compiler);
+
+        var ids = new CSharpRollbackProcess().RollbackMutationsInError(
+            compilerWrapper,
+            ImmutableArray.Create(CreateErrorDiagnostic("CS0161", method)),
+            ICSharpRollbackProcess.Mode.Normal,
+            false);
+
+        ids.ShouldBe([2]);
+        using var stream = new MemoryStream();
+        compilerWrapper.Emit(stream).Success.ShouldBeTrue();
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- add focused rollback tests for mixed block/non-block safe-mode selection
- cover expression-only diagnostic scanning versus whole-member fallback
- verify nearest-erasing-mutation selection for unassigned variables and missing returns

## Mutation proof

The tests target five behavior-changing survivors reported in #3713:

| Mutation | Baseline | This branch |
| --- | --- | --- |
| conditional forced true in `FindMutationWithNode` | Survived | Killed focused / Timeout full suite |
| conditional forced false in `FindMutationWithNode` | Survived | Killed focused / Timeout full suite |
| `Any()` to `All()` in safe-mode block selection | Survived | Killed focused / Timeout full suite |
| `Last()` to `First()` for missing-return rollback | Survived | Killed |
| `Reverse()` to `AsEnumerable()` for assignment rollback | Survived | Killed |

On exact revisions with the full unit-test selection, detected mutants increase from 57/133 (42.9%) to 99/133 (74.4%), survivors fall from 56 to 18, and no-coverage mutants fall from 20 to 16. The focused rollback-test-class run classifies all five targeted mutants as killed.

Mutation command, run from `src/Stryker.Core/Stryker.Core` in separate exact-revision worktrees:

```console
dotnet stryker --config-file .mut-3713-proof-config.json --output .mut-3713-<side> --skip-version-check
```

## Testing

- focused `CSharpRollbackProcessTests`: 17 passed, 1 pre-existing skipped
- Windows vstest suite: 1,541 passed, 1 pre-existing skipped
- Microsoft.Testing.Platform suite: 191 passed
- Solution/netcore integration validation: passed

```console
dotnet test src/Stryker.Core/Stryker.Core.UnitTest/Stryker.Core.UnitTest.csproj -c Debug --filter "FullyQualifiedName~CSharpRollbackProcessTests"
dotnet restore src/Stryker.slnx
dotnet build src/Stryker.slnx -c Debug --no-restore
dotnet test src/Stryker.vstest.slnf -c Debug --no-build
cd src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest && dotnet test --configuration Debug --report-trx --results-directory ../../../TestResults
pwsh ./integration-tests.ps1
```

## Review history

https://gist.github.com/anagnorisis2peripeteia/880446b6e897f456fe40ff4944aa4b29

Closes #3713

AI assistance: I used Codex to help develop and review the tests and assemble the evidence. I reviewed the final diff and verified the focused tests, exact-revision mutation runs, and full Windows CI locally.
