### PR TITLE
fix(core): synchronize reportedMutants in MutationTestProcess.OnMutantTested

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutationTest/MutationTestProcessTests.cs
@@ -410,4 +410,24 @@ public class MutationTestProcessTests : TestBase
         Mock.Get(mutationTestExecutor).VerifyNoOtherCalls();
         result.Result.MutationScore.ShouldBe(double.NaN);
     }
+
+    [TestMethod]
+    public void OnMutantTested_ShouldBeThreadSafe()
+    {
+        var reporterMock = new Mock<IReporter>();
+        var target = new MutationTestProcess(Mock.Of<IMutationTestExecutor>(), Mock.Of<ICoverageAnalyser>(), Mock.Of<IMutationProcess>(), TestLoggerFactory.CreateLogger<MutationTestProcess>());
+        target.Initialize(Input, new StrykerOptions(), reporterMock.Object);
+        
+        var reportedMutants = new System.Collections.Generic.HashSet<IMutant>();
+        var mutant = new Mutant { Id = 1, ResultStatus = MutantStatus.Killed };
+        var method = target.GetType().GetMethod("OnMutantTested", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        
+        System.Threading.Tasks.Parallel.For(0, 1000, new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = 10 }, i =>
+        {
+            method.Invoke(target, new object[] { mutant, reportedMutants });
+        });
+        
+        reportedMutants.Count.ShouldBe(1);
+        reporterMock.Verify(x => x.OnMutantTested(mutant), Times.Once);
+    }
 }

--- a/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/MutationTest/MutationTestProcess.cs
@@ -143,14 +143,21 @@ public class MutationTestProcess : IMutationTestProcess
 
     private void OnMutantTested(IMutant mutant, ISet<IMutant> reportedMutants)
     {
-        if (mutant.ResultStatus == MutantStatus.Pending || reportedMutants.Contains(mutant))
+        if (mutant.ResultStatus == MutantStatus.Pending)
         {
-            // skip duplicates or useless notifications
             return;
         }
 
+        lock (reportedMutants)
+        {
+            if (!reportedMutants.Add(mutant))
+            {
+                // skip duplicates or useless notifications
+                return;
+            }
+        }
+
         _reporter?.OnMutantTested(mutant);
-        reportedMutants.Add(mutant);
     }
 
     private static bool MutantsToTest(IEnumerable<IMutant> mutantsToTest)


### PR DESCRIPTION
Fixes #3727.

Running mutation testing at higher concurrency can cause a data race in `MutationTestProcess.OnMutantTested` when multiple background test completion threads attempt to add to the plain `HashSet<IMutant> reportedMutants` simultaneously, causing collection corruption and aborted test runs.

This PR wraps the `Add` call in a `lock(reportedMutants)` block to guarantee atomic updates and deduplication. It also adds a concurrent stress test to `MutationTestProcessTests` to prevent future regressions.