### PR TITLE
fix(report): use relative paths in json report to comply with schema

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Stryker.Utilities;
 using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -202,8 +203,9 @@ namespace ExtraProject.XUnit
         report.Thresholds.ShouldContainKeyAndValue("high", 80);
         report.Thresholds.ShouldContainKeyAndValue("low", 60);
 
+        var expectedRelativePath = FilePathUtils.NormalizePathSeparators(Path.GetRelativePath(report.ProjectRoot, _testFilePath));
         var testFile = report.TestFiles.ShouldHaveSingleItem();
-        testFile.Key.ShouldBe(_testFilePath);
+        testFile.Key.ShouldBe(expectedRelativePath);
         testFile.Value.Language.ShouldBe("cs");
         testFile.Value.Source.ShouldBe(_testFileContents);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -153,14 +153,14 @@ namespace ExtraProject.XUnit
     }
 
     [TestMethod]
-    public void JsonReport_ShouldContainFullPath()
+    public void JsonReport_ShouldContainRelativePath()
     {
         var folderComponent = ReportTestHelper.CreateProjectWith(root: RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "c://" : "/");
 
         var report = JsonReport.Build(new StrykerOptions(), folderComponent, It.IsAny<TestProjectsInfo>());
         var path = report.Files.Keys.First();
 
-        Path.IsPathFullyQualified(path).ShouldBeTrue($"{path} should not be a relative path");
+        Path.IsPathFullyQualified(path).ShouldBeFalse($"{path} should be a relative path");
     }
 
     [TestMethod]

--- a/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
+++ b/src/Stryker.Core/Stryker.Core/Reporters/Json/JsonReport.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using Stryker.Utilities;
 using Stryker.Abstractions.Options;
 using Stryker.Abstractions.ProjectComponents;
 using Stryker.Abstractions.Reporting;
@@ -59,13 +61,15 @@ public class JsonReport : IJsonReport
         return files;
     }
 
-    private static Dictionary<string, ISourceFile> GenerateFileReportComponents(IStrykerOptions options, IReadOnlyFileLeaf fileComponent)
+    private Dictionary<string, ISourceFile> GenerateFileReportComponents(IStrykerOptions options, IReadOnlyFileLeaf fileComponent)
     {
+        var relativePath = FilePathUtils.NormalizePathSeparators(Path.GetRelativePath(ProjectRoot, fileComponent.FullPath));
+
         if (fileComponent.IsComponentExcluded(options.Mutate))
         {
-            return new Dictionary<string, ISourceFile> { { fileComponent.FullPath, SourceFile.Ignored } };
+            return new Dictionary<string, ISourceFile> { { relativePath, SourceFile.Ignored } };
         }
-        return new Dictionary<string, ISourceFile> { { fileComponent.FullPath, new SourceFile(fileComponent) } };
+        return new Dictionary<string, ISourceFile> { { relativePath, new SourceFile(fileComponent) } };
      }
 
     private void AddTestFiles(ITestProjectsInfo testProjectsInfo)
@@ -75,13 +79,15 @@ public class JsonReport : IJsonReport
             TestFiles = new Dictionary<string, IJsonTestFile>();
             foreach (var testFile in testProjectsInfo.TestFiles)
             {
-                if (TestFiles.TryGetValue(testFile.FilePath, out var jsonFile))
+                var relativePath = FilePathUtils.NormalizePathSeparators(Path.GetRelativePath(ProjectRoot, testFile.FilePath));
+
+                if (TestFiles.TryGetValue(relativePath, out var jsonFile))
                 {
                     jsonFile.AddTestFile(testFile);
                 }
                 else
                 {
-                    TestFiles.Add(testFile.FilePath, new JsonTestFile(testFile));
+                    TestFiles.Add(relativePath, new JsonTestFile(testFile));
                 }
             }
         }


### PR DESCRIPTION
Fixes #3725. The `JsonReport` was using the absolute `FullPath` of source and test files as the keys in its `files` and `testFiles` dictionaries. This broke the mutation-testing-report schema (which mandates relative paths) and broke the baseline feature across systems. This PR calculates paths relative to the `ProjectRoot` (which corresponds to the run's base path or solution directory), effectively restoring cross-platform baseline matching and schema conformance.