### PR TITLE
Migrate to Buildalyzer 9.0.0 (breaking-change fallout) [blocked on release]

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Grynwald.MarkdownGenerator" Version="3.0.106" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="DotNet.Glob" Version="3.1.3" />
-    <PackageVersion Include="Buildalyzer" Version="8.0.0" />
+    <PackageVersion Include="Buildalyzer" Version="9.0.0-pr356" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="Serilog" Version="4.3.1" />

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/BuildAnalyzerTestsBase.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/BuildAnalyzerTestsBase.cs
@@ -308,7 +308,6 @@ public class BuildAnalyzerTestsBase : TestBase, ISolutionProvider
             .Returns(analyzerResults);
         buildalyzerAnalyzerManagerMock.Setup(x => x.SetGlobalProperty(It.IsAny<string>(), It.IsAny<string>()));
         buildalyzerAnalyzerManagerMock.Setup(x => x.RemoveGlobalProperty(It.IsAny<string>()));
-        buildalyzerAnalyzerManagerMock.Setup(x => x.SolutionFilePath).Returns((string)null);
 
         foreach (var analyzerResult in analyzerResults)
         {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -16,6 +16,7 @@ using Stryker.Core.ProjectComponents.SourceProjects;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Solutions;
 using Stryker.Utilities.Buildalyzer;
+using SolutionInfo = Stryker.Core.ProjectComponents.SourceProjects.SolutionInfo;
 
 namespace Stryker.Core.Initialisation;
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest.csproj
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Moq" />
         <PackageReference Include="Shouldly" />

--- a/src/Stryker.Utilities/Stryker.Utilities.csproj
+++ b/src/Stryker.Utilities/Stryker.Utilities.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Buildalyzer" />
+    <PackageReference Include="NuGet.Frameworks" />
     <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="ResXResourceReader.NetStandard" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />


### PR DESCRIPTION
## What

Adopts the upcoming **Buildalyzer 9.0.0**, a breaking release that drops the in-process MSBuild engine and shrinks its dependency/API surface. This PR is the Stryker-side migration.

> [!WARNING]
> **Draft — blocked on Buildalyzer 9.0.0 being published to nuget.org.** The version is pinned to a local pre-release (`9.0.0-pr356`) as a placeholder; CI restore will fail until the real package ships. `packages.lock.json` files are intentionally *not* updated here — they should be regenerated against the published package.

## Changes

- **`Stryker.Utilities`** — add explicit `NuGet.Frameworks` `PackageReference`. `NuGetFramework` was reaching us transitively via Buildalyzer 8.0.0 (which depended on `NuGet.Frameworks`); 9.0.0 no longer does.
- **`Stryker.TestRunner.MicrosoftTestPlatform.UnitTest`** — add explicit `Microsoft.Extensions.Logging` `PackageReference`. `LoggerFactory` was transitive via Buildalyzer 8.0.0 (full `Microsoft.Extensions.Logging`); 9.0.0 depends only on `Microsoft.Extensions.Logging.Abstractions`.
- **`InputFileResolver`** — alias `SolutionInfo` to Stryker's own type. Buildalyzer 9.0.0 adds a public `Buildalyzer.SolutionInfo` that collides with `Stryker.Core.ProjectComponents.SourceProjects.SolutionInfo` under the existing `using Buildalyzer;`.
- **`BuildAnalyzerTestsBase`** — drop the now-invalid strict-mock setup for `IAnalyzerManager.SolutionFilePath`, which 9.0.0 removed (replaced by `Solution`). Stryker's product code no longer calls it, so the setup was dead.

## Verification

Verified end-to-end against a local build of Buildalyzer 9.0.0:
- Full solution builds (0 errors).
- A sample mutation run completes (out-of-process Buildalyzer analysis → build → test → report).
- `Stryker.Core.UnitTest` Initialisation tests: **147 passed, 0 failed**.

## Note for reviewers

During this migration I also found and reported a bug in the Buildalyzer 9.0.0 branch itself: `Buildalyzer.dll` carried phantom `Microsoft.Build*` assembly references (via `nameof(BuildalyzerLogger)`) that crashed standalone consumers on `new AnalyzerManager()`. That is fixed on the Buildalyzer side; this PR assumes that fix is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)