### PR TITLE
fix(MTP): send the runTests filter under the property the server binds

### DIFF
--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RunTestsRequestTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RunTestsRequestTests.cs
@@ -16,13 +16,17 @@ public class RunTestsRequestTests
         // serialized under any other property name is silently ignored and the
         // server runs the complete assembly, so mutation runs execute tests
         // that have no mutant assignment.
+
+        // Arrange
         var runId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var request = new RunTestsRequest(
             runId,
             [new RunRequestTestNode("case-uid", "Example.SampleTests.Case")]);
 
+        // Act
         var serialized = JsonSerializer.Serialize(request, RpcJsonSerializerOptions.Default);
 
+        // Assert
         using var document = JsonDocument.Parse(serialized);
         var root = document.RootElement;
         root.GetProperty("runId").GetString().ShouldBe(runId.ToString());

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RunTestsRequestTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RunTestsRequestTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using Shouldly;
+using Stryker.TestRunner.MicrosoftTestPlatform.Models;
+using Stryker.TestRunner.MicrosoftTestPlatform.RPC;
+
+namespace Stryker.TestRunner.MicrosoftTestPlatform.UnitTest;
+
+[TestClass]
+public class RunTestsRequestTests
+{
+    [TestMethod]
+    public void RunTestsRequest_ShouldSerializeFilterUnderTheServersPropertyNames()
+    {
+        // Microsoft.Testing.Platform's server binds the run filter from the
+        // "tests" property and each entry's "uid" and "display-name". A filter
+        // serialized under any other property name is silently ignored and the
+        // server runs the complete assembly, so mutation runs execute tests
+        // that have no mutant assignment.
+        var runId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var request = new RunTestsRequest(
+            runId,
+            [new RunRequestTestNode("case-uid", "Example.SampleTests.Case")]);
+
+        var serialized = JsonSerializer.Serialize(request, RpcJsonSerializerOptions.Default);
+
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+        root.GetProperty("runId").GetString().ShouldBe(runId.ToString());
+        var tests = root.GetProperty("tests");
+        tests.GetArrayLength().ShouldBe(1);
+        var test = tests[0];
+        test.GetProperty("uid").GetString().ShouldBe("case-uid");
+        test.GetProperty("display-name").GetString().ShouldBe("Example.SampleTests.Case");
+    }
+}

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/TestingPlatformClientTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/TestingPlatformClientTests.cs
@@ -579,7 +579,7 @@ public class TestingPlatformClientTests
         public bool ExitCalled { get; private set; }
         public Guid LastDiscoveryRunId { get; private set; }
         public Guid LastRunTestsRunId { get; private set; }
-        public TestNode[]? LastRunTestCases { get; private set; }
+        public RunRequestTestNode[]? LastRunTestCases { get; private set; }
 
         [JsonRpcMethod("initialize", UseSingleObjectParameterDeserialization = true)]
         public InitializeResponse Initialize(InitializeRequest request)
@@ -608,7 +608,7 @@ public class TestingPlatformClientTests
         public void RunTests(RunTestsRequest request)
         {
             LastRunTestsRunId = request.RunId;
-            LastRunTestCases = request.TestCases;
+            LastRunTestCases = request.Tests;
         }
     }
 

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
@@ -3,9 +3,22 @@ using System.Text.Json.Serialization;
 
 namespace Stryker.TestRunner.MicrosoftTestPlatform.Models;
 
+/// <summary>
+/// The `testing/runTests` request. Microsoft.Testing.Platform's server binds the
+/// test filter from the `tests` property and each entry's `uid` and
+/// `display-name`; a filter sent under any other property name is silently
+/// ignored and the server runs the complete assembly.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public sealed record RunTestsRequest(
     [property:JsonPropertyName("runId")]
     Guid RunId,
-    [property:JsonPropertyName("testCases")]
-    TestNode[]? TestCases = null);
+    [property:JsonPropertyName("tests")]
+    RunRequestTestNode[]? Tests = null);
+
+[ExcludeFromCodeCoverage]
+public sealed record RunRequestTestNode(
+    [property:JsonPropertyName("uid")]
+    string Uid,
+    [property:JsonPropertyName("display-name")]
+    string DisplayName);

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
@@ -11,14 +11,14 @@ namespace Stryker.TestRunner.MicrosoftTestPlatform.Models;
 /// </summary>
 [ExcludeFromCodeCoverage]
 public sealed record RunTestsRequest(
-    [property:JsonPropertyName("runId")]
+    [property: JsonPropertyName("runId")]
     Guid RunId,
-    [property:JsonPropertyName("tests")]
+    [property: JsonPropertyName("tests")]
     RunRequestTestNode[]? Tests = null);
 
 [ExcludeFromCodeCoverage]
 public sealed record RunRequestTestNode(
-    [property:JsonPropertyName("uid")]
+    [property: JsonPropertyName("uid")]
     string Uid,
-    [property:JsonPropertyName("display-name")]
+    [property: JsonPropertyName("display-name")]
     string DisplayName);

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/TestingPlatformClient.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/TestingPlatformClient.cs
@@ -143,7 +143,10 @@ public sealed class TestingPlatformClient : ITestingPlatformClient
             using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromMinutes(3));
             var runListener = new TestNodeUpdatesResponseListener(requestId, action);
             _targetHandler.RegisterResponseListener(runListener);
-            await JsonRpcClient.InvokeWithParameterObjectAsync("testing/runTests", new RunTestsRequest(RunId: requestId, TestCases: testNodes), cancellationToken: cancellationTokenSource.Token);
+            var requestNodes = testNodes
+                ?.Select(node => new RunRequestTestNode(node.Uid, node.DisplayName))
+                .ToArray();
+            await JsonRpcClient.InvokeWithParameterObjectAsync("testing/runTests", new RunTestsRequest(RunId: requestId, Tests: requestNodes), cancellationToken: cancellationTokenSource.Token);
             return runListener;
         });
 


### PR DESCRIPTION
## Problem

The `testing/runTests` request serializes its test filter as `testCases`, but Microsoft.Testing.Platform's server binds the run filter from the `tests` property (and `uid` / `display-name` on each entry). The server treats the unbound property as the absence of a filter and runs the **complete assembly** for every run request.

For mutation runs this is severe:

- every session pays the full-suite execution cost, regardless of coverage analysis — filtered runs are silently unfiltered;
- tests that are not part of the batch execute against whichever mutant is currently active, which corrupts verdicts in both directions for any activation scheme that assumes only the requested tests run.

## Reproduction / verification

Verified against a live Microsoft.Testing.Platform server (shipped with Microsoft.NET.Test.Sdk 18.7, xunit.v3 test assembly, .NET 10):

- **Before**: a run request filtered to a single test executed all ~1,700 tests in the assembly (observed via the update stream: full suite reported in-progress/passed).
- **After**: the same request runs exactly the requested test.
- Binding `displayName` instead of `display-name` is rejected by the shipped server's binder (`KeyNotFoundException: Key 'display-name' was not found`), so the entry shape matches the shipped server rather than the camelCase used elsewhere in the protocol.

## Change

- `RunTestsRequest` serializes the filter as `tests`, with a dedicated `RunRequestTestNode(uid, display-name)` entry shape (the response-side `TestNode` keeps its existing shape).
- `TestingPlatformClient.RunTestsAsync` maps the requested nodes into that shape.
- New serialization regression test pinning the wire property names; the existing fake-server round-trip test now exercises the corrected `tests` binding end-to-end.

All 201 tests in `Stryker.TestRunner.MicrosoftTestPlatform.UnitTest` pass.