### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Issues for the HTML report should be issued at [mutation-testing-elements](https
 
 ## Star History
 
-<a href="https://www.star-history.com/#stryker-mutator/stryker-net&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#stryker-mutator/stryker-net&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=stryker-mutator/stryker-net&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=stryker-mutator/stryker-net&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=stryker-mutator/stryker-net&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=stryker-mutator/stryker-net&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=stryker-mutator/stryker-net&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=stryker-mutator/stryker-net&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README currently does not render because the service backing it can no longer access the stargazer data it needs. This change moves the chart to an alternative service that uses a different data source, requires no API token, and keeps the chart working as before.