### PR TITLE
fix(rollback): attribute compile errors caused by mutations erasing throw statements

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpCompilingProcessTests.cs
@@ -520,6 +520,134 @@ public class Calculator
         projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.Pending).ShouldBe(3);
     }
 
+    [TestMethod]
+    public void ShouldCompileAndRollbackErrorWhenMutationErasesTerminalThrow()
+    {
+        // issue #3783: erasing the terminal throw of a non-void method causes CS0161 at the method
+        // declaration. Only the mutations erasing the throw should be rolled back; the others must survive.
+        var sourceFile = """
+            using System;
+            using System.Collections.Generic;
+
+            namespace ExampleProject;
+
+            public static class MethodResolver
+            {
+                private static readonly List<string> _log = new();
+
+                public static int FailForMissingKey(string key)
+                {
+                    _log.Add(key);
+                    throw new KeyNotFoundException($"No handler matched {key}.");
+                }
+            }
+            """;
+        var projectContentsMutants = MutateAndCompileSource(sourceFile).ToList();
+        // those results can change if mutators are added.
+        // the block mutation on the method body and the statement mutation on the throw are genuine compile errors
+        projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.CompileError).ShouldBe(2);
+        // the statement mutation on _log.Add and the string mutation must survive
+        projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.Pending).ShouldBe(2);
+        projectContentsMutants.Where(t => t.Mutation.Type == Mutator.String)
+            .ShouldAllBe(t => t.ResultStatus == MutantStatus.Pending);
+    }
+
+    [TestMethod]
+    public void ShouldCompileAndRollbackErrorWhenMutationErasesThrowInCatchClause()
+    {
+        // issue #3783: erasing the throw of a catch clause lets the catch complete normally, breaking
+        // definite assignment (CS0165) at a use site after the try/catch. Only the mutations erasing
+        // the assignment or the throw should be rolled back; the others must survive.
+        var sourceFile = """
+            using System;
+            using System.Collections.Generic;
+
+            namespace ExampleProject;
+
+            public static class Transformer
+            {
+                public static int Transform(string[] upperInputs)
+                {
+                    string[] transformed;
+                    try
+                    {
+                        transformed = (string[])upperInputs.Clone();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException("Failed to transform", e);
+                    }
+                    if (transformed.Length != upperInputs.Length)
+                    {
+                        return -1;
+                    }
+                    return transformed.Length;
+                }
+            }
+            """;
+        var projectContentsMutants = MutateAndCompileSource(sourceFile).ToList();
+        // those results can change if mutators are added.
+        // block mutations on the method body, try block and catch block plus the statement mutation
+        // on the throw are genuine compile errors
+        projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.CompileError).ShouldBe(4);
+        // the string, equality, unary and 'return -1' block mutations must survive
+        projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.Pending).ShouldBe(4);
+        projectContentsMutants.Where(t => t.Mutation.Type == Mutator.String || t.Mutation.Type == Mutator.Equality)
+            .ShouldAllBe(t => t.ResultStatus == MutantStatus.Pending);
+    }
+
+    [TestMethod]
+    public void ShouldCompileAndRollbackErrorWhenCollectionExpressionAssignmentsAreErased()
+    {
+        // issue #3783: block mutations erasing collection expression assignments across if/else chains
+        // break definite assignment (CS0165) at the use site. They must be attributed and rolled back
+        // individually, without safe mode discarding the collection expression mutations.
+        var sourceFile = """
+            using System;
+
+            namespace ExampleProject;
+
+            public enum AccessArea { ViewAlpha, EditAlpha, ViewBeta, EditBeta }
+
+            public static class AccessExtensions
+            {
+                public static (AccessArea[][], AccessArea[][]) ResolveRights(int kind, bool canEdit)
+                {
+                    AccessArea[][] primaryRights;
+                    AccessArea[][] secondaryRights;
+                    if (kind == 1)
+                    {
+                        if (canEdit)
+                        {
+                            primaryRights = [[AccessArea.ViewAlpha, AccessArea.EditAlpha]];
+                            secondaryRights = [[AccessArea.ViewBeta, AccessArea.EditBeta]];
+                        }
+                        else
+                        {
+                            primaryRights = [[AccessArea.ViewAlpha]];
+                            secondaryRights = [[AccessArea.ViewBeta]];
+                        }
+                    }
+                    else
+                    {
+                        primaryRights = [[AccessArea.ViewAlpha]];
+                        secondaryRights = [[AccessArea.ViewBeta]];
+                    }
+                    return (primaryRights, secondaryRights);
+                }
+            }
+            """;
+        var projectContentsMutants = MutateAndCompileSource(sourceFile).ToList();
+        // those results can change if mutators are added.
+        // only the block mutations erasing branch assignments are genuine compile errors
+        projectContentsMutants.Where(t => t.ResultStatus == MutantStatus.CompileError)
+            .ShouldAllBe(t => t.Mutation.Type == Mutator.Block);
+        projectContentsMutants.Count(t => t.ResultStatus == MutantStatus.CompileError).ShouldBe(4);
+        // collection expression mutations compile and must survive
+        projectContentsMutants.Where(t => t.Mutation.Type == Mutator.CollectionExpression)
+            .ShouldAllBe(t => t.ResultStatus == MutantStatus.Pending);
+    }
+
     private static IEnumerable<IMutant> MutateAndCompileSource(string sourceFile)
     {
         var filesystemRoot = Path.GetPathRoot(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Compiling/CSharpRollbackProcessTests.cs
@@ -1123,6 +1123,137 @@ public class CSharpRollbackProcessTests : TestBase
     }
 
     [TestMethod]
+    public void RollbackProcess_ShouldRollbackMutationErasingTerminalThrow()
+    {
+        // a mutation erasing the terminal throw of a non-void method triggers CS0161 at the method
+        // declaration; the rollback process must attribute it instead of entering safe mode (issue #3783)
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+        """
+        using System;
+        using System.Collections.Generic;
+        namespace ExampleProject
+        {
+            public class MethodResolver
+            {
+                public int ActiveMutation = 1;
+                private readonly List<string> _log = new List<string>();
+
+                public int FailForMissingKey(string key)
+                {
+                    {
+                        if(ActiveMutation == 4){;}else{_log.Add(key);}
+                        if(ActiveMutation == 5){;}else{throw new InvalidOperationException("No handler matched " + key);}
+                    }
+                }
+            }
+        }
+        """);
+        var root = syntaxTree.GetRoot();
+
+        var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(
+            mutantIf1,
+            mutantIf1.WithAdditionalAnnotations(GetMutationIdMarker(4), GetMutationTypeMarker(Mutator.Statement), _ifEngineMarker)
+        );
+        var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+        root = root.ReplaceNode(
+            mutantIf2,
+            mutantIf2.WithAdditionalAnnotations(GetMutationIdMarker(5), GetMutationTypeMarker(Mutator.Statement), _ifEngineMarker)
+        );
+        var annotatedSyntaxTree = root.SyntaxTree;
+
+        var compiler = CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: new List<PortableExecutableReference>() {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+            });
+
+        var target = new CSharpRollbackProcess();
+
+        using var ms = new MemoryStream();
+        var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
+
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var rollbackResult = compilerWrapper.Emit(ms);
+
+        rollbackResult.Success.ShouldBeTrue();
+        // only the throw erasing mutation should be rolled back, the other mutation must survive
+        ids.ShouldBe(new Collection<int> { 5 });
+    }
+
+    [TestMethod]
+    public void RollbackProcess_ShouldRollbackMutationErasingThrowInCatchClause()
+    {
+        // a mutation erasing the throw of a catch clause lets the catch complete normally, which breaks
+        // definite assignment (CS0165) at the use site; the rollback process must attribute it instead of
+        // entering safe mode (issue #3783)
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+        """
+        using System;
+        namespace ExampleProject
+        {
+            public class Transformer
+            {
+                public int ActiveMutation = 1;
+
+                public string Translate(string input)
+                {
+                    var dummy = 0;
+                    if(ActiveMutation == 3){dummy = 2;}else{dummy = 1;}
+                    string result;
+                    try
+                    {
+                        result = input.ToUpperInvariant();
+                    }
+                    catch (Exception e)
+                    {
+                        if(ActiveMutation == 6){;}else{throw new InvalidOperationException("failed", e);}
+                    }
+                    return result + dummy;
+                }
+            }
+        }
+        """);
+        var root = syntaxTree.GetRoot();
+
+        var mutantIf1 = root.DescendantNodes().OfType<IfStatementSyntax>().First();
+        root = root.ReplaceNode(
+            mutantIf1,
+            mutantIf1.WithAdditionalAnnotations(GetMutationIdMarker(3), GetMutationTypeMarker(Mutator.Statement), _ifEngineMarker)
+        );
+        var mutantIf2 = root.DescendantNodes().OfType<IfStatementSyntax>().ToList()[1];
+        root = root.ReplaceNode(
+            mutantIf2,
+            mutantIf2.WithAdditionalAnnotations(GetMutationIdMarker(6), GetMutationTypeMarker(Mutator.Statement), _ifEngineMarker)
+        );
+        var annotatedSyntaxTree = root.SyntaxTree;
+
+        var compiler = CSharpCompilation.Create("TestCompilation",
+            syntaxTrees: new Collection<SyntaxTree>() { annotatedSyntaxTree },
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+            references: new List<PortableExecutableReference>() {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Environment).Assembly.Location)
+            });
+
+        var target = new CSharpRollbackProcess();
+
+        using var ms = new MemoryStream();
+        var compileResult = compiler.Emit(ms);
+        var compilerWrapper = new CompilerWrapper(compiler);
+
+        var ids = target.RollbackMutationsInError(compilerWrapper, compileResult.Diagnostics, ICSharpRollbackProcess.Mode.Normal, false);
+        var rollbackResult = compilerWrapper.Emit(ms);
+
+        rollbackResult.Success.ShouldBeTrue();
+        // only the throw erasing mutation should be rolled back, the other mutation must survive
+        ids.ShouldBe(new Collection<int> { 6 });
+    }
+
+    [TestMethod]
     public void RollbackProcess_ShouldRollbackError_RolledBackCompilationShouldCompileWhenUriIsEmpty()
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(

--- a/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
+++ b/src/Stryker.Core/Stryker.Core/Compiling/CSharpRollbackProcess.cs
@@ -271,8 +271,13 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
             {
                 var identifierText = ExtractIdentifier(diagnostic, brokenMutation);
                 if (!string.IsNullOrEmpty(identifierText)
-                    && ScanErasingMutation(
-                        x => x.AssignsThis(identifierText), brokenMutation, brokenMutations, mode))
+                    && (ScanErasingMutation(
+                            x => x.AssignsThis(identifierText), brokenMutation, brokenMutations, mode)
+                        // a mutation erasing a throw statement can also break definite assignment,
+                        // e.g. when a catch clause no longer throws, execution can continue past the
+                        // try/catch without the variable being assigned
+                        || ScanErasingMutation(
+                            x => x is ThrowStatementSyntax, brokenMutation, brokenMutations, mode)))
                 {
                     continue;
                 }
@@ -285,7 +290,8 @@ public class CSharpRollbackProcess : ICSharpRollbackProcess
                     // CS0161 implies a block body
                     brokenMutation = methodDeclarationSyntax.Body!.Statements.Last();
                 }
-                if (ScanErasingMutation(x => x is ReturnStatementSyntax, brokenMutation, brokenMutations, mode))
+                // erasing a throw statement can also make the end of a non-void method reachable
+                if (ScanErasingMutation(x => x is ReturnStatementSyntax or ThrowStatementSyntax, brokenMutation, brokenMutations, mode))
                 {
                     continue;
                 }


### PR DESCRIPTION
Fixes #3783

## Problem

Mutations erasing a `throw` statement were not attributable when the resulting compile error surfaced at a different source location than the mutated node. The rollback process then fell into safe mode and marked **every** mutation in the enclosing method as a compile error; on large projects the resulting rollback churn ended in the `CompilationException` from `RollbackMutationsInError` reported in the issue.

Two attribution gaps, both in `CSharpRollbackProcess.IdentifyMutationsAndFlagForRollback`:

- **CS0161** (*not all code paths return a value*): when a method's reachability relies on a terminal `throw`, a statement/block mutation erasing that throw triggers CS0161 at the method declaration. The handler only scanned for mutations erasing a `ReturnStatementSyntax`, found nothing, and safe mode discarded the whole method (issue repro shape 3: 4 of 4 mutants lost).
- **CS0165/CS0177** (*use of unassigned local variable*): a `catch` clause that no longer throws lets execution continue past the try/catch without the variable being assigned, reporting CS0165 at the use site. The handler only scanned for mutations erasing an assignment, so once the genuine assignment-erasing mutations were rolled back, the remaining CS0165 was unattributable and safe mode discarded the whole method (issue repro shape 2: 11 of 11 mutants lost, including unrelated string/unary mutations).

Shape 1 from the issue (block mutations erasing collection expression assignments) turned out to already be attributed correctly — those mutants genuinely cannot compile and are rolled back individually without safe mode. A regression test now pins that behavior.

## Fix

Extend both erasing scans to also consider mutations erasing a `ThrowStatementSyntax`:

- CS0161 scans for mutations erasing a `return` **or a `throw`**.
- CS0165/CS0177 first scans for assignment-erasing mutations (unchanged), and when none is found, makes a second pass scanning for throw-erasing mutations.

The guilty mutation is now rolled back individually and unrelated mutations in the same method survive. With the fix, the issue's shape 2 goes from 11/11 mutants lost to 4 genuine compile errors (body/try/catch block mutations and the throw statement mutation), and shape 3 from 4/4 lost to 2 genuine compile errors — with no safe-mode warnings.

## Tests

- `CSharpRollbackProcessTests`: two new unit tests (`ShouldRollbackMutationErasingTerminalThrow`, `ShouldRollbackMutationErasingThrowInCatchClause`) driving real Roslyn diagnostics through the rollback process; each includes an unrelated mutation in the same method that must survive, so the tests fail if safe mode is (wrongly) engaged.
- `CSharpCompilingProcessTests`: three new end-to-end tests running the full mutate → compile → rollback pipeline over the three code shapes from the issue.

All 1550 tests in `Stryker.Core.UnitTest` pass.

## Validation on the original codebase

A locally packed `dotnet-stryker` with this fix was run against the ~600-file / ~94K-line project that originally crashed: the run now completes with a mutation score instead of aborting after ~3.5 minutes, and the `"unidentified mutation"` / `"Safe Mode!"` warnings for the CS0165/CS0161 shapes are gone.
