### PR TITLE
fix(vstest): correctly assign MsTest flag to disable parallelization

### DIFF
--- a/src/Stryker.TestRunner.VsTest/VsTestContextInformation.cs
+++ b/src/Stryker.TestRunner.VsTest/VsTestContextInformation.cs
@@ -255,7 +255,7 @@ public sealed class VsTestContextInformation : IDisposable
 
         if (tests.Any(testCase => testCase.Framework == TestFrameworks.MsTest))
         {
-            _testFramework &= ~TestFrameworks.MsTest;
+            _testFramework |= TestFrameworks.MsTest;
         }
     }
 


### PR DESCRIPTION
Fixes #3757. The `DetectTestFrameworks` method incorrectly cleared the MsTest flag using `&= ~`. This prevented Stryker from injecting `<DisableParallelization>true</DisableParallelization>` for MSTest projects, which caused tests to run in parallel and scramble coverage attribution. Changed the operator to `|=` to correctly set the flag.