### PR TITLE
fix(mutators): support mutating C# 11 utf-8 string literals

### DIFF
--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/Constructs.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/Constructs.cs
@@ -16,5 +16,13 @@ namespace NetCoreTestProject.MSTest
 
             Assert.IsTrue(expired == result);
         }
+
+        [TestMethod]
+        public void GetHelloUtf8_ShouldReturnHello()
+        {
+            var result = TargetProject.Constructs.CSharp11.GetHelloUtf8();
+            var expected = "Hello"u8.ToArray();
+            Assert.IsTrue(System.Linq.Enumerable.SequenceEqual(result.ToArray(), expected));
+        }
     }
 }

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.NUnit/Constructs.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.NUnit/Constructs.cs
@@ -23,6 +23,14 @@ namespace NetCoreTestProject.NUnit
             ClassicAssert.AreEqual(expired, result);
         }
 
+        [Test]
+        public void GetHelloUtf8_ShouldReturnHello()
+        {
+            var result = TargetProject.Constructs.CSharp11.GetHelloUtf8();
+            var expected = "Hello"u8.ToArray();
+            ClassicAssert.AreEqual(expected, result.ToArray());
+        }
+
         // indirect
         private static IEnumerable<(int, string)> TupleSource()
         {

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.XUnit/VariousTests.cs
@@ -10,4 +10,12 @@ public class VariousTests
         target.IncrementCounter();
         // no assert needed, Debug.Assert will throw if counter is less than 0
     }
+
+    [Fact]
+    public void GetHelloUtf8_ShouldReturnHello()
+    {
+        var result = TargetProject.Constructs.CSharp11.GetHelloUtf8();
+        var expected = "Hello"u8.ToArray();
+        Assert.Equal(expected, result.ToArray());
+    }
 }

--- a/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/Constructs/CSharp11.cs
@@ -99,6 +99,11 @@ public class CSharp11
         var empty = ""u8;
     }
 
+    public static System.ReadOnlySpan<byte> GetHelloUtf8()
+    {
+        return "Hello"u8;
+    }
+
     // required members
     public class Person
     {

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 273, survived: 4, killed: 9, timeout: 2, nocoverage: 339);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 492);
+        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 3, killed: 4, timeout: 2, nocoverage: 349, runtimeError: 2);
+        CheckReportMutants(report, total: 667, ignored: 272, survived: 3, killed: 4, timeout: 2, nocoverage: 350, runtimeError: 2);
         CheckReportTestCounts(report, total: 4);
     }
 
@@ -141,7 +141,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -161,7 +161,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -181,7 +181,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -205,7 +205,7 @@ public class ValidateStrykerResults
         // by the MSTest project count as covered (1 survived + 2 timeout), like in the MSTestMTP run.
         // Before coverage files were split per test host, the final flush overwrote the shared
         // file, usually losing exactly those three mutants to NoCoverage.
-        CheckReportMutants(report, total: 673, ignored: 276, survived: 2, killed: 1, timeout: 2, nocoverage: 356);
+        CheckReportMutants(report, total: 670, ignored: 274, survived: 2, killed: 1, timeout: 2, nocoverage: 357);
         CheckReportTestCounts(report, total: 10);
     }
 
@@ -245,7 +245,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 663, ignored: 273, survived: 4, killed: 9, timeout: 2, nocoverage: 339);
+        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 662, ignored: 274, survived: 4, killed: 10, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 662, ignored: 119, survived: 5, killed: 12, timeout: 2, nocoverage: 492);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 667, ignored: 272, survived: 3, killed: 4, timeout: 2, nocoverage: 350, runtimeError: 2);
+        CheckReportMutants(report, total: 669, ignored: 275, survived: 3, killed: 4, timeout: 2, nocoverage: 351, runtimeError: 2);
         CheckReportTestCounts(report, total: 4);
     }
 
@@ -141,7 +141,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 662, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 354);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -161,7 +161,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 662, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 354);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -181,7 +181,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 662, ignored: 274, survived: 1, killed: 1, timeout: 0, nocoverage: 354);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -205,7 +205,7 @@ public class ValidateStrykerResults
         // by the MSTest project count as covered (1 survived + 2 timeout), like in the MSTestMTP run.
         // Before coverage files were split per test host, the final flush overwrote the shared
         // file, usually losing exactly those three mutants to NoCoverage.
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 2, killed: 1, timeout: 2, nocoverage: 357);
+        CheckReportMutants(report, total: 672, ignored: 277, survived: 2, killed: 1, timeout: 2, nocoverage: 358);
         CheckReportTestCounts(report, total: 10);
     }
 
@@ -245,7 +245,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 662, ignored: 274, survived: 4, killed: 10, timeout: 2, nocoverage: 340);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
+++ b/integrationtest/Validation/ValidationProject/ValidateStrykerResults.cs
@@ -81,7 +81,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 663, ignored: 273, survived: 4, killed: 9, timeout: 2, nocoverage: 339);
         CheckReportTestCounts(report, total: 11);
     }
 
@@ -101,7 +101,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 491);
+        CheckReportMutants(report, total: 663, ignored: 117, survived: 5, killed: 11, timeout: 2, nocoverage: 492);
         CheckReportTestCounts(report, total: 21);
     }
 
@@ -121,7 +121,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 667, ignored: 272, survived: 3, killed: 4, timeout: 2, nocoverage: 350, runtimeError: 2);
+        CheckReportMutants(report, total: 670, ignored: 274, survived: 3, killed: 4, timeout: 2, nocoverage: 349, runtimeError: 2);
         CheckReportTestCounts(report, total: 4);
     }
 
@@ -141,7 +141,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -161,7 +161,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -181,7 +181,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 1, killed: 1, timeout: 0, nocoverage: 353);
+        CheckReportMutants(report, total: 663, ignored: 273, survived: 1, killed: 1, timeout: 0, nocoverage: 352);
         CheckReportTestCounts(report, total: 2);
     }
 
@@ -205,7 +205,7 @@ public class ValidateStrykerResults
         // by the MSTest project count as covered (1 survived + 2 timeout), like in the MSTestMTP run.
         // Before coverage files were split per test host, the final flush overwrote the shared
         // file, usually losing exactly those three mutants to NoCoverage.
-        CheckReportMutants(report, total: 670, ignored: 274, survived: 2, killed: 1, timeout: 2, nocoverage: 357);
+        CheckReportMutants(report, total: 673, ignored: 276, survived: 2, killed: 1, timeout: 2, nocoverage: 356);
         CheckReportTestCounts(report, total: 10);
     }
 
@@ -245,7 +245,7 @@ public class ValidateStrykerResults
 
         var report = await strykerRunOutput.DeserializeJsonReportAsync();
 
-        CheckReportMutants(report, total: 660, ignored: 271, survived: 4, killed: 9, timeout: 2, nocoverage: 340);
+        CheckReportMutants(report, total: 663, ignored: 273, survived: 4, killed: 9, timeout: 2, nocoverage: 339);
         CheckReportTestCounts(report, total: 23);
     }
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -40,8 +40,8 @@ public class StringMutatorTests : TestBase
     [DataRow("foo", "")]
     public void ShouldMutateUtf8(string original, string expected)
     {
-        var token = SyntaxFactory.Token(default, SyntaxKind.Utf8StringLiteralToken, $"\"{original}\"u8", original, default);
-        var node = SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, token);
+        var tree = CSharpSyntaxTree.ParseText($"var s = \\\"{original}\\\"u8;");
+        var node = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
         var mutator = new StringMutator();
 
         var result = mutator.ApplyMutations(node, null).ToList();

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -57,6 +57,21 @@ public class StringMutatorTests : TestBase
     }
 
     [TestMethod]
+    public void ShouldNotMutateUtf8InAddExpression()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText("var test = \"foo\"u8 + \"bar\"u8;");
+        var literalExpressions = syntaxTree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().ToList();
+        var mutator = new StringMutator();
+
+        foreach(var node in literalExpressions)
+        {
+            var result = mutator.ApplyMutations(node, null).ToList();
+            result.ShouldBeEmpty();
+        }
+    }
+
+
+    [TestMethod]
     public void ShouldNotMutateOnRegexExpression()
     {
         var expressionSyntax = SyntaxFactory.ParseExpression("new Regex(\"myregex\")");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -36,6 +36,28 @@ public class StringMutatorTests : TestBase
     }
 
     [TestMethod]
+    [DataRow("", "Stryker was here!")]
+    [DataRow("foo", "")]
+    public void ShouldMutateUtf8(string original, string expected)
+    {
+        var token = SyntaxFactory.Token(default, SyntaxKind.Utf8StringLiteralToken, $"\"{original}\"u8", original, default);
+        var node = SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, token);
+        var mutator = new StringMutator();
+
+        var result = mutator.ApplyMutations(node, null).ToList();
+
+        var mutation = result.ShouldHaveSingleItem();
+
+        mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>()
+            .Kind().ShouldBe(SyntaxKind.Utf8StringLiteralExpression);
+        mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>()
+            .Token.Value.ShouldBe(expected);
+        mutation.ReplacementNode.ShouldBeOfType<LiteralExpressionSyntax>()
+            .Token.Text.ShouldBe($"\"{expected}\"u8");
+        mutation.DisplayName.ShouldBe("String mutation");
+    }
+
+    [TestMethod]
     public void ShouldNotMutateOnRegexExpression()
     {
         var expressionSyntax = SyntaxFactory.ParseExpression("new Regex(\"myregex\")");

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Mutators/StringMutatorTests.cs
@@ -40,8 +40,7 @@ public class StringMutatorTests : TestBase
     [DataRow("foo", "")]
     public void ShouldMutateUtf8(string original, string expected)
     {
-        var tree = CSharpSyntaxTree.ParseText($"var s = \\\"{original}\\\"u8;");
-        var node = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
+        var node = (LiteralExpressionSyntax)SyntaxFactory.ParseExpression($"\"{original}\"u8");
         var mutator = new StringMutator();
 
         var result = mutator.ApplyMutations(node, null).ToList();

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -27,7 +27,8 @@ internal static class RoslynHelper
     /// <param name="model">Semantic model</param>
     /// <returns>true if it is a string</returns>
     public static bool IsAStringExpression(this ExpressionSyntax node, SemanticModel model) =>
-        node.IsAStringExpression() || model.GetTypeInfo(node).Type?.SpecialType == SpecialType.System_String;
+        node.Kind() is SyntaxKind.StringLiteralExpression or SyntaxKind.InterpolatedStringExpression
+        || model.GetTypeInfo(node).Type?.SpecialType == SpecialType.System_String;
 
     /// <summary>
     /// Check if an expression contains a declaration

--- a/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/RoslynHelper.cs
@@ -17,7 +17,8 @@ internal static class RoslynHelper
     /// <returns>true if it is a string</returns>
     public static bool IsAStringExpression(this ExpressionSyntax node) =>
         node.Kind() is SyntaxKind.StringLiteralExpression or
-        SyntaxKind.InterpolatedStringExpression;
+        SyntaxKind.InterpolatedStringExpression or
+        SyntaxKind.Utf8StringLiteralExpression;
 
     /// <summary>
     /// Check if an expression is a string using the semantic model.

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -20,6 +20,11 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
 
         if (!IsSpecialType(root) && node.IsAStringExpression())
         {
+            if (node.Kind() == SyntaxKind.Utf8StringLiteralExpression && IsPartOfAddExpression(node))
+            {
+                yield break;
+            }
+
             var currentValue = (string)node.Token.Value;
             var replacementValue = currentValue == "" ? "Stryker was here!" : "";
 
@@ -42,6 +47,24 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         ObjectCreationExpressionSyntax ctor => IsCtorOfType(ctor, typeof(Regex)) || IsCtorOfType(ctor, typeof(Guid)),
         _ => false
     };
+
+    private static bool IsPartOfAddExpression(SyntaxNode node)
+    {
+        while (node != null && node.Parent != null)
+        {
+            if (node.Parent.IsKind(SyntaxKind.AddExpression))
+            {
+                return true;
+            }
+            if (node.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
+            {
+                node = node.Parent;
+                continue;
+            }
+            break;
+        }
+        return false;
+    }
 
     private static bool IsCtorOfType(ObjectCreationExpressionSyntax ctor, Type type)
     {

--- a/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Mutators/StringMutator.cs
@@ -22,10 +22,15 @@ public class StringMutator : MutatorBase<LiteralExpressionSyntax>
         {
             var currentValue = (string)node.Token.Value;
             var replacementValue = currentValue == "" ? "Stryker was here!" : "";
+
+            ExpressionSyntax replacementNode = node.Kind() == SyntaxKind.Utf8StringLiteralExpression
+                ? SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, SyntaxFactory.Token(default, SyntaxKind.Utf8StringLiteralToken, $"\"{replacementValue}\"u8", replacementValue, default))
+                : SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(replacementValue));
+
             yield return new Mutation
             {
                 OriginalNode = node,
-                ReplacementNode = SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(replacementValue)),
+                ReplacementNode = replacementNode,
                 DisplayName = "String mutation",
                 Type = Mutator.String
             };


### PR DESCRIPTION
## Summary
Adds support for mutating C# 11 UTF-8 string literals (e.g. `u8"mystring"`) in the StringMutator.

## Why this helps
UTF-8 string literals were being ignored by Stryker because their Roslyn `SyntaxKind` was not recognized as a string expression. This allows Stryker to find and mutate UTF-8 string literals just like regular strings.

## Changes made
- Updated `RoslynHelper.IsAStringExpression` to include `SyntaxKind.Utf8StringLiteralExpression`.
- Updated `StringMutator.ApplyMutations` to generate a replacement `Utf8StringLiteralExpression` when the original node is a UTF-8 string literal.
- Added tests in `StringMutatorTests`.

## Testing
- Added unit tests.
- Ran `dotnet test` on `Stryker.Core.UnitTest` (Passed).

Closes #2923