### PR TITLE
fix(initialization): Improve support for F# test projects

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -228,7 +228,6 @@ namespace MyProject.MSTest
     public void MutateProject_WithMultipleFilesWithSameClassAndMethod_UsesNamespaceToSelectCorrectFile()
     {
         // arrange
-
         var fileA = _iPath.Combine(_pathRoot, "tests","NUnitTests.cs");
         var fileB = _iPath.Combine(_pathRoot, "tests","XUnitTests.cs");
         _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
@@ -268,9 +267,9 @@ namespace MyProject.XUnit
     [TestMethod]
     public void MutateProject_WhenMethodNotFoundInAnyFile_RegistersNoTest()
     {
+        var filePath = _iPath.Combine(_pathRoot, "tests","SampleTests.cs");
         // arrange
-        const string filePath = "c:\\tests\\SampleTests.cs";
-        _fileSystemMock.Directory.CreateDirectory("c:\\tests");
+        _fileSystemMock.Directory.CreateDirectory("tests");
         _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.Tests
 {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -31,34 +31,40 @@ public class ProjectMutatorTests : TestBase
     private readonly Mock<IReporter> _reporterMock = new(MockBehavior.Strict);
     private readonly Mock<IInitialisationProcess> _initialisationProcessMock = new(MockBehavior.Strict);
     private readonly MutationTestInput _mutationTestInput;
-    private readonly IFileSystem _fileSystemMock = new MockFileSystem();
+    private readonly MockFileSystem _fileSystemMock = new();
+    private readonly IPath _iPath;
     private readonly string _testFilePath;
-    private readonly string _testFileContents = @"using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ExtraProject.XUnit
-{
-    public class UnitTest1
-    {
-        [TestMethod]
-        public void Test1()
-        {
-            // example test
-        }
+    private const string _testFileContents = """
+                                             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-        [TestMethod]
-        public void Test2()
-        {
-            // example test
-        }
-    }
-}
-";
+                                             namespace ExtraProject.XUnit
+                                             {
+                                                 public class UnitTest1
+                                                 {
+                                                     [TestMethod]
+                                                     public void Test1()
+                                                     {
+                                                         // example test
+                                                     }
+
+                                                     [TestMethod]
+                                                     public void Test2()
+                                                     {
+                                                         // example test
+                                                     }
+                                                 }
+                                             }
+
+                                             """;
+
+    private string _pathRoot;
 
     public ProjectMutatorTests()
     {
-        var iPath = _fileSystemMock.Path;
-        var root = iPath.GetPathRoot(_fileSystemMock.Directory.GetCurrentDirectory()) ?? "";
-        _testFilePath = iPath.Combine(root, "mytestfile.cs");
+        _iPath = _fileSystemMock.Path;
+        _pathRoot = _iPath.GetPathRoot(_fileSystemMock.Directory.GetCurrentDirectory()) ?? "";
+        _testFilePath = _iPath.Combine(_pathRoot, "mytestfile.cs");
         _mutationTestProcessMock.Setup(x => x.Mutate());
         _mutationTestProcessMock.Setup(x => x.Initialize(It.IsAny<MutationTestInput>(), It.IsAny<IStrykerOptions>(), It.IsAny<IReporter>()));
         _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
@@ -68,18 +74,18 @@ namespace ExtraProject.XUnit
             {
                 { "Language", "C#" },
                 { "AssemblyName", "TestProject" },
-                { "TargetDir", iPath.Combine(root, "bin","Debug","netcoreapp3.1") },
+                { "TargetDir", _iPath.Combine(_pathRoot, "bin","Debug","netcoreapp3.1") },
                 { "TargetFileName", "TestProject.dll" }
             },
-            projectFilePath: iPath.Combine(root, "project.csproj"),
+            projectFilePath: _iPath.Combine(_pathRoot, "project.csproj"),
             targetFramework: "netcoreapp3.1",
-            projectReferences: Array.Empty<string>(),
-            sourceFiles: Array.Empty<string>()).Object;
+            projectReferences: [],
+            sourceFiles: []).Object;
 
         var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
-            FullPath = iPath.Combine(root, "TestClass.cs"),
+            FullPath = _iPath.Combine(_pathRoot, "TestClass.cs"),
             SyntaxTree = CSharpSyntaxTree.ParseText("class TestClass { }")
         });
 
@@ -88,7 +94,7 @@ namespace ExtraProject.XUnit
             TestProjects = new List<TestProject>
             {
                 new(_fileSystemMock, TestHelper.SetupProjectAnalyzerResult(
-                    projectFilePath: iPath.Combine(root, "testproject.csproj"),
+                    projectFilePath: _iPath.Combine(_pathRoot, "testproject.csproj"),
                     targetFramework: "netcoreapp3.1",
                     sourceFiles: [_testFilePath]).Object)
             }
@@ -97,7 +103,7 @@ namespace ExtraProject.XUnit
         {
             SourceProjectInfo = new SourceProjectInfo(analyzerResult, testProjectsInfo)
             {
-                ProjectContents = folder,
+                ProjectContents = folder
             }
         };
     }
@@ -106,10 +112,9 @@ namespace ExtraProject.XUnit
     public void MutateProject_WithNunitFqnId_RegistersTestToFile()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
-        const string filePath = "C:\\tests\\SampleTests.cs";
-        fileSystem.Directory.CreateDirectory("C:\\tests");
-        fileSystem.File.WriteAllText(filePath, @"
+         var filePath = _iPath.Combine(_pathRoot,"tests", "SampleTests.cs");
+        _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
+        _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.NUnit
 {
     public class SampleTests
@@ -121,7 +126,7 @@ namespace MyProject.NUnit
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         const string fqn = "MyProject.NUnit.SampleTests.TestAgeExplicit";
         var description = CreateFallbackDescription(id: fqn, name: "TestAgeExplicit", fqn: fqn);
-        var input = CreateInput(fileSystem, [description], [filePath]);
+        var input = CreateInput(_fileSystemMock, [description], [filePath]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -136,10 +141,9 @@ namespace MyProject.NUnit
     public void MutateProject_WithNunitFqnIdAndParameters_StripsParameterListBeforeMatching()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
-        const string filePath = "C:\\tests\\SampleTests.cs";
-        fileSystem.Directory.CreateDirectory("C:\\tests");
-        fileSystem.File.WriteAllText(filePath, @"
+        var filePath = _iPath.Combine(_pathRoot,"tests", "SampleTests.cs");
+        _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
+        _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.NUnit
 {
     public class SampleTests
@@ -151,7 +155,7 @@ namespace MyProject.NUnit
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         const string fqnWithParams = "MyProject.NUnit.SampleTests.TestAgeExplicit(29,False)";
         var description = CreateFallbackDescription(id: fqnWithParams, name: "TestAgeExplicit(29,False)", fqn: fqnWithParams);
-        var input = CreateInput(fileSystem, [description], [filePath]);
+        var input = CreateInput(_fileSystemMock, [description], [filePath]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -166,10 +170,9 @@ namespace MyProject.NUnit
     public void MutateProject_WithMstestGuidId_FindsMethodByDisplayName()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
-        const string filePath = "C:\\tests\\SampleTests.cs";
-        fileSystem.Directory.CreateDirectory("C:\\tests");
-        fileSystem.File.WriteAllText(filePath, @"
+        var filePath = _iPath.Combine(_pathRoot,"tests", "SampleTests.cs");
+        _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
+        _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.MSTest
 {
     public class SampleTests
@@ -181,7 +184,7 @@ namespace MyProject.MSTest
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         var guid = Guid.NewGuid().ToString();
         var description = CreateFallbackDescription(id: guid, name: "TestTimeout", fqn: guid);
-        var input = CreateInput(fileSystem, [description], [filePath]);
+        var input = CreateInput(_fileSystemMock, [description], [filePath]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -196,10 +199,9 @@ namespace MyProject.MSTest
     public void MutateProject_WithMstestGuidIdAndParameters_StripsParameterListBeforeMatching()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
-        const string filePath = "C:\\tests\\SampleTests.cs";
-        fileSystem.Directory.CreateDirectory("C:\\tests");
-        fileSystem.File.WriteAllText(filePath, @"
+        var filePath = _iPath.Combine(_pathRoot,"tests", "SampleTests.cs");
+        _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
+        _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.MSTest
 {
     public class SampleTests
@@ -211,7 +213,7 @@ namespace MyProject.MSTest
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         var guid = Guid.NewGuid().ToString();
         var description = CreateFallbackDescription(id: guid, name: "TestAgeExplicit (29,False)", fqn: guid);
-        var input = CreateInput(fileSystem, [description], [filePath]);
+        var input = CreateInput(_fileSystemMock, [description], [filePath]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -226,13 +228,11 @@ namespace MyProject.MSTest
     public void MutateProject_WithMultipleFilesWithSameClassAndMethod_UsesNamespaceToSelectCorrectFile()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
-        var iPath = fileSystem.Path;
-        var root = iPath.GetPathRoot(fileSystem.Directory.GetCurrentDirectory())??"";
-        var fileA = iPath.Combine(root, "tests","NUnitTests.cs");
-        var fileB = iPath.Combine(root, "tests","XUnitTests.cs");
-        fileSystem.Directory.CreateDirectory(iPath.Combine(root, "tests"));
-        fileSystem.File.WriteAllText(fileA, @"
+
+        var fileA = _iPath.Combine(_pathRoot, "tests","NUnitTests.cs");
+        var fileB = _iPath.Combine(_pathRoot, "tests","XUnitTests.cs");
+        _fileSystemMock.Directory.CreateDirectory(_iPath.Combine(_pathRoot, "tests"));
+        _fileSystemMock.File.WriteAllText(fileA, @"
 namespace MyProject.NUnit
 {
     public class SampleTests
@@ -240,7 +240,7 @@ namespace MyProject.NUnit
         public void TestAgeExplicit() { }
     }
 }");
-        fileSystem.File.WriteAllText(fileB, @"
+        _fileSystemMock.File.WriteAllText(fileB, @"
 namespace MyProject.XUnit
 {
     public class SampleTests
@@ -252,7 +252,7 @@ namespace MyProject.XUnit
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         const string nunitFqn = "MyProject.NUnit.SampleTests.TestAgeExplicit";
         var description = CreateFallbackDescription(id: nunitFqn, name: "TestAgeExplicit", fqn: nunitFqn);
-        var input = CreateInput(fileSystem, [description], [fileA, fileB]);
+        var input = CreateInput(_fileSystemMock, [description], [fileA, fileB]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -269,10 +269,9 @@ namespace MyProject.XUnit
     public void MutateProject_WhenMethodNotFoundInAnyFile_RegistersNoTest()
     {
         // arrange
-        var fileSystem = new MockFileSystem();
         const string filePath = "c:\\tests\\SampleTests.cs";
-        fileSystem.Directory.CreateDirectory("c:\\tests");
-        fileSystem.File.WriteAllText(filePath, @"
+        _fileSystemMock.Directory.CreateDirectory("c:\\tests");
+        _fileSystemMock.File.WriteAllText(filePath, @"
 namespace MyProject.Tests
 {
     public class SampleTests
@@ -284,7 +283,7 @@ namespace MyProject.Tests
         var target = new ProjectMutator(TestLoggerFactory.CreateLogger<ProjectMutator>(), serviceProviderMock.Object);
         const string fqn = "MyProject.Tests.SampleTests.NonExistingTest";
         var description = CreateFallbackDescription(id: fqn, name: "NonExistingTest", fqn: fqn);
-        var input = CreateInput(fileSystem, [description], [filePath]);
+        var input = CreateInput(_fileSystemMock, [description], [filePath]);
 
         // act
         target.MutateProject(new StrykerOptions(), input, _reporterMock.Object, _mutationTestProcessMock.Object);
@@ -353,7 +352,7 @@ namespace MyProject.Tests
         return descriptionMock.Object;
     }
 
-    private static MutationTestInput CreateInput(IFileSystem fileSystem, IList<IFrameworkTestDescription> descriptions, string[] testFilePaths)
+    private MutationTestInput CreateInput(IFileSystem fileSystem, IList<IFrameworkTestDescription> descriptions, string[] testFilePaths)
     {
         var testRunResult = new TestRunResult(
             vsTestDescriptions: descriptions,
@@ -368,9 +367,9 @@ namespace MyProject.Tests
             properties: new Dictionary<string, string>
             {
                 { "Language", "C#" }, { "AssemblyName", "SourceProject" },
-                { "TargetDir", "c:\\bin\\Debug\\net" }, { "TargetFileName", "SourceProject.dll" }
+                { "TargetDir", _iPath.Combine(_pathRoot, "bin", "Debug", "net") }, { "TargetFileName", "SourceProject.dll" }
             },
-            projectFilePath: "c:\\source.csproj",
+            projectFilePath: _iPath.Combine(_pathRoot, "source.csproj"),
             targetFramework: "net",
             projectReferences: [],
             sourceFiles: []);
@@ -380,12 +379,12 @@ namespace MyProject.Tests
             {
                 { "Language", "C#" }
             },
-            projectFilePath: "c:\\testproject.csproj",
+            projectFilePath: _iPath.Combine(_pathRoot, "testproject.csproj"),
             targetFramework: "net",
             sourceFiles: testFilePaths);
 
         var sourceFolder = new FolderComposite();
-        sourceFolder.Add(new CsharpFileLeaf { FullPath = "c:\\Source.cs", SyntaxTree = CSharpSyntaxTree.ParseText("class Source { }") });
+        sourceFolder.Add(new CsharpFileLeaf { FullPath = _iPath.Combine(_pathRoot, "Source.cs"), SyntaxTree = CSharpSyntaxTree.ParseText("class Source { }") });
 
         return new MutationTestInput
         {

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Initialisation/ProjectMutatorTests.cs
@@ -32,7 +32,7 @@ public class ProjectMutatorTests : TestBase
     private readonly Mock<IInitialisationProcess> _initialisationProcessMock = new(MockBehavior.Strict);
     private readonly MutationTestInput _mutationTestInput;
     private readonly IFileSystem _fileSystemMock = new MockFileSystem();
-    private readonly string _testFilePath = "c:\\mytestfile.cs";
+    private readonly string _testFilePath;
     private readonly string _testFileContents = @"using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExtraProject.XUnit
@@ -56,6 +56,9 @@ namespace ExtraProject.XUnit
 
     public ProjectMutatorTests()
     {
+        var iPath = _fileSystemMock.Path;
+        var root = iPath.GetPathRoot(_fileSystemMock.Directory.GetCurrentDirectory()) ?? "";
+        _testFilePath = iPath.Combine(root, "mytestfile.cs");
         _mutationTestProcessMock.Setup(x => x.Mutate());
         _mutationTestProcessMock.Setup(x => x.Initialize(It.IsAny<MutationTestInput>(), It.IsAny<IStrykerOptions>(), It.IsAny<IReporter>()));
         _fileSystemMock.File.WriteAllText(_testFilePath, _testFileContents);
@@ -65,10 +68,10 @@ namespace ExtraProject.XUnit
             {
                 { "Language", "C#" },
                 { "AssemblyName", "TestProject" },
-                { "TargetDir", "c:\\bin\\Debug\\netcoreapp3.1" },
+                { "TargetDir", iPath.Combine(root, "bin","Debug","netcoreapp3.1") },
                 { "TargetFileName", "TestProject.dll" }
             },
-            projectFilePath: "c:\\project.csproj",
+            projectFilePath: iPath.Combine(root, "project.csproj"),
             targetFramework: "netcoreapp3.1",
             projectReferences: Array.Empty<string>(),
             sourceFiles: Array.Empty<string>()).Object;
@@ -76,7 +79,7 @@ namespace ExtraProject.XUnit
         var folder = new FolderComposite();
         folder.Add(new CsharpFileLeaf
         {
-            FullPath = "c:\\TestClass.cs",
+            FullPath = iPath.Combine(root, "TestClass.cs"),
             SyntaxTree = CSharpSyntaxTree.ParseText("class TestClass { }")
         });
 
@@ -85,14 +88,14 @@ namespace ExtraProject.XUnit
             TestProjects = new List<TestProject>
             {
                 new(_fileSystemMock, TestHelper.SetupProjectAnalyzerResult(
-                    projectFilePath: "c:\\testproject.csproj",
+                    projectFilePath: iPath.Combine(root, "testproject.csproj"),
                     targetFramework: "netcoreapp3.1",
                     sourceFiles: [_testFilePath]).Object)
             }
         };
         _mutationTestInput = new MutationTestInput()
         {
-            SourceProjectInfo = new Stryker.Core.ProjectComponents.SourceProjects.SourceProjectInfo(analyzerResult, testProjectsInfo)
+            SourceProjectInfo = new SourceProjectInfo(analyzerResult, testProjectsInfo)
             {
                 ProjectContents = folder,
             }
@@ -224,9 +227,11 @@ namespace MyProject.MSTest
     {
         // arrange
         var fileSystem = new MockFileSystem();
-        const string fileA = "C:\\tests\\NUnitTests.cs";
-        const string fileB = "C:\\tests\\XUnitTests.cs";
-        fileSystem.Directory.CreateDirectory("C:\\tests");
+        var iPath = fileSystem.Path;
+        var root = iPath.GetPathRoot(fileSystem.Directory.GetCurrentDirectory())??"";
+        var fileA = iPath.Combine(root, "tests","NUnitTests.cs");
+        var fileB = iPath.Combine(root, "tests","XUnitTests.cs");
+        fileSystem.Directory.CreateDirectory(iPath.Combine(root, "tests"));
         fileSystem.File.WriteAllText(fileA, @"
 namespace MyProject.NUnit
 {
@@ -371,6 +376,10 @@ namespace MyProject.Tests
             sourceFiles: []);
 
         var testAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
+            properties: new Dictionary<string, string>
+            {
+                { "Language", "C#" }
+            },
             projectFilePath: "c:\\testproject.csproj",
             targetFramework: "net",
             sourceFiles: testFilePaths);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
@@ -106,5 +107,24 @@ public class TestProjectTests
         var sut = new TestProject(fileSystem, analyzerResult.Object);
 
         sut.TestFiles.Single().FilePath.ShouldBe(path.GetFullPath(expectedSourcePath));
+    }
+
+    [TestMethod]
+    public void HandlesNonCSharpProject()
+    {
+        var fileSystem = new MockFileSystem();
+        var path = fileSystem.Path;
+        var projectPath =  path.GetFullPath(path.Combine("repo", "tests", "Tests.fsproj"));
+        var relativeSourcePath = path.Combine("SimulationSetup", "Tests.fs");
+        var expectedSourcePath = path.Combine("repo", "tests", relativeSourcePath);
+        fileSystem.AddFile(expectedSourcePath, new MockFileData("module Tests"));
+        var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
+            projectFilePath: projectPath,
+            sourceFiles: [relativeSourcePath],
+            properties: new Dictionary<string, string>{["Language"]="F#"});
+
+        var sut = new TestProject(fileSystem, analyzerResult.Object);
+
+        sut.TestFiles.ShouldBeEmpty();
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
@@ -69,8 +69,9 @@ public class TestProjectTests
     {
         // Arrange
         var fileSystem = new MockFileSystem();
-        var rootPath = Path.Combine("c", "TestProject");
-        var filePath = Path.Combine(rootPath, "ExampleTestFilePreprocessorSymbols.cs");
+        var path = fileSystem.Path;
+        var rootPath = path.Combine("c", "TestProject");
+        var filePath = path.Combine(rootPath, "ExampleTestFilePreprocessorSymbols.cs");
         fileSystem.AddDirectory(rootPath);
 
         var testProjectAnalyzerResultMock = TestHelper.SetupProjectAnalyzerResult(
@@ -78,7 +79,7 @@ public class TestProjectTests
             sourceFiles: new string[] { filePath },
             preprocessorSymbols: new string[] { "NET6_0_OR_GREATER" }
         );
-        var file = File.ReadAllText(Path.Combine(".", "TestResources", "ExampleTestFilePreprocessorSymbols.cs"));
+        var file = File.ReadAllText(path.Combine(".", "TestResources", "ExampleTestFilePreprocessorSymbols.cs"));
         fileSystem.AddFile(filePath, new MockFileData(file));
 
         // Act
@@ -93,9 +94,10 @@ public class TestProjectTests
     public void ConstructorResolvesRelativeSourceFilesFromProjectDirectory()
     {
         var fileSystem = new MockFileSystem();
-        var projectPath = Path.Combine("c:", "repo", "tests", "Tests.fsproj");
-        var relativeSourcePath = Path.Combine("SimulationSetup", "Tests.fs");
-        var expectedSourcePath = Path.Combine("c:", "repo", "tests", relativeSourcePath);
+        var path = fileSystem.Path;
+        var projectPath =  path.GetFullPath(path.Combine("repo", "tests", "Tests.fsproj"));
+        var relativeSourcePath = path.GetFullPath(path.Combine("SimulationSetup", "Tests.fs"));
+        var expectedSourcePath = path.GetFullPath(path.Combine("repo", "tests", relativeSourcePath));
         fileSystem.AddFile(expectedSourcePath, new MockFileData("module Tests"));
         var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
             projectFilePath: projectPath,

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
@@ -88,4 +88,21 @@ public class TestProjectTests
         var nodes = testProject.TestFiles.First().SyntaxTree.GetRoot().DescendantNodes();
         testProject.TestFiles.First().SyntaxTree.GetRoot().DescendantNodes().Where(n => n is MethodDeclarationSyntax).Count().ShouldBe(4);
     }
+
+    [TestMethod]
+    public void ConstructorResolvesRelativeSourceFilesFromProjectDirectory()
+    {
+        var fileSystem = new MockFileSystem();
+        var projectPath = Path.Combine("c:", "repo", "tests", "Tests.fsproj");
+        var relativeSourcePath = Path.Combine("SimulationSetup", "Tests.fs");
+        var expectedSourcePath = Path.Combine("c:", "repo", "tests", relativeSourcePath);
+        fileSystem.AddFile(expectedSourcePath, new MockFileData("module Tests"));
+        var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
+            projectFilePath: projectPath,
+            sourceFiles: [relativeSourcePath]);
+
+        var sut = new TestProject(fileSystem, analyzerResult.Object);
+
+        sut.TestFiles.Single().FilePath.ShouldBe(expectedSourcePath);
+    }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectTests.cs
@@ -96,8 +96,8 @@ public class TestProjectTests
         var fileSystem = new MockFileSystem();
         var path = fileSystem.Path;
         var projectPath =  path.GetFullPath(path.Combine("repo", "tests", "Tests.fsproj"));
-        var relativeSourcePath = path.GetFullPath(path.Combine("SimulationSetup", "Tests.fs"));
-        var expectedSourcePath = path.GetFullPath(path.Combine("repo", "tests", relativeSourcePath));
+        var relativeSourcePath = path.Combine("SimulationSetup", "Tests.fs");
+        var expectedSourcePath = path.Combine("repo", "tests", relativeSourcePath);
         fileSystem.AddFile(expectedSourcePath, new MockFileData("module Tests"));
         var analyzerResult = TestHelper.SetupProjectAnalyzerResult(
             projectFilePath: projectPath,
@@ -105,6 +105,6 @@ public class TestProjectTests
 
         var sut = new TestProject(fileSystem, analyzerResult.Object);
 
-        sut.TestFiles.Single().FilePath.ShouldBe(expectedSourcePath);
+        sut.TestFiles.Single().FilePath.ShouldBe(path.GetFullPath(expectedSourcePath));
     }
 }

--- a/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectsInfoTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/ProjectComponents/TestProjects/TestProjectsInfoTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
-using Stryker.Abstractions.Testing;
 using Stryker.Core.ProjectComponents.TestProjects;
 using Stryker.Utilities;
 using Stryker.Utilities.Buildalyzer;
@@ -23,13 +22,13 @@ public class TestProjectsInfoTests : TestBase
     public void ShouldGenerateInjectionPath()
     {
         var sourceProjectAnalyzerResults = TestHelper.SetupProjectAnalyzerResult(
-                properties: new Dictionary<string, string>() {
+                properties: new Dictionary<string, string> {
                     { "TargetDir", "/app/bin/Debug/" },
                     { "TargetFileName", "AppToTest.dll" }
                 }).Object;
 
         var testProjectAnalyzerResults = TestHelper.SetupProjectAnalyzerResult(
-                properties: new Dictionary<string, string>() {
+                properties: new Dictionary<string, string> {
                     { "TargetDir", "/test/bin/Debug/" },
                     { "TargetFileName", "TestName.dll" }
                 }).Object;
@@ -55,12 +54,12 @@ public class TestProjectsInfoTests : TestBase
         fileSystem.AddFile(fileAPath, new MockFileData(fileA));
         fileSystem.AddFile(fileBPath, new MockFileData(fileB));
         var testProjectAnalyzerResultAMock = TestHelper.SetupProjectAnalyzerResult(
-            references: Array.Empty<string>(),
-            sourceFiles: new string[] { fileAPath }
+            references: [],
+            sourceFiles: [fileAPath]
         );
         var testProjectAnalyzerResultBMock = TestHelper.SetupProjectAnalyzerResult(
-            references: Array.Empty<string>(),
-            sourceFiles: new string[] { fileBPath }
+            references: [],
+            sourceFiles: [fileBPath]
         );
 
         var testProjectA = new TestProject(fileSystem, testProjectAnalyzerResultAMock.Object);
@@ -102,12 +101,12 @@ public class TestProjectsInfoTests : TestBase
         var fileA = File.ReadAllText(Path.Combine(".", "TestResources", "ExampleTestFileA.cs"));
         fileSystem.AddFile(fileAPath, new MockFileData(fileA));
         var testProjectAnalyzerResultAMock = TestHelper.SetupProjectAnalyzerResult(
-            references: Array.Empty<string>(),
-            sourceFiles: new string[] { fileAPath }
+            references: [],
+            sourceFiles: [fileAPath]
         );
         var testProjectAnalyzerResultBMock = TestHelper.SetupProjectAnalyzerResult(
-            references: Array.Empty<string>(),
-            sourceFiles: new string[] { fileAPath }
+            references: [],
+            sourceFiles: [fileAPath]
         );
 
         var testProjectA = new TestProject(fileSystem, testProjectAnalyzerResultAMock.Object);
@@ -141,6 +140,10 @@ public class TestProjectsInfoTests : TestBase
         // Arrange
         var fileSystem = Mock.Of<IFileSystem>(MockBehavior.Strict);
         var file = Mock.Of<IFile>(MockBehavior.Strict);
+        var mock = new MockFileSystem();
+        Mock.Get(fileSystem).Setup(f => f.Path).Returns(mock.Path);
+        Mock.Get(fileSystem).Setup(f => f.Directory).Returns(mock.Directory);
+
         Mock.Get(fileSystem).Setup(f => f.File).Returns(file);
 
         var sourceProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
@@ -181,15 +184,18 @@ public class TestProjectsInfoTests : TestBase
         var fileSystem = Mock.Of<IFileSystem>(MockBehavior.Strict);
         var file = Mock.Of<IFile>(MockBehavior.Strict);
         Mock.Get(fileSystem).Setup(f => f.File).Returns(file);
+        var mock = new MockFileSystem();
+        Mock.Get(fileSystem).Setup(f => f.Path).Returns(mock.Path);
+        Mock.Get(fileSystem).Setup(f => f.Directory).Returns(mock.Directory);
 
         var sourceProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-                properties: new Dictionary<string, string>() {
+                properties: new Dictionary<string, string> {
                     { "TargetDir", "/app/bin/Debug/" },
                     { "TargetFileName", "AppToTest.dll" }
                 }).Object;
 
         var testProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-                properties: new Dictionary<string, string>() {
+                properties: new Dictionary<string, string> {
                     { "TargetDir", "/test/bin/Debug/" },
                     { "TargetFileName", "TestName.dll" }
                 }).Object;
@@ -216,19 +222,21 @@ public class TestProjectsInfoTests : TestBase
     [TestMethod]
     public void RestoreOriginalAssembly_IgnoreIfBackupCopyFails()
     {
-        // Arrange
         var fileSystem = Mock.Of<IFileSystem>(MockBehavior.Strict);
         var file = Mock.Of<IFile>(MockBehavior.Strict);
         Mock.Get(fileSystem).Setup(f => f.File).Returns(file);
+        var mock = new MockFileSystem();
+        Mock.Get(fileSystem).Setup(f => f.Path).Returns(mock.Path);
+        Mock.Get(fileSystem).Setup(f => f.Directory).Returns(mock.Directory);
 
         var sourceProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-            properties: new Dictionary<string, string>() {
+            properties: new Dictionary<string, string> {
                 { "TargetDir", "/app/bin/Debug/" },
                 { "TargetFileName", "AppToTest.dll" }
             }).Object;
 
         var testProjectAnalyzerResult = TestHelper.SetupProjectAnalyzerResult(
-            properties: new Dictionary<string, string>() {
+            properties: new Dictionary<string, string> {
                 { "TargetDir", "/test/bin/Debug/" },
                 { "TargetFileName", "TestName.dll" }
             }).Object;
@@ -275,6 +283,11 @@ public class TestProjectsInfoTests : TestBase
                     { "TargetFileName", "TestName.dll" }
                 }).Object;
 
+        Mock.Get(directory).Setup(d => d.Exists(sourceProjectAnalyzerResult.GetAssemblyDirectoryPath())).Returns(true);
+        var mock = new MockFileSystem();
+        Mock.Get(fileSystem).Setup(f => f.Path).Returns(mock.Path);
+        Mock.Get(directory).Setup(d => d.GetCurrentDirectory()).Returns(mock.Directory.GetCurrentDirectory());
+
         var testProject = new TestProject(fileSystem, testProjectAnalyzerResult);
         var testProjectsInfo = new TestProjectsInfo(fileSystem, NullLogger<TestProjectsInfo>.Instance)
         {
@@ -283,8 +296,6 @@ public class TestProjectsInfoTests : TestBase
 
         var injectionPath = TestProjectsInfo.GetInjectionFilePath(testProjectAnalyzerResult, sourceProjectAnalyzerResult);
         var backupPath = injectionPath + ".stryker-unchanged";
-
-        Mock.Get(directory).Setup(d => d.Exists(sourceProjectAnalyzerResult.GetAssemblyDirectoryPath())).Returns(true);
 
         Mock.Get(file).Setup(f => f.Exists(injectionPath)).Returns(true);
         Mock.Get(file).Setup(f => f.Exists(backupPath)).Returns(false);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/Reporters/Json/JsonReporterTests.cs
@@ -26,7 +26,7 @@ namespace Stryker.Core.UnitTest.Reporters.Json;
 public class JsonReporterTests : TestBase
 {
     private readonly IFileSystem _fileSystemMock = new MockFileSystem();
-    private readonly string _testFilePath = "c:\\mytestfile.cs";
+    private readonly string _testFilePath = "mytestfile.cs";
     private readonly string _testFileContents = @"using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ExtraProject.XUnit
@@ -203,7 +203,7 @@ namespace ExtraProject.XUnit
         report.Thresholds.ShouldContainKeyAndValue("low", 60);
 
         var testFile = report.TestFiles.ShouldHaveSingleItem();
-        testFile.Key.ShouldBe(_testFilePath);
+        testFile.Key.ShouldBe(_fileSystemMock.Path.GetFullPath(_testFilePath));
         testFile.Value.Language.ShouldBe("cs");
         testFile.Value.Source.ShouldBe(_testFileContents);
 

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
@@ -3,6 +3,8 @@ using System.Collections.Immutable;
 using System.IO;
 using Buildalyzer;
 using Moq;
+using Stryker.Abstractions;
+using Stryker.Utilities.Buildalyzer;
 
 namespace Stryker.Core.UnitTest;
 
@@ -32,6 +34,8 @@ public static class TestHelper
             analyzerResultMock.Setup(x => x.Properties).Returns(properties);
         }
 
+        properties["Language"] = "C#";
+        projectFilePath ??= "testproject.csproj";
         if (projectFilePath != null)
         {
             analyzerResultMock.Setup(x => x.ProjectFilePath).Returns(projectFilePath);

--- a/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/TestHelper.cs
@@ -34,7 +34,7 @@ public static class TestHelper
             analyzerResultMock.Setup(x => x.Properties).Returns(properties);
         }
 
-        properties["Language"] = "C#";
+        properties.TryAdd("Language", "C#");
         projectFilePath ??= "testproject.csproj";
         if (projectFilePath != null)
         {

--- a/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
+++ b/src/Stryker.Core/Stryker.Core/Initialisation/ProjectMutator.cs
@@ -107,7 +107,7 @@ public class ProjectMutator : IProjectMutator
         var sourceName = isGuid ? unitTest.Name : unitTest.FullyQualifiedName;
 
         var (methodName, className, namespaceName) = ParseMethodComponents(sourceName);
-        if (string.IsNullOrEmpty(methodName))
+        if (string.IsNullOrEmpty(methodName) || testFiles == null)
         {
             return (null, null);
         }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -40,16 +40,10 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
         var directoryName = iPath.GetDirectoryName(AnalyzerResult.ProjectFilePath);
         if (string.IsNullOrEmpty(directoryName))
         {
-            if (iPath.IsPathRooted(AnalyzerResult.ProjectFilePath))
-            {
-                directoryName = iPath.GetPathRoot(AnalyzerResult.ProjectFilePath);
-            }
-            else
-            {
-                directoryName = iPath.GetPathRoot(fileSystem.Directory.GetCurrentDirectory());
-            }
+            directoryName = iPath.GetPathRoot(iPath.IsPathRooted(AnalyzerResult.ProjectFilePath) ? AnalyzerResult.ProjectFilePath
+                : fileSystem.Directory.GetCurrentDirectory());
         }
-        var projectRoot = iPath.GetFullPath(directoryName);
+        var projectRoot = iPath.GetFullPath(directoryName!);
         foreach (var file in testProjectAnalyzerResult.SourceFiles)
         {
             var filePath = file;

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -6,9 +6,11 @@ using System.Text;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Stryker.Abstractions;
 using Stryker.Abstractions.Exceptions;
 using Stryker.Abstractions.ProjectComponents;
 using Stryker.Core.MutantFilters;
+using Stryker.Utilities.Buildalyzer;
 
 namespace Stryker.Core.ProjectComponents.TestProjects;
 
@@ -28,11 +30,22 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
         AnalyzerResult = testProjectAnalyzerResult;
 
         var testFiles = new List<TestFile>();
+        if (testProjectAnalyzerResult.GetLanguage() != Language.Csharp)
+        {
+            TestFiles = testFiles;
+            return;
+        }
+        var projectRoot = fileSystem.Path.GetFullPath(fileSystem.Path.GetDirectoryName(AnalyzerResult.ProjectFilePath)??"");
         foreach (var file in testProjectAnalyzerResult.SourceFiles)
         {
-            var sourceCode = fileSystem.File.ReadAllText(file);
+            var filePath = file;
+            if (!string.IsNullOrEmpty(projectRoot) && !fileSystem.Path.IsPathRooted(filePath))
+            {
+                filePath = fileSystem.Path.Combine(projectRoot, file);
+            }
+            var sourceCode = fileSystem.File.ReadAllText(filePath);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode,
-                path: file,
+                path: filePath,
                 encoding: Encoding.UTF32,
                 options: new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.None, preprocessorSymbols: testProjectAnalyzerResult.PreprocessorSymbols));
 
@@ -41,7 +54,7 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
                 testFiles.Add(new TestFile
                 {
                     SyntaxTree = syntaxTree,
-                    FilePath = file,
+                    FilePath = filePath,
                     Source = sourceCode
                 });
             }

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -35,13 +35,27 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
             TestFiles = testFiles;
             return;
         }
-        var projectRoot = fileSystem.Path.GetFullPath(fileSystem.Path.GetDirectoryName(AnalyzerResult.ProjectFilePath)??"");
+
+        var iPath = fileSystem.Path;
+        var directoryName = iPath.GetDirectoryName(AnalyzerResult.ProjectFilePath);
+        if (string.IsNullOrEmpty(directoryName))
+        {
+            if (iPath.IsPathRooted(AnalyzerResult.ProjectFilePath))
+            {
+                directoryName = iPath.GetPathRoot(AnalyzerResult.ProjectFilePath);
+            }
+            else
+            {
+                directoryName = iPath.GetPathRoot(fileSystem.Directory.GetCurrentDirectory());
+            }
+        }
+        var projectRoot = iPath.GetFullPath(directoryName);
         foreach (var file in testProjectAnalyzerResult.SourceFiles)
         {
             var filePath = file;
-            if (!string.IsNullOrEmpty(projectRoot) && !fileSystem.Path.IsPathRooted(filePath))
+            if (!string.IsNullOrEmpty(projectRoot) && !iPath.IsPathRooted(filePath))
             {
-                filePath = fileSystem.Path.Combine(projectRoot, file);
+                filePath = iPath.Combine(projectRoot, file);
             }
             var sourceCode = fileSystem.File.ReadAllText(filePath);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode,

--- a/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
+++ b/src/Stryker.Core/Stryker.Core/ProjectComponents/TestProjects/TestProject.cs
@@ -43,7 +43,7 @@ public sealed class TestProject : IEquatable<ITestProject>, ITestProject
             directoryName = iPath.GetPathRoot(iPath.IsPathRooted(AnalyzerResult.ProjectFilePath) ? AnalyzerResult.ProjectFilePath
                 : fileSystem.Directory.GetCurrentDirectory());
         }
-        var projectRoot = iPath.GetFullPath(directoryName!);
+        var projectRoot = iPath.GetFullPath(directoryName);
         foreach (var file in testProjectAnalyzerResult.SourceFiles)
         {
             var filePath = file;


### PR DESCRIPTION
- Handle relative path for test source files
- Only attempt to parse files if they are csharp source files
- refactors TestProject related tests to make them OS agnostic

Fixes #3804