### PR TITLE
ci: run Microsoft Testing Platform unit tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,9 @@ stages:
     # Run from the project directory: its global.json opts dotnet test into Microsoft.Testing.Platform,
     # and dotnet test resolves global.json from the working directory, not the project directory.
     # This project cannot run via Stryker.vstest.slnf because VSTest is unsupported for MTP on .NET 10 SDK+.
-    - pwsh: '$(Agent.BuildDirectory)/tools/dotnet-coverage collect "dotnet test" -f xml -o "$(Agent.BuildDirectory)\TestResults\coverage.mtp.xml"'
+    # The project is pinned with --project so the step cannot pick up another project added here later;
+    # MTP's dotnet test rejects a positional project path, so the flag form is required.
+    - pwsh: '$(Agent.BuildDirectory)/tools/dotnet-coverage collect "dotnet test --project Stryker.TestRunner.MicrosoftTestPlatform.UnitTest.csproj" -f xml -o "$(Agent.BuildDirectory)\TestResults\coverage.mtp.xml"'
       displayName: 'Run Microsoft Testing Platform unit tests'
       workingDirectory: 'src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest'
     - task: SonarCloudAnalyze@4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
         projectVersion: '$(PackageVersion)'
         extraProperties: |
           sonar.verbose=true
-          sonar.cs.vscoveragexml.reportsPaths=$(Agent.BuildDirectory)\TestResults\coverage.xml
+          sonar.cs.vscoveragexml.reportsPaths=$(Agent.BuildDirectory)\TestResults\coverage.xml,$(Agent.BuildDirectory)\TestResults\coverage.mtp.xml
     - task: DotNetCoreCLI@2
       displayName: 'Build Stryker'
       inputs:
@@ -75,6 +75,12 @@ stages:
     - pwsh: '$(Agent.BuildDirectory)/tools/dotnet-coverage collect "dotnet test Stryker.vstest.slnf" -f xml -o "$(Agent.BuildDirectory)\TestResults\coverage.xml"'
       displayName: 'Run unit tests'
       workingDirectory: 'src'
+    # Run from the project directory: its global.json opts dotnet test into Microsoft.Testing.Platform,
+    # and dotnet test resolves global.json from the working directory, not the project directory.
+    # This project cannot run via Stryker.vstest.slnf because VSTest is unsupported for MTP on .NET 10 SDK+.
+    - pwsh: '$(Agent.BuildDirectory)/tools/dotnet-coverage collect "dotnet test" -f xml -o "$(Agent.BuildDirectory)\TestResults\coverage.mtp.xml"'
+      displayName: 'Run Microsoft Testing Platform unit tests'
+      workingDirectory: 'src/Stryker.TestRunner.MicrosoftTestPlatform.UnitTest'
     - task: SonarCloudAnalyze@4
     - task: SonarCloudPublish@4
       inputs:


### PR DESCRIPTION
## Summary

- run the Microsoft Testing Platform unit test project in a dedicated CI step
- include its coverage report in the SonarCloud coverage inputs

## Why

`Stryker.TestRunner.MicrosoftTestPlatform.UnitTest` is built through `Stryker.slnx`, but it is intentionally absent from `Stryker.vstest.slnf`. As a result, its 200 tests were not running in CI and 1,340 covered blocks in `Stryker.TestRunner.MicrosoftTestPlatform.dll` were invisible to SonarCloud.

The project cannot simply be added to `Stryker.vstest.slnf`: it uses `MSTest.Sdk` with Microsoft.Testing.Platform, and the VSTest target is unsupported on .NET 10 SDK and later.

The new step runs from the test project's directory so `dotnet test` discovers its nested `global.json` and selects Microsoft.Testing.Platform. Running the same project from `src` does not discover that file and incorrectly falls back to VSTest.

## Verification

- confirmed the project fails from `src` with the VSTest-target error
- confirmed all 200 tests pass when `dotnet test` runs from the project directory
- collected coverage successfully and confirmed 1,340 covered blocks for `Stryker.TestRunner.MicrosoftTestPlatform.dll`
- parsed `azure-pipelines.yml` successfully as YAML
