### PR TITLE
fix(mtp): send run request test selection as `tests` not `testCases`

### DIFF
--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RpcWireFormatTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RpcWireFormatTests.cs
@@ -21,8 +21,13 @@ public class RpcWireFormatTests
     private static readonly TestNode TestNodeWithoutLocation =
         new("some-uid", "SomeTest", "action", "discovered");
 
-    private static JsonElement Serialize<T>(T value) =>
-        JsonDocument.Parse(JsonSerializer.Serialize(value, RpcJsonSerializerOptions.Default)).RootElement;
+    // The JsonDocument owns the pooled memory backing its elements, so it is disposed here and the
+    // element is cloned: a cloned JsonElement is detached from the document and stays valid after it.
+    private static JsonElement Serialize<T>(T value)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(value, RpcJsonSerializerOptions.Default));
+        return document.RootElement.Clone();
+    }
 
     [TestMethod]
     public void RunTestsRequest_SerializesSelectionAsTests()

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RpcWireFormatTests.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest/RpcWireFormatTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Shouldly;
+using Stryker.TestRunner.MicrosoftTestPlatform.Models;
+using Stryker.TestRunner.MicrosoftTestPlatform.RPC;
+
+namespace Stryker.TestRunner.MicrosoftTestPlatform.UnitTest;
+
+/// <summary>
+/// Asserts the on-the-wire shape of the payloads Stryker sends to a Microsoft Testing Platform
+/// server, against the names the platform actually reads them under.
+/// </summary>
+/// <remarks>
+/// These assertions deliberately inspect the raw JSON instead of round-tripping through Stryker's
+/// own records. A round-trip test uses the same record on both ends, so it passes for any property
+/// name and cannot detect a mismatch with the platform - which is how the run request came to send
+/// its test selection as <c>testCases</c> while the platform reads <c>tests</c>.
+/// </remarks>
+[TestClass]
+public class RpcWireFormatTests
+{
+    private static readonly TestNode TestNodeWithoutLocation =
+        new("some-uid", "SomeTest", "action", "discovered");
+
+    private static JsonElement Serialize<T>(T value) =>
+        JsonDocument.Parse(JsonSerializer.Serialize(value, RpcJsonSerializerOptions.Default)).RootElement;
+
+    [TestMethod]
+    public void RunTestsRequest_SerializesSelectionAsTests()
+    {
+        var request = new RunTestsRequest(Guid.NewGuid(), [TestNodeWithoutLocation]);
+
+        var json = Serialize(request);
+
+        json.TryGetProperty("tests", out var tests).ShouldBeTrue(
+            "Microsoft.Testing.Platform reads the run request test selection from 'tests' (JsonRpcStrings.Tests).");
+        tests.GetArrayLength().ShouldBe(1);
+    }
+
+    [TestMethod]
+    public void RunTestsRequest_DoesNotSerializeSelectionAsTestCases()
+    {
+        var request = new RunTestsRequest(Guid.NewGuid(), [TestNodeWithoutLocation]);
+
+        var json = Serialize(request);
+
+        json.TryGetProperty("testCases", out _).ShouldBeFalse(
+            "'testCases' is not read by the platform, so a selection sent under that name is silently dropped and every test runs.");
+    }
+
+    [TestMethod]
+    public void RunTestsRequest_SerializesRunId()
+    {
+        var runId = Guid.NewGuid();
+
+        var json = Serialize(new RunTestsRequest(runId, [TestNodeWithoutLocation]));
+
+        json.GetProperty("runId").GetGuid().ShouldBe(runId);
+    }
+
+    [TestMethod]
+    public void RunTestsRequest_OmitsSelection_WhenRunningEveryTest()
+    {
+        var json = Serialize(new RunTestsRequest(Guid.NewGuid()));
+
+        json.TryGetProperty("tests", out _).ShouldBeFalse(
+            "An absent selection must be omitted so the platform runs every test.");
+    }
+
+    [TestMethod]
+    [DataRow("location.file")]
+    [DataRow("location.line-start")]
+    [DataRow("location.line-end")]
+    [DataRow("location.type")]
+    [DataRow("location.method")]
+    public void TestNode_OmitsLocationProperty_WhenAbsent(string propertyName)
+    {
+        var json = Serialize(TestNodeWithoutLocation);
+
+        json.TryGetProperty(propertyName, out _).ShouldBeFalse(
+            $"The platform probes '{propertyName}' with TryGetValue and then asserts it is not null, so an explicit null fails the request.");
+    }
+
+    [TestMethod]
+    public void TestNode_SerializesRequiredProperties()
+    {
+        var json = Serialize(TestNodeWithoutLocation);
+
+        json.GetProperty("uid").GetString().ShouldBe("some-uid");
+        json.GetProperty("display-name").GetString().ShouldBe("SomeTest");
+        json.GetProperty("node-type").GetString().ShouldBe("action");
+        json.GetProperty("execution-state").GetString().ShouldBe("discovered");
+    }
+
+    [TestMethod]
+    public void TestNode_SerializesLocationProperties_WhenPresent()
+    {
+        var node = new TestNode("some-uid", "SomeTest", "action", "discovered",
+            LocationFile: "/src/SomeTests.cs",
+            LocationLineStart: 10,
+            LocationLineEnd: 20,
+            LocationType: "SomeTests",
+            LocationMethod: "SomeTest");
+
+        var json = Serialize(node);
+
+        json.GetProperty("location.file").GetString().ShouldBe("/src/SomeTests.cs");
+        json.GetProperty("location.line-start").GetInt32().ShouldBe(10);
+        json.GetProperty("location.line-end").GetInt32().ShouldBe(20);
+        json.GetProperty("location.type").GetString().ShouldBe("SomeTests");
+        json.GetProperty("location.method").GetString().ShouldBe("SomeTest");
+    }
+
+    [TestMethod]
+    public void TestNode_DiscoveredWithoutLocation_RoundTripsWithoutNullLocation()
+    {
+        // A node the server reported without location info must survive being echoed back as part of
+        // a run request selection, which is the direction that makes the null-vs-absent distinction matter.
+        const string DiscoveredNode = """
+            {"uid":"some-uid","display-name":"SomeTest","node-type":"action","execution-state":"discovered"}
+            """;
+
+        var node = JsonSerializer.Deserialize<TestNode>(DiscoveredNode, RpcJsonSerializerOptions.Default);
+
+        node.ShouldNotBeNull();
+        node.LocationFile.ShouldBeNull();
+
+        var json = Serialize(new RunTestsRequest(Guid.NewGuid(), [node]));
+
+        var serializedNode = json.GetProperty("tests")[0];
+        serializedNode.TryGetProperty("location.file", out _).ShouldBeFalse();
+        serializedNode.GetProperty("uid").GetString().ShouldBe("some-uid");
+    }
+
+    [TestMethod]
+    public void DiscoveryRequest_SerializesRunId()
+    {
+        var runId = Guid.NewGuid();
+
+        var json = Serialize(new DiscoveryRequest(runId));
+
+        json.GetProperty("runId").GetGuid().ShouldBe(runId);
+    }
+}

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/RunTestsRequest.cs
@@ -3,9 +3,19 @@ using System.Text.Json.Serialization;
 
 namespace Stryker.TestRunner.MicrosoftTestPlatform.Models;
 
+/// <summary>
+/// Parameters of a <c>testing/runTests</c> request.
+/// </summary>
+/// <remarks>
+/// The test selection is serialized as <c>tests</c> because that is the name the Microsoft Testing
+/// Platform reads it under (<c>JsonRpcStrings.Tests</c>). The property is optional server-side, so a
+/// misnamed selection is dropped silently and the server runs every test instead of the selection.
+/// An absent selection is omitted rather than written as an explicit null, so that "run every test"
+/// is expressed the way the protocol describes it.
+/// </remarks>
 [ExcludeFromCodeCoverage]
 public sealed record RunTestsRequest(
     [property:JsonPropertyName("runId")]
     Guid RunId,
-    [property:JsonPropertyName("testCases")]
+    [property:JsonPropertyName("tests"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     TestNode[]? TestCases = null);

--- a/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/TestNode.cs
+++ b/src/Stryker.TestRunner.MicrosoftTestPlatform/Models/TestNode.cs
@@ -3,6 +3,17 @@ using System.Text.Json.Serialization;
 
 namespace Stryker.TestRunner.MicrosoftTestPlatform.Models;
 
+/// <summary>
+/// A Microsoft Testing Platform test node.
+/// </summary>
+/// <remarks>
+/// Nodes are received during discovery and sent back as the selection of a <c>testing/runTests</c>
+/// request, so this type is serialized in both directions. The optional location properties are
+/// omitted when absent rather than written as explicit nulls: the platform probes them with
+/// <c>TryGetValue</c> and then asserts the value is not null, so an explicit null reads as a present
+/// but invalid property and fails the request for every test the framework reported without a
+/// location.
+/// </remarks>
 [ExcludeFromCodeCoverage]
 public sealed record TestNode
 (
@@ -18,17 +29,17 @@ public sealed record TestNode
     [property: JsonPropertyName("execution-state")]
     string ExecutionState,
 
-    [property: JsonPropertyName("location.file")]
+    [property: JsonPropertyName("location.file"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? LocationFile = null,
 
-    [property: JsonPropertyName("location.line-start")]
+    [property: JsonPropertyName("location.line-start"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     int? LocationLineStart = null,
 
-    [property: JsonPropertyName("location.line-end")]
+    [property: JsonPropertyName("location.line-end"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     int? LocationLineEnd = null,
 
-    [property: JsonPropertyName("location.type")]
+    [property: JsonPropertyName("location.type"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? LocationType = null,
 
-    [property: JsonPropertyName("location.method")]
+    [property: JsonPropertyName("location.method"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? LocationMethod = null);


### PR DESCRIPTION
Fixes #3754

## Problem

The MTP runner serialized the `testing/runTests` test selection under the JSON name `testCases`, but Microsoft.Testing.Platform reads it as `tests`:

* Protocol spec: `interface RunTestsParams { tests?: TestNode[], runId: GUID }`
* Wire constant: `JsonRpcMethods.cs` -> `public const string Tests = "tests";`
* Deserializer: `GetOptionalPropertyFromJson(properties, JsonRpcStrings.Tests)`

`tests` is **optional** server-side, so an unrecognised `testCases` is dropped without any error or warning and the server falls through to running the **entire test suite**.

The likely origin is the testfx `samples/Playground/ServerMode` sample this client was ported from, where the *C# member* is `TestCases` but the *wire name* is `tests`:

```csharp
public sealed record RunRequest(
    [property:JsonProperty("tests")]
    TestNode[]? TestCases,
```

Present since the MTP runner was introduced in #3404.

## Second, related defect

`TestNode`'s optional `location.*` members were written as explicit nulls. The platform probes them with `TryGetValue` - which succeeds on an explicit null - and then asserts non-null:

```csharp
if (properties.TryGetValue("location.file", out object? location_file))
{
    ApplicationStateGuard.Ensure(location_file is not null);   // throws InvalidOperationException
```

This was latent while `TestNode`s only flowed server -> client, and would have become live the moment the rename made selection actually work: every test the framework reported without location info would fail the run request. Both parts have to land together, so they are in one commit.

The same applies to the selection itself, which is now omitted rather than sent as `"tests": null` when running every test.

## Changes

* `RunTestsRequest.TestCases` serializes as `tests`, omitted when null.
* `TestNode` location properties omitted when null.
* New `RpcWireFormatTests` asserting the raw JSON payload.

## Why the existing tests did not catch this

Two independent reasons, both worth noting because they explain the blind spot:

1. `SingleMicrosoftTestPlatformRunner.RunAssemblyTestsAsync` currently always passes `testUidFilter: null`, so no selection is ever sent in practice and the wrong name was never exercised against a real server.
2. `TestingPlatformClientTests.FakeTestServer` deserializes using Stryker's **own** `RunTestsRequest` record, so the name matches on both ends and the test passes for any name.

The new tests therefore assert the **raw JSON** rather than round-tripping through Stryker's records, so they are anchored to the platform's contract instead of to our own types.

## Verification

* Full `Stryker.TestRunner.MicrosoftTestPlatform.UnitTest` suite: **213/213 pass** (3 consecutive runs).
* Reverting only the source fix while keeping the new tests: **8 tests fail**, covering both defects. Confirms they are real regression guards rather than tests written to match current behaviour.
* Full `Stryker.slnx` builds with 0 errors.

## Scope

Deliberately narrow. Actually *using* a selection (passing a real `testUidFilter`) only pays off once MTP coverage is per-test rather than cumulative, so that belongs in a follow-up. This change is a prerequisite for it and is correct on its own: it makes the payload match the protocol.

Note: I could not apply the :bug: Bug label to the linked issue (requires admin rights) - a maintainer may want to add it.