### PR TITLE
fix(since): only log changed files relevant to the project under test

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/SinceMutantFilterTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/MutantFilters/SinceMutantFilterTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Shouldly;
@@ -15,6 +16,7 @@ using Stryker.Core.Mutants;
 using Stryker.Core.ProjectComponents.Csharp;
 using Stryker.TestRunner.Tests;
 using Stryker.TestRunner.VsTest;
+using Stryker.Utilities.Logging;
 
 namespace Stryker.Core.UnitTest.MutantFilters;
 
@@ -334,6 +336,159 @@ public class SinceMutantFilterTests : TestBase
 
         // Assert
         result.ShouldBe(mutants);
+    }
+
+    [TestMethod]
+    public void Should_LogCsharpChangedFilesAtDebug_AndNonCsharpChangedFilesAtInformation()
+    {
+        // Arrange
+        var captureProvider = new CapturingLoggerProvider();
+        ApplicationLogging.LoggerFactory = new LoggerFactory(new[] { captureProvider });
+
+        var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
+        diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult
+        {
+            ChangedSourceFiles = new Collection<string> { "C:/src/myfile.cs", "C:/docs/readme.md" },
+            ChangedTestFiles = new Collection<string> { "C:/tests/mytest.cs" }
+        });
+
+        // Act
+        _ = new SinceMutantFilter(diffProvider.Object);
+
+        // Assert
+        captureProvider.Entries.ShouldContain(e => e.Level == LogLevel.Information && e.Message.Contains("readme.md"));
+        captureProvider.Entries.ShouldNotContain(e => e.Level == LogLevel.Information && e.Message.Contains("myfile.cs"));
+        captureProvider.Entries.ShouldNotContain(e => e.Level == LogLevel.Information && e.Message.Contains("mytest.cs"));
+        captureProvider.Entries.ShouldContain(e => e.Level == LogLevel.Debug && e.Message.Contains("myfile.cs"));
+        captureProvider.Entries.ShouldContain(e => e.Level == LogLevel.Debug && e.Message.Contains("mytest.cs"));
+        captureProvider.Entries.ShouldNotContain(e => e.Level == LogLevel.Debug && e.Message.Contains("readme.md"));
+    }
+
+    [TestMethod]
+    public void Should_LogRelevantChangedSourceFile_WhenFilteringMutants()
+    {
+        // Arrange
+        var captureProvider = new CapturingLoggerProvider();
+        ApplicationLogging.LoggerFactory = new LoggerFactory(new[] { captureProvider });
+
+        var options = new StrykerOptions() { Since = false };
+        var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
+
+        var myFile = Path.Combine("C:/test/", "myfile.cs");
+
+        diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult()
+        {
+            ChangedSourceFiles = new Collection<string>()
+            {
+                myFile
+            },
+            ChangedTestFiles = new Collection<string>()
+        });
+
+        var target = new SinceMutantFilter(diffProvider.Object);
+        var file = new CsharpFileLeaf { FullPath = myFile };
+
+        // Act
+        target.FilterMutants(new List<Mutant> { new Mutant() }, file, options);
+
+        // Assert
+        captureProvider.Entries.ShouldContain(e => e.Level == LogLevel.Information && e.Message.Contains(myFile));
+    }
+
+    [TestMethod]
+    public void Should_LogRelevantChangedTestFile_WhenCoveringTestsChanged()
+    {
+        // Arrange
+        var captureProvider = new CapturingLoggerProvider();
+        ApplicationLogging.LoggerFactory = new LoggerFactory(new[] { captureProvider });
+
+        var options = new StrykerOptions()
+        {
+            WithBaseline = false,
+            ProjectVersion = "version"
+        };
+
+        var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
+
+        var tests = new TestSet();
+        var test1 = new TestDescription("id1", "name1", "C:/testfile1.cs");
+        var test2 = new TestDescription("id2", "name2", "C:/testfile2.cs");
+        tests.RegisterTests(new[] { test1, test2 });
+        diffProvider.SetupGet(x => x.Tests).Returns(tests);
+        diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult
+        {
+            ChangedSourceFiles = new List<string>(),
+            ChangedTestFiles = new List<string> { "C:/testfile1.cs" }
+        });
+
+        var target = new SinceMutantFilter(diffProvider.Object);
+        var mutant = new Mutant { CoveringTests = new TestIdentifierList(new[] { test1 }) };
+
+        // Act
+        target.FilterMutants(new List<Mutant> { mutant }, new CsharpFileLeaf(), options);
+
+        // Assert
+        captureProvider.Entries.ShouldContain(e => e.Level == LogLevel.Information && e.Message.Contains("C:/testfile1.cs"));
+        captureProvider.Entries.ShouldNotContain(e => e.Message.Contains("C:/testfile2.cs"));
+    }
+
+    [TestMethod]
+    public void Should_LogRelevantChangedTestFile_OnlyOnce()
+    {
+        // Arrange
+        var captureProvider = new CapturingLoggerProvider();
+        ApplicationLogging.LoggerFactory = new LoggerFactory(new[] { captureProvider });
+
+        var options = new StrykerOptions()
+        {
+            WithBaseline = false,
+            ProjectVersion = "version"
+        };
+
+        var diffProvider = new Mock<IDiffProvider>(MockBehavior.Loose);
+
+        var tests = new TestSet();
+        var test1 = new TestDescription("id1", "name1", "C:/testfile1.cs");
+        tests.RegisterTests(new[] { test1 });
+        diffProvider.SetupGet(x => x.Tests).Returns(tests);
+        diffProvider.Setup(x => x.ScanDiff()).Returns(new DiffResult
+        {
+            ChangedSourceFiles = new List<string>(),
+            ChangedTestFiles = new List<string> { "C:/testfile1.cs" }
+        });
+
+        var target = new SinceMutantFilter(diffProvider.Object);
+        var mutants = new List<Mutant> { new Mutant { CoveringTests = new TestIdentifierList(new[] { test1 }) } };
+
+        // Act
+        target.FilterMutants(mutants, new CsharpFileLeaf() { FullPath = "C:/src/file1.cs" }, options);
+        target.FilterMutants(mutants, new CsharpFileLeaf() { FullPath = "C:/src/file2.cs" }, options);
+
+        // Assert
+        captureProvider.Entries.Count(e => e.Level == LogLevel.Information && e.Message.Contains("C:/testfile1.cs")).ShouldBe(1);
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new List<(LogLevel Level, string Message)>();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Entries);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly List<(LogLevel Level, string Message)> _entries;
+
+            public CapturingLogger(List<(LogLevel Level, string Message)> entries) => _entries = entries;
+
+            public IDisposable BeginScope<TState>(TState state) => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) =>
+                _entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }
 

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
@@ -1,4 +1,5 @@
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -17,6 +18,7 @@ public class SinceMutantFilter : IMutantFilter
     private readonly DiffResult _diffResult;
     private readonly ITestSet _tests;
     private readonly ILogger<SinceMutantFilter> _logger;
+    private readonly HashSet<string> _loggedRelevantTestFiles = new();
 
     public MutantFilter Type => MutantFilter.Since;
     public string DisplayName => "since filter";
@@ -32,20 +34,23 @@ public class SinceMutantFilter : IMutantFilter
         {
             _logger.LogInformation("{ChangedFilesCount} files changed", (_diffResult.ChangedSourceFiles?.Count ?? 0) + (_diffResult.ChangedTestFiles?.Count ?? 0));
 
-            if (_diffResult.ChangedSourceFiles != null)
-            {
-                foreach (var changedFile in _diffResult.ChangedSourceFiles)
-                {
-                    _logger.LogInformation("Changed file {ChangedFile}", changedFile);
-                }
-            }
-            if (_diffResult.ChangedTestFiles != null)
-            {
-                foreach (var changedFile in _diffResult.ChangedTestFiles)
-                {
-                    _logger.LogInformation("Changed test file {ChangedFile}", changedFile);
-                }
-            }
+            LogChangedFiles(_diffResult.ChangedSourceFiles, "Changed file {ChangedFile}");
+            LogChangedFiles(_diffResult.ChangedTestFiles, "Changed test file {ChangedFile}");
+        }
+    }
+
+    private void LogChangedFiles(ICollection<string> changedFiles, string message)
+    {
+        if (changedFiles is null)
+        {
+            return;
+        }
+
+        foreach (var changedFile in changedFiles)
+        {
+            // For non-csharp files we cannot determine whether they are relevant for the project under test, so always log those.
+            var logLevel = changedFile.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ? LogLevel.Debug : LogLevel.Information;
+            _logger.Log(logLevel, message, changedFile);
         }
     }
 
@@ -64,7 +69,7 @@ public class SinceMutantFilter : IMutantFilter
         // If the diff result flags this file as modified, we want to run all mutants again
         if (_diffResult.ChangedSourceFiles != null && _diffResult.ChangedSourceFiles.Contains(file.FullPath))
         {
-            _logger.LogDebug("Returning all mutants in {RelativePath} because the file is modified", file.RelativePath);
+            _logger.LogInformation("Changed file {FullPath} is part of the project under test; all mutants in it will be tested", file.FullPath);
             return SetMutantStatusForFileChanged(mutants);
         }
         else
@@ -135,9 +140,28 @@ public class SinceMutantFilter : IMutantFilter
                 mutant.ResultStatusReason = "One or more covering tests changed";
 
                 filteredMutants.Add(mutant);
+
+                LogRelevantChangedTestFiles(coveringTests);
             }
         }
 
         return filteredMutants;
+    }
+
+    private void LogRelevantChangedTestFiles(IEnumerable<ITestDescription> coveringTests)
+    {
+        if (_diffResult.ChangedTestFiles is null)
+        {
+            return;
+        }
+
+        foreach (var changedTestFile in _diffResult.ChangedTestFiles)
+        {
+            if (coveringTests.Any(coveringTest => coveringTest.TestFilePath == changedTestFile)
+                && _loggedRelevantTestFiles.Add(changedTestFile))
+            {
+                _logger.LogInformation("Changed test file {ChangedTestFile} covers mutants of the project under test", changedTestFile);
+            }
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
+++ b/src/Stryker.Core/Stryker.Core/MutantFilters/SinceMutantFilter.cs
@@ -18,7 +18,7 @@ public class SinceMutantFilter : IMutantFilter
     private readonly DiffResult _diffResult;
     private readonly ITestSet _tests;
     private readonly ILogger<SinceMutantFilter> _logger;
-    private readonly HashSet<string> _loggedRelevantTestFiles = new();
+    private readonly HashSet<string> _loggedRelevantTestFiles = new(StringComparer.OrdinalIgnoreCase);
 
     public MutantFilter Type => MutantFilter.Since;
     public string DisplayName => "since filter";
@@ -155,9 +155,20 @@ public class SinceMutantFilter : IMutantFilter
             return;
         }
 
+        var notYetLoggedCoveringTestFiles = new HashSet<string>(
+            coveringTests.Select(coveringTest => coveringTest.TestFilePath).Where(testFilePath => !string.IsNullOrEmpty(testFilePath)),
+            StringComparer.OrdinalIgnoreCase);
+        notYetLoggedCoveringTestFiles.ExceptWith(_loggedRelevantTestFiles);
+
+        // Early exit when every covering test file has already been logged.
+        if (notYetLoggedCoveringTestFiles.Count == 0)
+        {
+            return;
+        }
+
         foreach (var changedTestFile in _diffResult.ChangedTestFiles)
         {
-            if (coveringTests.Any(coveringTest => coveringTest.TestFilePath == changedTestFile)
+            if (notYetLoggedCoveringTestFiles.Contains(changedTestFile)
                 && _loggedRelevantTestFiles.Add(changedTestFile))
             {
                 _logger.LogInformation("Changed test file {ChangedTestFile} covers mutants of the project under test", changedTestFile);


### PR DESCRIPTION
Fixes #1652
Related: #3718

## What

When running with `since`, every changed file in the git diff was logged at Information level (`SinceMutantFilter` constructor), even files that have nothing to do with the project under test. On large repos this produced a log line per changed file, with real overhead on large diffs (see #3718).

This change:

- Logs changed **C#** source/test files at **Debug** level in the diff scan (still discoverable with `--verbosity debug`).
- Keeps **non-C#** files at **Information** level, as we cannot determine whether they are relevant (third checkbox of #1652).
- Logs a changed C# source file at **Information** level at the moment it is known to be relevant: when it matches a file of the project under test during mutant filtering (second checkbox of #1652).
- Logs a changed test file at **Information** level once per run when it covers mutants of the project under test (deduplicated via a `HashSet`).

The `{ChangedFilesCount} files changed` summary log stays unchanged, and filtering behavior itself is untouched — this is logging-only.

## Why

#1652 asked to only log changed files that are relevant to the project under test. The first checkbox (skip files excluded by `since.ignore-changes-in`) was already done; this closes the remaining two.

## Testing

- 5 new unit tests in `SinceMutantFilterTests` covering: log level split (C# → Debug, non-C# → Information), relevant source file logging, relevant test file logging, and once-per-run deduplication.
- All 13 tests in `SinceMutantFilterTests` pass; all 271 tests in the mutant-filter + diff-provider suites pass.