### PR TITLE
Improve relative path resolution for dotnet with msbuild

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/InitialBuildProcessTests.cs
@@ -133,6 +133,24 @@ public class InitialBuildProcessTests : TestBase
             Times.Once);
     }
 
+            [TestMethodWithIgnoreIfSupport]
+            [IgnoreIf(nameof(Is.NotWindows))]
+            public void InitialBuildProcess_WithSdkMsBuild_SetsDotnetHostPath()
+            {
+            var processMock = new Mock<IProcessExecutor>(MockBehavior.Strict);
+            processMock.SetupProcessMockToReturn("");
+            var target = new InitialBuildProcess(processMock.Object, new MockFileSystem(), TestLoggerFactory.CreateLogger<InitialBuildProcess>());
+
+            target.InitialBuild(true, null, "./ExampleProject.sln", msbuildPath: @"C:\Program Files\dotnet\sdk\10.0.111\MSBuild.dll");
+
+            processMock.Verify(x => x.Start(It.IsAny<string>(),
+                "dotnet",
+                It.Is<string>(arguments => arguments.Contains("/property:DOTNET_HOST_PATH=\"") && arguments.Contains("dotnet.exe\"")),
+                It.IsAny<IEnumerable<KeyValuePair<string, string>>>(),
+                It.IsAny<int>()),
+                Times.Once);
+            }
+
     [TestMethod]
     public void InitialBuildProcess_ShouldUseProvidedConfiguration()
     {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
@@ -13,6 +13,23 @@ namespace Stryker.Core.UnitTest.ProjectComponents.TestProjects;
 public class TestProjectTests
 {
     [TestMethod]
+    public void ConstructorResolvesRelativeSourceFilesFromProjectDirectory()
+    {
+        var fileSystem = new MockFileSystem();
+        var projectPath = Path.Combine("c:", "repo", "tests", "Tests.fsproj");
+        var relativeSourcePath = Path.Combine("SimulationSetup", "Tests.fs");
+        var expectedSourcePath = Path.Combine("c:", "repo", "tests", relativeSourcePath);
+        fileSystem.AddFile(expectedSourcePath, new MockFileData("module Tests"));
+        var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
+            projectFilePath: projectPath,
+            sourceFiles: [relativeSourcePath]);
+
+        var sut = new TestProject(fileSystem, analyzerResult.Object);
+
+        sut.TestFiles.Single().FilePath.ShouldBe(expectedSourcePath);
+    }
+
+    [TestMethod]
     public void TestProjectEqualsWhenAllPropertiesEqual()
     {
         // Arrange

--- a/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
+++ b/src/Stryker.Core/Stryker.Core/Helpers/MsBuildHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Stryker.Configuration;
 using Stryker.Core.Helpers.ProcessUtil;
@@ -87,6 +88,11 @@ public class MsBuildHelper
             fullOptions.Add($"{(usingMsBuild ? "/" : "--")}property:Platform={QuotesIfNeeded(platform)}");
         }
 
+        if (usingMsBuild && exe == "dotnet")
+        {
+            fullOptions.Add($"/property:DOTNET_HOST_PATH={QuotesIfNeeded(GetDotnetHostPath())}");
+        }
+
         if (options is not null)
         {
             fullOptions.Add(options);
@@ -95,6 +101,18 @@ public class MsBuildHelper
         var arguments = string.Join(' ', fullOptions);
         _logger.LogInformation("Building project {project} using {MsBuildPath} {Options} (directory {path}.)", projectFile, exe, arguments, path);
         return (_executor.Start(path, exe, arguments), exe, arguments);
+    }
+
+    private static string GetDotnetHostPath()
+    {
+        var configuredHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(configuredHostPath))
+        {
+            return configuredHostPath;
+        }
+
+        var executableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+        return Path.GetFullPath(Path.Combine(RuntimeEnvironment.GetRuntimeDirectory(), "..", "..", "..", executableName));
     }
 
     private (string executable, string command) GetMsBuildExeAndCommand()

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -30,9 +30,12 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
         var testFiles = new List<TestFile>();
         foreach (var file in testProjectAnalyzerResult.SourceFiles)
         {
-            var sourceCode = fileSystem.File.ReadAllText(file);
+            var sourceFilePath = fileSystem.Path.IsPathRooted(file) || string.IsNullOrEmpty(ProjectFilePath)
+                ? file
+                : fileSystem.Path.Combine(fileSystem.Path.GetDirectoryName(ProjectFilePath), file);
+            var sourceCode = fileSystem.File.ReadAllText(sourceFilePath);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode,
-                path: file,
+                path: sourceFilePath,
                 encoding: Encoding.UTF32,
                 options: new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.None, preprocessorSymbols: testProjectAnalyzerResult.PreprocessorSymbols));
 
@@ -41,7 +44,7 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
                 testFiles.Add(new TestFile
                 {
                     SyntaxTree = syntaxTree,
-                    FilePath = file,
+                    FilePath = sourceFilePath,
                     Source = sourceCode
                 });
             }


### PR DESCRIPTION
Pass DOTNET_HOST_PATH explicitly when invoking MSBuild through the .NET SDK.

- Use an existing DOTNET_HOST_PATH environment variable, otherwise resolve the host executable from the current runtime location.
- Resolve relative source-file paths returned by Buildalyzer relative to the test project directory.
- Preserve absolute source paths and use the resolved paths when parsing and storing test files.

Adds regression coverage for SDK-hosted MSBuild and relative source-file resolution.

Fixes #3804 