### PR TITLE
Quick fix for the issue with duplicate test projects on master

### DIFF
--- a/integration-tests.ps1
+++ b/integration-tests.ps1
@@ -51,9 +51,9 @@ function Run-Stryker {
   Push-Location $WorkingDirectory
   try {
     if ($effectiveArguments.Count -gt 0) {
-      & $stryker @effectiveArguments
+      & $stryker @effectiveArguments --diag
     } else {
-      & $stryker
+      & $stryker --diag
     }
   } finally {
     Pop-Location

--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/UnitTests.MSTest.csproj
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/UnitTests.MSTest.csproj
@@ -8,7 +8,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/UnitTests.MSTest.csproj
+++ b/integrationtest/TargetProjects/MicrosoftTestPlatform/UnitTests.MSTest/UnitTests.MSTest.csproj
@@ -4,11 +4,11 @@
     <!-- Enable Microsoft.Testing.Platform, this is an opt-in feature -->
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TargetFrameworks>net10.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/NetCoreTestProject.MSTest.csproj
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/NetCoreTestProject.MSTest.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/packages.lock.json
+++ b/integrationtest/TargetProjects/NetCore/NetCoreTestProject.MSTest/packages.lock.json
@@ -130,7 +130,157 @@
       "targetproject": {
         "type": "Project",
         "dependencies": {
-          "Library": "[4.16.0, )",
+          "Library": "[1.0.0, )",
+          "Microsoft.CodeAnalysis.Common": "[5.9.0, )",
+          "Serilog": "[4.4.0, )"
+        }
+      }
+    },
+    "net9.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
+        }
+      },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[3.11.1, )",
+        "resolved": "3.11.1",
+        "contentHash": "kM19LBh8U9cVXM/Mf9opGPh9Caq5ke9i9UCmLoe0z7bA1C3iZcAk1uiUW4IPiPLm4Xl5QDgaMcrzosLGZh2Jrg==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.VSTestBridge": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1"
+        }
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[3.11.1, )",
+        "resolved": "3.11.1",
+        "contentHash": "RMsYXK2639r/8hmP3W22DYU8+NdYep3uzUd3Tub25XrTr/b/FwGjsnr227PHnorVuitJJb8OmVIpBbUAA38i/Q==",
+        "dependencies": {
+          "MSTest.Analyzers": "3.11.1"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "5.9.0-1.26328.17",
+        "contentHash": "HP9NNk8ZjOSI2hgOyXnQg+kv7/X837Vr2nAlXiGAtqtYnYKjRRa1UmQFr8KFs5ynGYKqfbb8zB9APoWjiAGdMg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.9.0",
+        "contentHash": "IYaIaUWdIx539AReKZOBEqTskFusZfCh/wFSPilDvCn5Say8MegLw2LONcSIcVy+v3Gzv53qYBspgvBGSErfbQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Reflection.Metadata": "10.0.1"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.VSTestBridge": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "k3sgJ6e6WeTS1lAR28SnsRP11IkhT4ymvWvoUM3xd++MNOyusR06bWaiC2iICeOGuiV/iO+Tr9q2XSvznwvQLw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.AdapterUtilities": "17.13.0",
+          "Microsoft.TestPlatform.ObjectModel": "17.13.0",
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.AdapterUtilities": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "bFZ3uAhosdXjyXKURDQy37fPosCJQwedB5DG/SzsXL1QXsrfsIYty2kQMqCRRUqm8sBZBRHWRp4BT9SmpWXcKQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
+        }
+      },
+      "MSTest.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.1",
+        "contentHash": "+oKXORtJ7W3W+/Y3vUbUmWMQbaFQSzqy9YbmRvE3Le8i31gI5Wwe3lrz9dMWuxHSuCEP7CRpnAuAoTI9wGadrA=="
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "ZC6Le3rr4TVJJjS4KsQAesxeF1EhW9qcZmmG7eP5Y2G3+gTGkJEUXkq4+tZNPtyp05I0wWOxnIjwtxFweJsObw=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zpcfT/wacPPhE17zcudozlxQtWN/84qyiMyZNGLnK4cj2IMBtLsZYwYjVnALUhPliwyUVj/P7kaZvBWYBCnf2Q==",
+        "dependencies": {
+          "System.Collections.Immutable": "10.0.1"
+        }
+      },
+      "library": {
+        "type": "Project"
+      },
+      "targetproject": {
+        "type": "Project",
+        "dependencies": {
+          "Library": "[1.0.0, )",
           "Microsoft.CodeAnalysis.Common": "[5.9.0, )",
           "Serilog": "[4.4.0, )"
         }

--- a/integrationtest/TargetProjects/NetCore/TargetProject/TargetProject.csproj
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/TargetProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/integrationtest/TargetProjects/NetCore/TargetProject/packages.lock.json
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/packages.lock.json
@@ -1,14 +1,16 @@
 {
   "version": 1,
   "dependencies": {
-    "net10.0": {
+    "net9.0": {
       "Microsoft.CodeAnalysis.Common": {
         "type": "Direct",
         "requested": "[5.6.0, )",
         "resolved": "5.6.0",
         "contentHash": "eWYNB5e92PSdkQ0xcmy2aLtrvBXNydnVi0Hj/VjaAely6XBqA3By+ClGAJaj4d16pzQmrXPLLK9RDVuS1Ec9xQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "5.3.0"
+          "Microsoft.CodeAnalysis.Analyzers": "5.3.0",
+          "System.Collections.Immutable": "10.0.1",
+          "System.Reflection.Metadata": "10.0.1"
         }
       },
       "Serilog": {
@@ -21,6 +23,19 @@
         "type": "Transitive",
         "resolved": "5.3.0",
         "contentHash": "KuLhbZwB0L8JikL86AE5VWEp3RLNjIcp+j8yz9EJ/UBgRz4+qDEjHg/tluRFbpYpD/e37BqaaNFbQ0vqawBwWQ=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "zpcfT/wacPPhE17zcudozlxQtWN/84qyiMyZNGLnK4cj2IMBtLsZYwYjVnALUhPliwyUVj/P7kaZvBWYBCnf2Q==",
+        "dependencies": {
+          "System.Collections.Immutable": "10.0.1"
+        }
       },
       "library": {
         "type": "Project"

--- a/integrationtest/TargetProjects/NetCore/TargetProject/packages.lock.json
+++ b/integrationtest/TargetProjects/NetCore/TargetProject/packages.lock.json
@@ -8,9 +8,15 @@
         "resolved": "5.9.0",
         "contentHash": "IYaIaUWdIx539AReKZOBEqTskFusZfCh/wFSPilDvCn5Say8MegLw2LONcSIcVy+v3Gzv53qYBspgvBGSErfbQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17"
+          "Microsoft.CodeAnalysis.Analyzers": "5.9.0-1.26328.17",
+          "System.Buffers": "4.6.1",
           "System.Collections.Immutable": "10.0.1",
-          "System.Reflection.Metadata": "10.0.1"
+          "System.Memory": "4.6.3",
+          "System.Numerics.Vectors": "4.6.1",
+          "System.Reflection.Metadata": "10.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.1.2",
+          "System.Text.Encoding.CodePages": "8.0.0",
+          "System.Threading.Tasks.Extensions": "4.6.3"
         }
       },
       "Serilog": {
@@ -24,10 +30,25 @@
         "resolved": "5.9.0-1.26328.17",
         "contentHash": "HP9NNk8ZjOSI2hgOyXnQg+kv7/X837Vr2nAlXiGAtqtYnYKjRRa1UmQFr8KFs5ynGYKqfbb8zB9APoWjiAGdMg=="
       },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "N8GXpmiLMtljq7gwvyS+1QvKT/W2J8sNAvx+HVg4NGmsG/H+2k/y9QI23auLJRterrzCiDH+IWAw4V/GPwsMlw=="
+      },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "10.0.1",
         "contentHash": "kdTe61B8P7i2M1pODC3MLbZ/CfFGjpC6c6jzxjQoB5DHZNewayCRqgFUmx3JKB6vLQtozpMQEiw+R5fO32Jv4g=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.6.3",
+        "contentHash": "qdcDOgnFZY40+Q9876JUHnlHu7bosOHX8XISRoH94fwk6hgaeQGSgfZd8srWRZNt5bV9ZW2TljcegDNxsf+96A=="
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "sQxefTnhagrhoq2ReR0D/6K0zJcr9Hrd6kikeXsA1I8kOCboTavcUC4r7TSfpKFeE163uMuxZcyfO1mGO3EN8Q=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -36,6 +57,21 @@
         "dependencies": {
           "System.Collections.Immutable": "10.0.1"
         }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.1.2",
+        "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "OZIsVplFGaVY90G2SbpgU7EnCoOO5pw1t4ic21dBF3/1omrJFpAGoNAVpPyMVOC90/hvgkGG3VFqR13YgZMQfg=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA=="
       },
       "library": {
         "type": "Project"

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InputFileResolverTests.cs
@@ -1078,6 +1078,39 @@ using System.Reflection;
     }
 
     [TestMethod]
+    public void ShouldHandleTestProjectsWithMultipleTargets()
+    {
+        // Arrange
+        var fileSystem = BuildMockFileSystem();
+
+        var options = new StrykerOptions
+        {
+            ProjectPath = Path.Combine(_sourcePath),
+            TestProjects = new List<string>
+            {
+                _testProjectFilePath,
+            }
+        };
+
+        var sourceProjectManagerMock = SourceProjectAnalyzerMock(_sourceProjectFilePath, []);
+        var testProjectManagerMock = TestProjectAnalyzerMock(_testProjectFilePath, _sourceProjectFilePath, ["netcoreapp2.1", "net8.0"]);
+
+        var analyzerResults = new Dictionary<string, IProjectAnalyzer>
+        {
+            { "MyProject", sourceProjectManagerMock.Object },
+            { "MyProject.UnitTests", testProjectManagerMock.Object },
+        };
+        BuildBuildAnalyzerMock(analyzerResults);
+
+        var target = BuildTestResolver(fileSystem);
+        // Act
+        var result = target.ResolveSourceProjectInfos(options).SourceProjectInfos.First();
+
+        // Assert
+        result.TestProjectsInfo.TestProjects.Count().ShouldBe(1);
+    }
+
+    [TestMethod]
     public void ShouldFindSourceProjectWhenSingleProjectReferenceAndNoFilter()
     {
         var fileSystem = InitializeAllMocks();

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -334,7 +334,7 @@ public class InputFileResolver(
                         // Stryker will recursively scan projects
                         // add any project reference for progressive discovery (when not using solution file)
                         list.Add(projectAnalysisContext.GetProjectReferences()
-                            .Where(projectReference => FileSystem.File.Exists(projectReference)));
+                            .Where(projectReference => FileSystem.File.Exists(projectReference)).ToList());
                     }
                 );
             }
@@ -418,12 +418,12 @@ public class InputFileResolver(
     }
 
     private (List<MutableProjectTree>, List<ProjectSimulatedBuildWrapper>) ExtractMutableProjectTrees(
-        IEnumerable<ProjectSimulatedBuildWrapper> mutableProjectsAnalyzerResults)
+        IEnumerable<ProjectSimulatedBuildWrapper> projectsSimulatedBuild)
     {
         // separate test projects from mutable projects, and keep only analyzer results building an assembly (exclude solution folders and such)
         var testProjects = new List<ProjectSimulatedBuildWrapper>();
         var mutableProjects = new List<ProjectSimulatedBuildWrapper>();
-        foreach (var project in mutableProjectsAnalyzerResults)
+        foreach (var project in projectsSimulatedBuild)
         {
             if (project.IsTestProject())
             {
@@ -432,6 +432,10 @@ public class InputFileResolver(
             else if (project.BuildsAnAssembly())
             {
                 mutableProjects.Add(project);
+            }
+            else
+            {
+                _logger.LogDebug("Disregarding project {discarded} as it does not build an assembly.", project.ProjectFileName);
             }
         }
         var mutableToTestMap = mutableProjects.ToDictionary(p =>p, p => new MutableProjectTree(p, _logger));
@@ -477,7 +481,7 @@ public class InputFileResolver(
                         continue;
                     }
                     // find the entry
-                    mutableToTestMap[candidateProject][candidateTarget].TestProjects.Add(variant);
+                    mutableToTestMap[candidateProject][candidateTarget].AddTestProject(variant);
 
                     foundOneProject = true;
                 }
@@ -512,7 +516,7 @@ public class InputFileResolver(
                 {
                     continue;
                 }
-                mutableToTestMap[candidateProject][candidateVariant].TestProjects.Add(variant);
+                mutableToTestMap[candidateProject][candidateVariant].AddTestProject(variant);
 
                 foundOneProject = true;
             }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -334,7 +334,7 @@ public class InputFileResolver(
                         // Stryker will recursively scan projects
                         // add any project reference for progressive discovery (when not using solution file)
                         list.Add(projectAnalysisContext.GetProjectReferences()
-                            .Where(projectReference => FileSystem.File.Exists(projectReference)).ToList());
+                            .Where(projectReference => FileSystem.File.Exists(projectReference)));
                     }
                 );
             }

--- a/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/InputFileResolver.cs
@@ -435,7 +435,7 @@ public class InputFileResolver(
             }
             else
             {
-                _logger.LogDebug("Disregarding project {discarded} as it does not build an assembly.", project.ProjectFileName);
+                _logger.LogDebug("Disregarding project {Discarded} as it does not build an assembly.", project.ProjectFileName);
             }
         }
         var mutableToTestMap = mutableProjects.ToDictionary(p =>p, p => new MutableProjectTree(p, _logger));

--- a/src/Stryker.Core/Stryker.Core/Initialisation/MutableProjectTarget.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/MutableProjectTarget.cs
@@ -32,7 +32,8 @@ internal class MutableProjectTarget(IAnalyzerResult target, ILogger logger)
     /// Add a new test project
     /// </summary>
     /// <param name="testProject"></param>
-    /// <returns></returns>
+    /// <returns>true if the project was added, false if it was already present</returns>
+    /// <remarks>This method filters duplicate on project name (not assembly name)</remarks>
     public bool AddTestProject(IAnalyzerResult testProject)
     {
         // this is a workaround for multitargeting projects

--- a/src/Stryker.Core/Stryker.Core/Initialisation/MutableProjectTarget.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/MutableProjectTarget.cs
@@ -29,6 +29,22 @@ internal class MutableProjectTarget(IAnalyzerResult target, ILogger logger)
     private static readonly string[] FoldersToExclude = ["obj", "bin", "node_modules", "StrykerOutput"];
 
     /// <summary>
+    /// Add a new test project
+    /// </summary>
+    /// <param name="testProject"></param>
+    /// <returns></returns>
+    public bool AddTestProject(IAnalyzerResult testProject)
+    {
+        // this is a workaround for multitargeting projects
+        if (TestProjects.Any(tp => tp.ProjectFilePath == testProject.ProjectFilePath))
+        {
+            return false;
+        }
+        TestProjects.Add(testProject);
+        return true;
+    }
+
+    /// <summary>
     /// Builds a <see cref="SourceProjectInfo"/> instance describing a project its associated test project(s)
     /// </summary>
     /// <param name="options">Stryker options</param>

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/RelatedSourceProjectsInfo.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/SourceProjects/RelatedSourceProjectsInfo.cs
@@ -28,7 +28,7 @@ public class RelatedSourceProjectsInfo(
             return true;
         }
         var testProjects = SourceProjectInfos.SelectMany(p => p.TestProjectsInfo.AnalyzerResults)
-            .Distinct().ToList();
+            .Distinct().GroupBy(p => p.ProjectFilePath).Select(g => g.First()).ToList();
         for (var i = 0; i < testProjects.Count; i++)
         {
             logger?.LogInformation(


### PR DESCRIPTION
This PR filters out any quasi-duplicate test project for a given mutable candidate. This can happen with multi-targeting test projects when two or more targets refer to the same target for the mutable projects. For illustration, Polly.Specs net8, net9 and net10 targets all refer to Polly net6 