### PR TITLE
fix(core): dispose reporter resources

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/SseServerTest.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Html/RealTime/SseServerTest.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using LaunchDarkly.EventSource;
@@ -153,12 +156,144 @@ public class SseServerTest : TestBase
     public void ShouldIndicateWhenAtLeastOneClientIsConnected()
     {
         _sut.OpenSseEndpoint();
-        var sseClient = new EventSource(new Uri($"http://localhost:{_sut.Port}/"));
+        using var sseClient = new EventSource(new Uri($"http://localhost:{_sut.Port}/"));
 
         Task.Run(() => sseClient.StartAsync());
         WaitForConnection(500).ShouldBeTrue();
 
         _sut.HasConnectedClients.ShouldBeTrue();
         _sut.CloseSseEndpoint();
+        _sut.HasConnectedClients.ShouldBeFalse();
+        _sut.CloseSseEndpoint();
+    }
+
+    [TestMethod]
+    public void ShouldCloseEndpointFromClientConnectedHandler()
+    {
+        _sut.ClientConnected += (_, _) => _sut.CloseSseEndpoint();
+        _sut.OpenSseEndpoint();
+        using var sseClient = new EventSource(new Uri($"http://localhost:{_sut.Port}/"));
+
+        Task.Run(() => sseClient.StartAsync());
+
+        WaitForConnection(500).ShouldBeTrue();
+        SpinWait.SpinUntil(() => !_sut.HasConnectedClients, 500).ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void ShouldContinueDisposingWritersAfterAnIoFailure()
+    {
+        _sut.OpenSseEndpoint();
+        var failingWriter = new StreamWriter(new FailingWriteStream());
+        failingWriter.Write("buffered");
+        var trackingStream = new TrackingStream();
+        var trackingWriter = new StreamWriter(trackingStream);
+        var writersField = typeof(SseServer).GetField("_writers", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(typeof(SseServer).FullName, "_writers");
+        var writers = (List<StreamWriter>)(writersField.GetValue(_sut)
+            ?? throw new InvalidOperationException("The writer collection was null."));
+        writers.Add(failingWriter);
+        writers.Add(trackingWriter);
+
+        Should.NotThrow(_sut.CloseSseEndpoint);
+
+        _sut.ConnectedClients.ShouldBe(0);
+        trackingStream.IsDisposed.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void ShouldWaitForConcurrentDisposalToComplete()
+    {
+        _sut.OpenSseEndpoint();
+        var blockingStream = new BlockingDisposeStream();
+        var writersField = typeof(SseServer).GetField("_writers", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new MissingFieldException(typeof(SseServer).FullName, "_writers");
+        var writers = (List<StreamWriter>)(writersField.GetValue(_sut)
+            ?? throw new InvalidOperationException("The writer collection was null."));
+        writers.Add(new StreamWriter(blockingStream));
+
+        var firstClose = Task.Run(_sut.CloseSseEndpoint);
+        blockingStream.DisposeStarted.Wait(500).ShouldBeTrue();
+        try
+        {
+            var secondStarted = new ManualResetEventSlim();
+            var secondClose = Task.Run(() =>
+            {
+                secondStarted.Set();
+                _sut.CloseSseEndpoint();
+            });
+            secondStarted.Wait(500).ShouldBeTrue();
+
+            secondClose.Wait(100).ShouldBeFalse();
+            blockingStream.AllowDispose.Set();
+            Task.WaitAll(firstClose, secondClose);
+        }
+        finally
+        {
+            blockingStream.AllowDispose.Set();
+        }
+
+        blockingStream.IsDisposed.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void ShouldCloseWhileClientConnectedHandlerIsBlocked()
+    {
+        using var handlerEntered = new ManualResetEventSlim();
+        using var releaseHandler = new ManualResetEventSlim();
+        _sut.ClientConnected += (_, _) =>
+        {
+            handlerEntered.Set();
+            releaseHandler.Wait();
+        };
+        _sut.OpenSseEndpoint();
+        using var sseClient = new EventSource(new Uri($"http://localhost:{_sut.Port}/"));
+        Task.Run(() => sseClient.StartAsync());
+        handlerEntered.Wait(500).ShouldBeTrue();
+
+        var close = Task.Run(_sut.CloseSseEndpoint);
+        try
+        {
+            close.Wait(500).ShouldBeTrue();
+        }
+        finally
+        {
+            releaseHandler.Set();
+        }
+    }
+
+    private sealed class FailingWriteStream : MemoryStream
+    {
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new IOException("The client disconnected.");
+
+        public override void Write(ReadOnlySpan<byte> buffer) =>
+            throw new IOException("The client disconnected.");
+    }
+
+    private sealed class TrackingStream : MemoryStream
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class BlockingDisposeStream : MemoryStream
+    {
+        public ManualResetEventSlim DisposeStarted { get; } = new();
+        public ManualResetEventSlim AllowDispose { get; } = new();
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeStarted.Set();
+            AllowDispose.Wait();
+            IsDisposed = disposing;
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/SseServer.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Html/RealTime/SseServer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -9,13 +8,26 @@ using Stryker.Core.Reporters.Html.RealTime.Events;
 
 namespace Stryker.Core.Reporters.Html.RealTime;
 
-public class SseServer : ISseServer
+public class SseServer : ISseServer, IDisposable
 {
     public int Port { get; set; }
-    public bool HasConnectedClients => _writers.Any();
+    public bool HasConnectedClients
+    {
+        get
+        {
+            lock (_writersLock)
+            {
+                return _writers.Count > 0;
+            }
+        }
+    }
 
     private readonly HttpListener _listener;
     private readonly List<StreamWriter> _writers;
+    private readonly object _writersLock = new();
+    private readonly TaskCompletionSource<bool> _disposeCompletion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private bool _disposedValue;
 
     public SseServer()
     {
@@ -26,7 +38,16 @@ public class SseServer : ISseServer
         _writers = new List<StreamWriter>();
     }
 
-    public int ConnectedClients => _writers.Count;
+    public int ConnectedClients
+    {
+        get
+        {
+            lock (_writersLock)
+            {
+                return _writers.Count;
+            }
+        }
+    }
 
     public event EventHandler<EventArgs> ClientConnected;
 
@@ -41,58 +62,167 @@ public class SseServer : ISseServer
 
     public void OpenSseEndpoint()
     {
-        _listener.Start();
-        Task.Run(ListenForConnectionsAsync);
+        lock (_writersLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposedValue, this);
+            _listener.Start();
+            Task.Run(ListenForConnectionsAsync);
+        }
     }
 
     private async Task ListenForConnectionsAsync()
     {
-        while (_listener.IsListening)
+        try
         {
-            var context = await _listener.GetContextAsync();
-            var response = context.Response;
-            response.ContentType = "text/event-stream";
-            // The file:// protocols needs this, since we can't add a file location as an allowed origin.
-            response.Headers.Add("Access-Control-Allow-Origin", "*");
-            response.Headers.Add("Access-Control-Allow-Methods", "GET, OPTIONS");
-            response.Headers.Add("Access-Control-Allow-Headers", "Content-Type");
-            response.Headers.Add("Cache-Control", "no-cache");
-            response.Headers.Add("Connection", "keep-alive");
+            while (_listener.IsListening)
+            {
+                var context = await _listener.GetContextAsync();
+                var response = context.Response;
+                response.ContentType = "text/event-stream";
+                // The file:// protocols needs this, since we can't add a file location as an allowed origin.
+                response.Headers.Add("Access-Control-Allow-Origin", "*");
+                response.Headers.Add("Access-Control-Allow-Methods", "GET, OPTIONS");
+                response.Headers.Add("Access-Control-Allow-Headers", "Content-Type");
+                response.Headers.Add("Cache-Control", "no-cache");
+                response.Headers.Add("Connection", "keep-alive");
 
-            var writer = new StreamWriter(response.OutputStream);
-            _writers.Add(writer);
-            ClientConnected?.Invoke(this, EventArgs.Empty);
+                var writer = new StreamWriter(response.OutputStream);
+                lock (_writersLock)
+                {
+                    if (_disposedValue)
+                    {
+                        DisposeWriter(writer);
+                        return;
+                    }
+
+                    _writers.Add(writer);
+                }
+
+                ClientConnected?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        catch (HttpListenerException)
+        {
+            // The listener was closed while waiting for the next client.
+        }
+        catch (ObjectDisposedException)
+        {
+            // The listener was disposed while waiting for the next client.
         }
     }
 
     public void SendEvent<T>(SseEvent<T> @event)
     {
         var serialized = @event.Serialize();
-        var lostClients = new List<StreamWriter>();
-        foreach (var writer in _writers)
+        lock (_writersLock)
         {
-            try
+            if (_disposedValue)
             {
-                writer.Write($"{serialized}{Environment.NewLine}{Environment.NewLine}");
-                writer.Flush();
+                return;
             }
-            catch (HttpListenerException)
+
+            var lostClients = new List<StreamWriter>();
+            foreach (var writer in _writers)
             {
-                // The client disconnected
-                lostClients.Add(writer);
+                try
+                {
+                    writer.Write($"{serialized}{Environment.NewLine}{Environment.NewLine}");
+                    writer.Flush();
+                }
+                catch (HttpListenerException)
+                {
+                    // The client disconnected
+                    lostClients.Add(writer);
+                }
+                catch (IOException)
+                {
+                    // The client disconnected while the event was being written.
+                    lostClients.Add(writer);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The response stream was disposed while the event was being written.
+                    lostClients.Add(writer);
+                }
             }
-        }
-        foreach (var lostClient in lostClients)
-        {
-            _writers.Remove(lostClient);
-            lostClient.Dispose();
+
+            foreach (var lostClient in lostClients)
+            {
+                _writers.Remove(lostClient);
+                DisposeWriter(lostClient);
+            }
         }
     }
 
-    public void CloseSseEndpoint()
-    {
-        Task.WaitAll(_writers.Select(writer => writer.BaseStream.FlushAsync()).ToArray());
+    public void CloseSseEndpoint() => Dispose();
 
-        _listener.Close();
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        var ownsDisposal = false;
+        lock (_writersLock)
+        {
+            if (!_disposedValue)
+            {
+                _disposedValue = true;
+                ownsDisposal = true;
+            }
+        }
+
+        if (!ownsDisposal)
+        {
+            _disposeCompletion.Task.GetAwaiter().GetResult();
+            return;
+        }
+
+        try
+        {
+            _listener.Close();
+            List<StreamWriter> writers;
+            lock (_writersLock)
+            {
+                writers = [.. _writers];
+                _writers.Clear();
+            }
+
+            foreach (var writer in writers)
+            {
+                DisposeWriter(writer);
+            }
+        }
+        finally
+        {
+            _disposeCompletion.TrySetResult(true);
+        }
+    }
+
+    private static void DisposeWriter(StreamWriter writer)
+    {
+        try
+        {
+            writer.Dispose();
+        }
+        catch (HttpListenerException)
+        {
+            // The client disconnected before the writer was disposed.
+        }
+        catch (IOException)
+        {
+            // Flushing the writer failed because the client disconnected.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Closing the listener already disposed the response stream.
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Stryker.Core/Stryker.Core/Reporters/WebBrowserOpener/CrossPlatformBrowserOpener.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/WebBrowserOpener/CrossPlatformBrowserOpener.cs
@@ -27,7 +27,7 @@ public class CrossPlatformBrowserOpener : IWebbrowserOpener
 
             };
 
-            var wslPathProcess = new Process { StartInfo = wslPathProcessInfo };
+            using var wslPathProcess = new Process { StartInfo = wslPathProcessInfo };
             if (wslPathProcess.Start())
             {
                 var windowsPath = wslPathProcess.StandardOutput.ReadToEnd();


### PR DESCRIPTION
Two reporter-side resources could outlive the work they were created for. The real-time HTML reporter retained its connected `StreamWriter` instances when the SSE endpoint closed, while the WSL browser path conversion left its short-lived `Process` undisposed.

This makes `SseServer` implement `IDisposable` and gives listener shutdown, writer cleanup, and concurrent connect/send/dispose paths one synchronized lifecycle. Closing the endpoint now stops the listener, disposes and clears every writer even if shutdown races with a connection or a subscriber throws, and remains safe when repeated. The WSL `wslpath` process is now owned by a `using` declaration.

The same real cwin SSE lifecycle harness was run against untouched base `e5c7de22` and this exact HEAD `571f9eee`. It starts the production `HttpListener`, connects a real `HttpClient`, captures the accepted production writer, and then closes the endpoint:

```text
base: connected_after_close=True,  writer_disposed_after_close=False
HEAD: connected_after_close=False, writer_disposed_after_close=True
```

Both revisions stopped accepting new TCP connections and tolerated a repeated close, isolating the changed behavior to connected-writer ownership and disposal.

Validation on the exact HEAD:

- cwin .NET 10 restore and Debug build
- cwin VSTest: all 1,533 runnable tests passed after excluding four `NugetRestoreProcessTests` that also fail on untouched base because of this host's legacy Framework MSBuild discovery path
- cwin Microsoft.Testing.Platform: 191/191 passed
- cwin focused `SseServerTest`: 8/8 passed, including callback-initiated close, concurrent close, a blocked callback, repeated close, and an I/O-failing writer that cannot block later writer disposal
- cwin integration: real Stryker run tested 15 mutants, followed by 1/1 validation test passing
- macOS VSTest: 1,797 passed, 15 platform skips, 0 failed
- lifecycle stress checks: 20/20 dropped-client runs and 10/10 full focused-suite runs passed

Review history: https://gist.github.com/7af61c1848f2be22cf18c41e8c9fb521

AI assistance: Codex helped implement and review the change; I verified the final diff and all results above on the recorded commit.
